### PR TITLE
Tatokhin/url validation fix

### DIFF
--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Provider.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Provider.cs
@@ -24,7 +24,7 @@ namespace OutOfSchool.Services.Models
         public string ShortTitle { get; set; }
 
         [DataType(DataType.Url)]
-        [MaxLength(100)]
+        [MaxLength(256)]
         public string Website { get; set; } = string.Empty;
 
         [DataType(DataType.EmailAddress)]
@@ -34,11 +34,11 @@ namespace OutOfSchool.Services.Models
         public string Email { get; set; } = string.Empty;
 
         [DataType(DataType.Url)]
-        [MaxLength(100)]
+        [MaxLength(256)]
         public string Facebook { get; set; } = string.Empty;
 
         [DataType(DataType.Url)]
-        [MaxLength(100)]
+        [MaxLength(256)]
         public string Instagram { get; set; } = string.Empty;
 
         [MaxLength(500)]

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -34,9 +34,11 @@ namespace OutOfSchool.Services.Models
         [MaxLength(256)]
         public string Website { get; set; } = string.Empty;
 
+        [DataType(DataType.Url)]
         [MaxLength(256)]
         public string Facebook { get; set; } = string.Empty;
 
+        [DataType(DataType.Url)]
         [MaxLength(256)]
         public string Instagram { get; set; } = string.Empty;
 

--- a/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20211006150527_ChangedUrlsLengthInProviderModel.Designer.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20211006150527_ChangedUrlsLengthInProviderModel.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
 namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211006150527_ChangedUrlsLengthInProviderModel")]
+    partial class ChangedUrlsLengthInProviderModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20211006150527_ChangedUrlsLengthInProviderModel.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20211006150527_ChangedUrlsLengthInProviderModel.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
+{
+    public partial class ChangedUrlsLengthInProviderModel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Website",
+                table: "Providers",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Instagram",
+                table: "Providers",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Facebook",
+                table: "Providers",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Website",
+                table: "Providers",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Instagram",
+                table: "Providers",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Facebook",
+                table: "Providers",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ProviderDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ProviderDto.cs
@@ -22,7 +22,7 @@ namespace OutOfSchool.WebApi.Models
         public string ShortTitle { get; set; }
 
         [DataType(DataType.Url)]
-        [MaxLength(100)]
+        [MaxLength(256)]
         public string Website { get; set; } = string.Empty;
 
         [DataType(DataType.EmailAddress)]
@@ -32,11 +32,11 @@ namespace OutOfSchool.WebApi.Models
         public string Email { get; set; } = string.Empty;
 
         [DataType(DataType.Url)]
-        [MaxLength(100)]
+        [MaxLength(256)]
         public string Facebook { get; set; } = string.Empty;
 
         [DataType(DataType.Url)]
-        [MaxLength(100)]
+        [MaxLength(256)]
         public string Instagram { get; set; } = string.Empty;
 
         [MaxLength(500)]

--- a/OutOfSchool/OutOfSchool.WebApi/Models/WorkshopDTO.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/WorkshopDTO.cs
@@ -35,10 +35,12 @@ namespace OutOfSchool.WebApi.Models
         [MaxLength(256)]
         public string Website { get; set; } = string.Empty;
 
-        [MaxLength(30)]
+        [DataType(DataType.Url)]
+        [MaxLength(256)]
         public string Facebook { get; set; } = string.Empty;
 
-        [MaxLength(30)]
+        [DataType(DataType.Url)]
+        [MaxLength(256)]
         public string Instagram { get; set; } = string.Empty;
 
         [Required(ErrorMessage = "Children's min age is required")]
@@ -106,7 +108,7 @@ namespace OutOfSchool.WebApi.Models
         public AddressDto Address { get; set; }
 
         public IEnumerable<TeacherDTO> Teachers { get; set; }
-       
+
         [Required]
         public List<DateTimeRangeDto> DateTimeRanges { get; set; }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
@@ -65,7 +65,7 @@ namespace OutOfSchool.WebApi.Util
             CreateMap<Provider, ProviderDto>().ReverseMap();
             CreateMap<Teacher, TeacherDTO>().ReverseMap();
             CreateMap<DateTimeRange, DateTimeRangeDto>()
-                .ForMember(dtr => dtr.Workdays, cfg => cfg.MapFrom(dtr => dtr.Workdays.ToDaysBitMaskEnumarable().ToList()));
+                .ForMember(dtr => dtr.Workdays, cfg => cfg.MapFrom(dtr => dtr.Workdays.ToDaysBitMaskEnumerable().ToList()));
             CreateMap<DateTimeRangeDto, DateTimeRange>()
                 .ForMember(dtr => dtr.Workdays, cfg => cfg.MapFrom(dtr => dtr.Workdays.ToDaysBitMask()));
         }


### PR DESCRIPTION
-changed validation rules for Website, Instagram, Facebook URLs in WorkshopDTO and ProviderDTO ( all - maxlength 256, datatype -url)
-unified full models with DTO's validation rules
-added migration to change max length in Url fields (instagram, facebook, website) for Provider table