### PR TITLE
Tatokhin/Unit tests + refactored controllers and services(Provider, InstitutionStatus, PermissionsForRole) 

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
@@ -87,7 +87,8 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task GetInstitutionStatusById_WhenIdIsInvalid_ReturnsBadRequestWithExceptionMessage(long id)
         {
             // Arrange
-            var exceptedResponse = new BadRequestObjectResult("error message");
+
+            var exceptedResponse = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
             service.Setup(x => x.GetById(id)).ReturnsAsync(institutionStatuses.SingleOrDefault(x => x.Id == id).ToModel());
 
             // Act
@@ -102,7 +103,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task GetById_WhenIdDoesntExist_ReturnsBadRequestWithExceptionMessage(long id)
         {
             // Arrange
-            var expectedResponse = new BadRequestObjectResult("Argument out of range");
+            var expectedResponse = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
             service.Setup(x => x.GetById(id)).Throws<ArgumentOutOfRangeException>();
 
             // Act
@@ -161,7 +162,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task Delete_WhenIdIsInvalid_ReturnsBadRequestWithExceptionMessageAsync(long id)
         {
             // Arrange
-            var expected = new BadRequestObjectResult("The id cannot be less than 1.");
+            var expected = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
             service.Setup(x => x.Delete(id));
 
             // Act
@@ -176,7 +177,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task DeleteInstitutionStatus_WhenIdDoesntExists_ReturnsBadRequestWithMessage(long id)
         {
             // Arrange
-            var expected = new BadRequestObjectResult("message error1");
+            var expected = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
             service.Setup(x => x.Delete(id)).Throws<ArgumentOutOfRangeException>();
 
             // Act
@@ -195,7 +196,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             return new InstitutionStatus()
             {
                 Id = 1,
-                Name = "Test",
+                Name = TestDataHelper.GetRandomWords(),
             };
         }
 
@@ -206,17 +207,17 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                 new InstitutionStatus()
                 {
                 Id = 1,
-                Name = "NoName",
+                Name = TestDataHelper.GetRandomWords(),
                 },
                 new InstitutionStatus()
                 {
                 Id = 2,
-                Name = "HaveName",
+                Name = TestDataHelper.GetRandomWords(),
                 },
                 new InstitutionStatus()
                 {
                 Id = 3,
-                Name = "MissName",
+                Name = TestDataHelper.GetRandomWords(),
                 },
             };
         }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
@@ -34,7 +34,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             controller = new InstitutionStatusController(service.Object, localizer.Object);
 
             // generate random collection of statuses and single entity to use in test cases.
-            institutionStatuses = InstitutionStatusGenerator.Generate(3);
+            institutionStatuses = InstitutionStatusGenerator.Generate(5);
             institutionStatus = InstitutionStatusGenerator.Generate();
         }
 
@@ -69,9 +69,9 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task GetInstitutionStatusById_WhenIdIsValid_ReturnOkResultObject()
         {
             // Arrange
-            var existingId = institutionStatuses.First().Id;
-            var expected = institutionStatuses.SingleOrDefault(x => x.Id == existingId).ToModel();
-            service.Setup(x => x.GetById(existingId)).ReturnsAsync(institutionStatuses.SingleOrDefault(x => x.Id == existingId).ToModel());
+            var existingId = institutionStatuses.Last().Id;
+            var expected = institutionStatuses.Where(x => x.Id == existingId).First().ToModel();
+            service.Setup(x => x.GetById(existingId)).ReturnsAsync(institutionStatuses.First(x => x.Id == existingId).ToModel());
 
             // Act
             var response = await controller.GetById(existingId).ConfigureAwait(false);
@@ -144,7 +144,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task DeleteInstitutionStatus_WhenIdIsValid_ReturnsNoContentResult()
         {
             // Arrange
-            var idToDelete = TestDataHelper.GetPositiveInt(institutionStatuses.Count() - 1);
+            var idToDelete = TestDataHelper.GetPositiveInt(institutionStatuses.Count());
             service.Setup(x => x.Delete(idToDelete));
 
             // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
@@ -43,6 +43,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             // Arrange
             var expected = institutionStatuses.Select(x => x.ToModel());
+
             service.Setup(x => x.GetAll()).ReturnsAsync(institutionStatuses.Select(x => x.ToModel()));
 
             // Act
@@ -69,9 +70,13 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task GetInstitutionStatusById_WhenIdIsValid_ReturnOkResultObject()
         {
             // Arrange
-            var existingId = institutionStatuses.Last().Id;
-            var expected = institutionStatuses.Where(x => x.Id == existingId).First().ToModel();
-            service.Setup(x => x.GetById(existingId)).ReturnsAsync(institutionStatuses.First(x => x.Id == existingId).ToModel());
+            var existingId = TestDataHelper.RandomItem(institutionStatuses as ICollection<InstitutionStatus>).Id;
+            var expected = institutionStatuses.Where(x => x.Id == existingId)
+                .First().ToModel();
+
+            service.Setup(x => x.GetById(existingId))
+                .ReturnsAsync(institutionStatuses.First(x => x.Id == existingId)
+                .ToModel());
 
             // Act
             var response = await controller.GetById(existingId).ConfigureAwait(false);
@@ -86,7 +91,9 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             // Arrange
             var invalidId = TestDataHelper.GetNegativeInt();
             var exceptedResponse = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
-            service.Setup(x => x.GetById(invalidId)).ReturnsAsync(institutionStatuses.SingleOrDefault(x => x.Id == invalidId).ToModel());
+            service.Setup(x => x.GetById(invalidId))
+                .ReturnsAsync(institutionStatuses.SingleOrDefault(x => x.Id == invalidId)
+                .ToModel());
 
             // Act
             var response = await controller.GetById(invalidId).ConfigureAwait(false);
@@ -101,6 +108,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             // Arrange
             var notExistId = TestDataHelper.GetPositiveInt(institutionStatuses.Count(), int.MaxValue);
             var expectedResponse = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
+
             service.Setup(x => x.GetById(notExistId)).Throws<ArgumentOutOfRangeException>();
 
             // Act
@@ -115,7 +123,11 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             // Arrange
             var expected = institutionStatus.ToModel();
-            var expectedResponse = new CreatedAtActionResult(nameof(controller.GetById), nameof(controller), new { id = expected.Id }, expected);
+            var expectedResponse = new CreatedAtActionResult(
+                nameof(controller.GetById),
+                nameof(controller),
+                new { id = expected.Id },
+                expected);
             service.Setup(x => x.Create(expected)).ReturnsAsync(institutionStatus.ToModel());
 
             // Act
@@ -144,7 +156,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task DeleteInstitutionStatus_WhenIdIsValid_ReturnsNoContentResult()
         {
             // Arrange
-            var idToDelete = TestDataHelper.GetPositiveInt(institutionStatuses.Count());
+            var idToDelete = TestDataHelper.RandomItem(institutionStatuses as ICollection<InstitutionStatus>).Id;
             service.Setup(x => x.Delete(idToDelete));
 
             // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using NUnit.Framework;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Tests.Common;
+using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Controllers.V1;
 using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
@@ -21,23 +22,20 @@ namespace OutOfSchool.WebApi.Tests.Controllers
     {
         private InstitutionStatusController controller;
         private Mock<IStatusService> service;
-        private Mock<IStringLocalizer<SharedResource>> localizer;
-
         private IEnumerable<InstitutionStatus> institutionStatuses;
         private InstitutionStatus institutionStatus;
-
-
 
         [SetUp]
         public void Setup()
         {
+            // setup controller
             service = new Mock<IStatusService>();
-            localizer = new Mock<IStringLocalizer<SharedResource>>();
-
+            var localizer = new Mock<IStringLocalizer<SharedResource>>();
             controller = new InstitutionStatusController(service.Object, localizer.Object);
 
-            institutionStatuses = FakeInstitutionStatuses();
-            institutionStatus = FakeInstitutionStatus();
+            // generate random collection of statuses and single entity to use in test cases.
+            institutionStatuses = InstitutionStatusGenerator.Generate(3);
+            institutionStatus = InstitutionStatusGenerator.Generate();
         }
 
         [Test]
@@ -68,46 +66,45 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         }
 
         [Test]
-        [TestCase(1)]
-        public async Task GetInstitutionStatusById_WhenIdIsValid_ReturnOkResultObject(long id)
+        public async Task GetInstitutionStatusById_WhenIdIsValid_ReturnOkResultObject()
         {
             // Arrange
-            var expected = institutionStatuses.SingleOrDefault(x => x.Id == id).ToModel();
-            service.Setup(x => x.GetById(id)).ReturnsAsync(institutionStatuses.SingleOrDefault(x => x.Id == id).ToModel());
+            var existingId = institutionStatuses.First().Id;
+            var expected = institutionStatuses.SingleOrDefault(x => x.Id == existingId).ToModel();
+            service.Setup(x => x.GetById(existingId)).ReturnsAsync(institutionStatuses.SingleOrDefault(x => x.Id == existingId).ToModel());
 
             // Act
-            var response = await controller.GetById(id).ConfigureAwait(false);
+            var response = await controller.GetById(existingId).ConfigureAwait(false);
 
             // Assert
             response.AssertResponseOkResultAndValidateValue(expected);
         }
 
         [Test]
-        [TestCase(-50)]
-        public async Task GetInstitutionStatusById_WhenIdIsInvalid_ReturnsBadRequestWithExceptionMessage(long id)
+        public async Task GetInstitutionStatusById_WhenIdIsInvalid_ReturnsBadRequestWithExceptionMessage()
         {
             // Arrange
-
+            var invalidId = TestDataHelper.GetNegativeInt();
             var exceptedResponse = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
-            service.Setup(x => x.GetById(id)).ReturnsAsync(institutionStatuses.SingleOrDefault(x => x.Id == id).ToModel());
+            service.Setup(x => x.GetById(invalidId)).ReturnsAsync(institutionStatuses.SingleOrDefault(x => x.Id == invalidId).ToModel());
 
             // Act
-            var response = await controller.GetById(id).ConfigureAwait(false);
+            var response = await controller.GetById(invalidId).ConfigureAwait(false);
 
             // Assert
             response.AssertExpectedResponseTypeAndCheckDataInside<BadRequestObjectResult>(exceptedResponse);
         }
 
         [Test]
-        [TestCase(100)]
-        public async Task GetById_WhenIdDoesntExist_ReturnsBadRequestWithExceptionMessage(long id)
+        public async Task GetById_WhenIdDoesntExist_ReturnsBadRequestWithExceptionMessage()
         {
             // Arrange
+            var notExistId = TestDataHelper.GetPositiveInt(institutionStatuses.Count(), int.MaxValue);
             var expectedResponse = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
-            service.Setup(x => x.GetById(id)).Throws<ArgumentOutOfRangeException>();
+            service.Setup(x => x.GetById(notExistId)).Throws<ArgumentOutOfRangeException>();
 
             // Act
-            var response = await controller.GetById(id).ConfigureAwait(false);
+            var response = await controller.GetById(notExistId).ConfigureAwait(false);
 
             // Assert
             response.AssertExpectedResponseTypeAndCheckDataInside<BadRequestObjectResult>(expectedResponse);
@@ -144,82 +141,47 @@ namespace OutOfSchool.WebApi.Tests.Controllers
 
 
         [Test]
-        [TestCase(1)]
-        public async Task DeleteInstitutionStatus_WhenIdIsValid_ReturnsNoContentResult(long id)
+        public async Task DeleteInstitutionStatus_WhenIdIsValid_ReturnsNoContentResult()
         {
             // Arrange
-            service.Setup(x => x.Delete(id));
+            var idToDelete = TestDataHelper.GetPositiveInt(institutionStatuses.Count() - 1);
+            service.Setup(x => x.Delete(idToDelete));
 
             // Act
-            var response = await controller.Delete(id);
+            var response = await controller.Delete(idToDelete);
 
             // Assert
             Assert.IsInstanceOf<NoContentResult>(response);
         }
 
         [Test]
-        [TestCase(-50)]
-        public async Task Delete_WhenIdIsInvalid_ReturnsBadRequestWithExceptionMessageAsync(long id)
+        public async Task Delete_WhenIdIsInvalid_ReturnsBadRequestWithExceptionMessageAsync()
         {
             // Arrange
+            var invalidId = TestDataHelper.GetNegativeInt();
             var expected = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
-            service.Setup(x => x.Delete(id));
+            service.Setup(x => x.Delete(invalidId));
 
             // Act
-            var response = await controller.Delete(id).ConfigureAwait(false);
+            var response = await controller.Delete(invalidId).ConfigureAwait(false);
 
             // Assert
             response.AssertExpectedResponseTypeAndCheckDataInside<BadRequestObjectResult>(expected);
         }
 
         [Test]
-        [TestCase(10)]
-        public async Task DeleteInstitutionStatus_WhenIdDoesntExists_ReturnsBadRequestWithMessage(long id)
+        public async Task DeleteInstitutionStatus_WhenIdDoesntExists_ReturnsBadRequestWithMessage()
         {
             // Arrange
+            var notExistId = TestDataHelper.GetPositiveInt(institutionStatuses.Count(), int.MaxValue);
             var expected = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
-            service.Setup(x => x.Delete(id)).Throws<ArgumentOutOfRangeException>();
+            service.Setup(x => x.Delete(notExistId)).Throws<ArgumentOutOfRangeException>();
 
             // Act
-            var response = await controller.Delete(id).ConfigureAwait(false);
+            var response = await controller.Delete(notExistId).ConfigureAwait(false);
 
             // Assert
             response.AssertExpectedResponseTypeAndCheckDataInside<BadRequestObjectResult>(expected);
-        }
-
-
-        /// <summary>
-        /// faking data for testing.
-        /// </summary>
-        private InstitutionStatus FakeInstitutionStatus()
-        {
-            return new InstitutionStatus()
-            {
-                Id = 1,
-                Name = TestDataHelper.GetRandomWords(),
-            };
-        }
-
-        private IEnumerable<InstitutionStatus> FakeInstitutionStatuses()
-        {
-            return new List<InstitutionStatus>()
-            {
-                new InstitutionStatus()
-                {
-                Id = 1,
-                Name = TestDataHelper.GetRandomWords(),
-                },
-                new InstitutionStatus()
-                {
-                Id = 2,
-                Name = TestDataHelper.GetRandomWords(),
-                },
-                new InstitutionStatus()
-                {
-                Id = 3,
-                Name = TestDataHelper.GetRandomWords(),
-                },
-            };
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
@@ -34,7 +34,6 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public void Setup()
         {
             service = new Mock<IPermissionsForRoleService>();
-
             controller = new PermissionsForRoleController(service.Object);
 
             permissionsForAllRoles = FakePermissionsForAllRoles();
@@ -71,7 +70,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         [Test]
         public void GetAllPermissions_WhenCalled_ReturnsAllSystemPermissions()
         {
-            //Arrange
+            // Arrange
             var expectedValue = Enum.GetValues(typeof(Permissions))
                 .Cast<Permissions>()
                 .Select(p => (p, p.ToString()));
@@ -85,10 +84,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
 
 
         [Test]
-        [TestCase("Admin")]
-        public async Task GetByRoleName_WhenRoleNameIsValid_ReturnOkResultObject(string roleName)
+        public async Task GetByRoleName_WhenRoleNameIsValid_ReturnOkResultObject()
         {
             // Arrange
+            var roleName = Role.Admin.ToString();
             var expected = permissionsForAllRoles.Where(s => s.RoleName == roleName).Select(p => p.ToModel()).FirstOrDefault();
             service.Setup(x => x.GetByRole(roleName)).ReturnsAsync(permissionsForAllRoles.SingleOrDefault(x => x.RoleName == roleName).ToModel());
 
@@ -100,11 +99,11 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         }
 
         [Test]
-        [TestCase("fakeRole")]
-        public async Task GetByRoleName_NotExistingRoleName_ReturnsBadRequest(string roleName)
+        public async Task GetByRoleName_NotExistingRoleName_ReturnsBadRequest()
         {
             // Arrange
-            var expectedResponse = new BadRequestObjectResult("roleName");
+            var roleName = TestDataHelper.GetRandomRole();
+            var expectedResponse = new BadRequestObjectResult(nameof(roleName));
             service.Setup(x => x.GetByRole(roleName)).ThrowsAsync(new ArgumentNullException());
 
             // Act
@@ -137,7 +136,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task UpdatePermissionsForRole_WhenModelIsValid_ReturnsOkObjectResult()
         {
             // Arrange
-            permissionsForRoleEntity.Description = "new";
+            permissionsForRoleEntity.Description = TestDataHelper.GetRandomWords();
             var expected = permissionsForRoleEntity.ToModel();
             service.Setup(x => x.Update(expected)).ReturnsAsync(permissionsForRoleEntity.ToModel());
 
@@ -153,8 +152,9 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             // Arrange
             var expected = permissionsForRoleEntity.ToModel();
-            var expectedResponse = new BadRequestObjectResult("message error");
-            service.Setup(x => x.Update(expected)).ThrowsAsync(new DbUpdateConcurrencyException("message error"));
+            var errorMessage = TestDataHelper.GetRandomWords();
+            var expectedResponse = new BadRequestObjectResult(errorMessage);
+            service.Setup(x => x.Update(expected)).ThrowsAsync(new DbUpdateConcurrencyException(errorMessage));
 
             // Act
             var response = await controller.Update(expected).ConfigureAwait(false);
@@ -168,12 +168,11 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         /// </summary>
         private PermissionsForRole FakePermissionsForRole()
         {
-            var permissions = new List<Permissions> { Permissions.SystemManagement, Permissions.AddressAddNew, Permissions.AddressEdit, };
             return new PermissionsForRole()
             {
                 Id = 1,
-                RoleName = "TestAdmin",
-                PackedPermissions = permissions.PackPermissionsIntoString(),
+                RoleName = TestDataHelper.GetRandomRole(),
+                PackedPermissions = TestDataHelper.GetFakePackedPermissions(),
             };
         }
 
@@ -181,28 +180,25 @@ namespace OutOfSchool.WebApi.Tests.Controllers
 
         private IEnumerable<PermissionsForRole> FakePermissionsForAllRoles()
         {
-            var permissions1 = new List<Permissions> { Permissions.SystemManagement, Permissions.AccessAll, };
-            var permissions2 = new List<Permissions> { Permissions.WorkshopAddNew, Permissions.TeacherAddNew, Permissions.ProviderAddNew, };
-            var permissions3 = new List<Permissions> { Permissions.FavoriteAddNew, Permissions.ApplicationAddNew, Permissions.ChildAddNew, };
-
             return new List<PermissionsForRole>()
             {
                 new PermissionsForRole()
                 {
                 Id = 1,
                 RoleName = Role.Admin.ToString(),
-                PackedPermissions = permissions1.PackPermissionsIntoString(),  },
+                PackedPermissions = TestDataHelper.GetFakePackedPermissions(),  
+                },
                 new PermissionsForRole()
                 {
                 Id = 2,
                 RoleName = Role.Provider.ToString(),
-                PackedPermissions = permissions2.PackPermissionsIntoString(),
+                PackedPermissions = TestDataHelper.GetFakePackedPermissions(),
                 },
                 new PermissionsForRole()
                 {
                 Id = 3,
                 RoleName = Role.Parent.ToString(),
-                PackedPermissions = permissions3.PackPermissionsIntoString(),
+                PackedPermissions = TestDataHelper.GetFakePackedPermissions(),
 
                 },
             };

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
@@ -12,6 +12,7 @@ using OutOfSchool.Common.PermissionsModule;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Tests.Common;
+using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Controllers.V1;
 using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
@@ -36,8 +37,8 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             service = new Mock<IPermissionsForRoleService>();
             controller = new PermissionsForRoleController(service.Object);
 
-            permissionsForAllRoles = FakePermissionsForAllRoles();
-            permissionsForRoleEntity = FakePermissionsForRole();
+            permissionsForAllRoles = PermissionsForRolesGenerator.GenerateForExistingRoles();
+            permissionsForRoleEntity = PermissionsForRolesGenerator.Generate();
         }
 
         [Test]
@@ -162,47 +163,5 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             // Assert
             response.AssertExpectedResponseTypeAndCheckDataInside<BadRequestObjectResult>(expectedResponse);
         }
-
-        /// <summary>
-        /// faking data for testing.
-        /// </summary>
-        private PermissionsForRole FakePermissionsForRole()
-        {
-            return new PermissionsForRole()
-            {
-                Id = 1,
-                RoleName = TestDataHelper.GetRandomRole(),
-                PackedPermissions = TestDataHelper.GetFakePackedPermissions(),
-            };
-        }
-
-
-
-        private IEnumerable<PermissionsForRole> FakePermissionsForAllRoles()
-        {
-            return new List<PermissionsForRole>()
-            {
-                new PermissionsForRole()
-                {
-                Id = 1,
-                RoleName = Role.Admin.ToString(),
-                PackedPermissions = TestDataHelper.GetFakePackedPermissions(),  
-                },
-                new PermissionsForRole()
-                {
-                Id = 2,
-                RoleName = Role.Provider.ToString(),
-                PackedPermissions = TestDataHelper.GetFakePackedPermissions(),
-                },
-                new PermissionsForRole()
-                {
-                Id = 3,
-                RoleName = Role.Parent.ToString(),
-                PackedPermissions = TestDataHelper.GetFakePackedPermissions(),
-
-                },
-            };
-        }
-
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
@@ -88,7 +88,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             // Arrange
             var roleName = Role.Admin.ToString();
-            var expected = permissionsForAllRoles.Where(s => s.RoleName == roleName).Select(p => p.ToModel()).FirstOrDefault();
+            var expected = permissionsForAllRoles.Where(s => s.RoleName == roleName).Select(p => p.ToModel()).First();
             service.Setup(x => x.GetByRole(roleName)).ReturnsAsync(permissionsForAllRoles.SingleOrDefault(x => x.RoleName == roleName).ToModel());
 
             // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -88,7 +87,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task GetByRoleName_WhenRoleNameIsValid_ReturnOkResultObject()
         {
             // Arrange
-            var roleName = Role.Admin.ToString();
+            var roleName = nameof(Role.Admin);
             var expected = permissionsForAllRoles.Where(s => s.RoleName == roleName).Select(p => p.ToModel()).First();
             service.Setup(x => x.GetByRole(roleName)).ReturnsAsync(permissionsForAllRoles.SingleOrDefault(x => x.RoleName == roleName).ToModel());
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
@@ -1,14 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using NUnit.Framework;
 using OutOfSchool.Common.PermissionsModule;
 using OutOfSchool.Services.Enums;
+using OutOfSchool.Services.Models;
 using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Controllers.V1;
+using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 
@@ -20,8 +24,8 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         private PermissionsForRoleController controller;
         private Mock<IPermissionsForRoleService> service;
 
-        private IEnumerable<PermissionsForRoleDTO> permissionsForAllRoles;
-        private PermissionsForRoleDTO permissionsForRoleDTO;
+        private IEnumerable<PermissionsForRole> permissionsForAllRoles;
+        private PermissionsForRole permissionsForRoleEntity;
 
 
 
@@ -33,20 +37,21 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             controller = new PermissionsForRoleController(service.Object);
 
             permissionsForAllRoles = FakePermissionsForAllRoles();
-            permissionsForRoleDTO = FakePermissionsForRole();
+            permissionsForRoleEntity = FakePermissionsForRole();
         }
 
         [Test]
         public async Task GetsAllPermissionsForRoles_ReturnsOkAllEnititiesInValue()
         {
             // Arrange
-            service.Setup(x => x.GetAll()).ReturnsAsync(permissionsForAllRoles);
+            var expected = permissionsForAllRoles.Select(s => s.ToModel());
+            service.Setup(x => x.GetAll()).ReturnsAsync(permissionsForAllRoles.Select(s => s.ToModel()));
 
             // Act
             var response = await controller.Get().ConfigureAwait(false);
 
             // Assert
-            response.GetAssertedResponseOkAndValidValue<IEnumerable<PermissionsForRoleDTO>>();
+            response.AssertResponseOkResultAndValidateValue(expected);
         }
 
         [Test]
@@ -65,11 +70,16 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         [Test]
         public void GetAllPermissions_WhenCalled_ReturnsAllSystemPermissions()
         {
+            //Arrange
+            var expectedValue = Enum.GetValues(typeof(Permissions))
+                .Cast<Permissions>()
+                .Select(p => new { permission = p.ToString(), code = p });
+
             // Act
             var response = controller.GetAllPermissions();
 
             // Assert
-            response.GetAssertedResponseValidateValueNotEmpty<OkObjectResult>();
+            response.AssertResponseOkResultAndValidateValue(expectedValue);
         }
 
         [Test]
@@ -77,13 +87,14 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task GetByRoleName_WhenRoleNameIsValid_ReturnOkResultObject(string roleName)
         {
             // Arrange
-            service.Setup(x => x.GetByRole(roleName)).ReturnsAsync(permissionsForAllRoles.SingleOrDefault(x => x.RoleName == roleName));
+            var expected = permissionsForAllRoles.Where(s => s.RoleName == roleName).Select(p => p.ToModel()).FirstOrDefault();
+            service.Setup(x => x.GetByRole(roleName)).ReturnsAsync(permissionsForAllRoles.SingleOrDefault(x => x.RoleName == roleName).ToModel());
 
             // Act
             var response = await controller.GetByRoleName(roleName).ConfigureAwait(false);
 
             // Assert
-            response.GetAssertedResponseOkAndValidValue<PermissionsForRoleDTO>();
+            response.AssertResponseOkResultAndValidateValue(expected);
         }
 
         [Test]
@@ -91,78 +102,105 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task GetByRoleName_NotExistingRoleName_ReturnsBadRequest(string roleName)
         {
             // Arrange
-            service.Setup(x => x.GetByRole(roleName)).Throws<ArgumentNullException>();
+            var expectedResponse = new BadRequestObjectResult("roleName");
+            service.Setup(x => x.GetByRole(roleName)).ThrowsAsync(new ArgumentNullException());
 
             // Act
             var response = await controller.GetByRoleName(roleName).ConfigureAwait(false);
 
             // Assert
-            response.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
+            response.AssertExpectedResponseTypeAndCheckDataInside<BadRequestObjectResult>(expectedResponse);
         }
 
         [Test]
         public async Task CreatePermissionsForRole_WhenModelIsValid_ReturnsCreatedAtActionResult()
         {
             // Arrange
-            service.Setup(x => x.Create(permissionsForRoleDTO)).ReturnsAsync(permissionsForRoleDTO);
+            var expected = permissionsForRoleEntity.ToModel();
+            var expectedResponse = new CreatedAtActionResult(
+                nameof(controller.GetByRoleName),
+                nameof(ProviderController),
+                new { id = expected.Id, roleName = expected.RoleName },
+                expected);
+            service.Setup(x => x.Create(expected)).ReturnsAsync(permissionsForRoleEntity.ToModel());
 
             // Act
-            var response = await controller.Create(permissionsForRoleDTO).ConfigureAwait(false);
+            var response = await controller.Create(expected).ConfigureAwait(false);
 
             // Assert
-            response.GetAssertedResponseValidateValueNotEmpty<CreatedAtActionResult>();
+            response.AssertExpectedResponseTypeAndCheckDataInside<CreatedAtActionResult>(expectedResponse);
         }
 
         [Test]
         public async Task UpdatePermissionsForRole_WhenModelIsValid_ReturnsOkObjectResult()
         {
             // Arrange
-            service.Setup(x => x.Update(permissionsForRoleDTO)).ReturnsAsync(permissionsForRoleDTO);
+            permissionsForRoleEntity.Description = "new";
+            var expected = permissionsForRoleEntity.ToModel();
+            service.Setup(x => x.Update(expected)).ReturnsAsync(permissionsForRoleEntity.ToModel());
 
             // Act
-            var response = await controller.Update(permissionsForRoleDTO).ConfigureAwait(false);
+            var response = await controller.Update(expected).ConfigureAwait(false);
 
             // Assert
-            response.GetAssertedResponseOkAndValidValue<PermissionsForRoleDTO>();
+            response.AssertResponseOkResultAndValidateValue(expected);
+        }
+
+        [Test]
+        public async Task UpdatePermissionsForRole_WhenProblemsWithDb_ReturnsBadRequestWithError()
+        {
+            // Arrange
+            var expected = permissionsForRoleEntity.ToModel();
+            var expectedResponse = new BadRequestObjectResult("message error");
+            service.Setup(x => x.Update(expected)).ThrowsAsync(new DbUpdateConcurrencyException("message error"));
+
+            // Act
+            var response = await controller.Update(expected).ConfigureAwait(false);
+
+            // Assert
+            response.AssertExpectedResponseTypeAndCheckDataInside<BadRequestObjectResult>(expectedResponse);
         }
 
         /// <summary>
         /// faking data for testing.
         /// </summary>
-        private PermissionsForRoleDTO FakePermissionsForRole()
+        private PermissionsForRole FakePermissionsForRole()
         {
-            return new PermissionsForRoleDTO()
+            var permissions = new List<Permissions> { Permissions.SystemManagement, Permissions.AddressAddNew, Permissions.AddressEdit, };
+            return new PermissionsForRole()
             {
                 Id = 1,
                 RoleName = "TestAdmin",
-                Permissions = new List<Permissions> { Permissions.SystemManagement, Permissions.AddressAddNew, Permissions.AddressEdit, },
+                PackedPermissions = permissions.PackPermissionsIntoString(),
             };
         }
 
 
 
-        private IEnumerable<PermissionsForRoleDTO> FakePermissionsForAllRoles()
+        private IEnumerable<PermissionsForRole> FakePermissionsForAllRoles()
         {
-            return new List<PermissionsForRoleDTO>()
+            var permissions1 = new List<Permissions> { Permissions.SystemManagement, Permissions.AccessAll, };
+            var permissions2 = new List<Permissions> { Permissions.WorkshopAddNew, Permissions.TeacherAddNew, Permissions.ProviderAddNew, };
+            var permissions3 = new List<Permissions> { Permissions.FavoriteAddNew, Permissions.ApplicationAddNew, Permissions.ChildAddNew, };
+
+            return new List<PermissionsForRole>()
             {
-                new PermissionsForRoleDTO()
+                new PermissionsForRole()
                 {
                 Id = 1,
                 RoleName = Role.Admin.ToString(),
-                Permissions = new List<Permissions> { Permissions.SystemManagement, Permissions.AccessAll, },
-                },
-                new PermissionsForRoleDTO()
+                PackedPermissions = permissions1.PackPermissionsIntoString(),  },
+                new PermissionsForRole()
                 {
                 Id = 2,
                 RoleName = Role.Provider.ToString(),
-                Permissions = new List<Permissions> { Permissions.WorkshopAddNew, Permissions.TeacherAddNew, Permissions.ProviderAddNew, },
-
+                PackedPermissions = permissions2.PackPermissionsIntoString(),
                 },
-                new PermissionsForRoleDTO()
+                new PermissionsForRole()
                 {
                 Id = 3,
                 RoleName = Role.Parent.ToString(),
-                Permissions = new List<Permissions> { Permissions.FavoriteAddNew, Permissions.ApplicationAddNew, Permissions.ChildAddNew, },
+                PackedPermissions = permissions3.PackPermissionsIntoString(),
 
                 },
             };

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -73,7 +74,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             //Arrange
             var expectedValue = Enum.GetValues(typeof(Permissions))
                 .Cast<Permissions>()
-                .Select(p => new { permission = p.ToString(), code = p });
+                .Select(p => (p, p.ToString()));
 
             // Act
             var response = controller.GetAllPermissions();
@@ -81,6 +82,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             // Assert
             response.AssertResponseOkResultAndValidateValue(expectedValue);
         }
+
 
         [Test]
         [TestCase("Admin")]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -83,7 +83,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         }
 
         [Test]
-        public async Task GetProviders_WhenCalled_ReturnsOkResultObject()
+        public async Task GetProviders_WhenCalled_ReturnsOkResultObject_WithColletionOfDTosValue()
         {
             // Arrange
             providerService.Setup(x => x.GetAll()).ReturnsAsync(providerDtos);
@@ -100,7 +100,15 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         [Test]
         public async Task GetProviders_ReturnsExpectedCollectionOfDtos()
         {
+            // Arrange
+            providerService.Setup(x => x.GetAll()).ReturnsAsync(providerDtos);
 
+
+            // Act
+            var result = (await providerController.Get().ConfigureAwait(false) as ObjectResult).Value as IEnumerable<ProviderDto>;
+
+            // Assert
+            Assert.That(providerDtos.Union(result).Count, Is.EqualTo(providerDtos.Count()));
         }
 
         [Test]
@@ -128,6 +136,21 @@ namespace OutOfSchool.WebApi.Tests.Controllers
 
             // Assert
             result.GetAssertedResponseOkAndValidValue<ProviderDto>();
+        }
+
+        [Test]
+        public async Task GetProviderById_WhenProviderWithIdExistsInDb_ReturnsExpectedProviderDto()
+        {
+            // Arrange
+            var existingId = providerDtos.Select(x => x.Id).FirstOrDefault();
+            var expectedProvider = providerDtos.SingleOrDefault(x => x.Id == existingId);
+            providerService.Setup(x => x.GetById(It.IsAny<Guid>())).ReturnsAsync(providerDtos.SingleOrDefault(x => x.Id == existingId));
+
+            // Act
+            var result = (await providerController.GetById(existingId).ConfigureAwait(false) as ObjectResult).Value as ProviderDto;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expectedProvider));
         }
 
         [Test]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -184,8 +184,8 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             // Arrange
             var providerToUpdate = providers.FirstOrDefault();
-            providerToUpdate.FullTitle = "New Title for changed provider";
-            var providerDto = providerToUpdate.ToModel();   
+            providerToUpdate.FullTitle = TestDataHelper.GetRandomWords();
+            var providerDto = providerToUpdate.ToModel();
             providerService.Setup(x => x.Update(providerDto, It.IsAny<string>()))
                 .ReturnsAsync(providerToUpdate.ToModel());
 
@@ -223,7 +223,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             // Arrange
             var providerToUpdateDto = providers.FirstOrDefault().ToModel();
-            providerToUpdateDto.FullTitle = "New Title for changed provider";
+            providerToUpdateDto.FullTitle = TestDataHelper.GetRandomWords();
             var expected = new BadRequestObjectResult("Can't change Provider with such parameters.\n" +
                         "Please check that information are valid.");
             providerService.Setup(x => x.Update(providerToUpdateDto, It.IsAny<string>())).ReturnsAsync(null as ProviderDto);
@@ -241,7 +241,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             // Arrange
             var providerToUpdateDto = ProviderDtoGenerator.Generate();
-            providerToUpdateDto.FullTitle = "New Title for changed provider";
+            providerToUpdateDto.FullTitle = TestDataHelper.GetRandomWords();
             var expected = new BadRequestObjectResult(new DbUpdateConcurrencyException());
             providerService.Setup(x => x.Update(providerToUpdateDto, It.IsAny<string>())).ThrowsAsync(new DbUpdateConcurrencyException());
 
@@ -271,7 +271,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             // Arrange
             var guid = Guid.NewGuid();
-            var expected = new BadRequestObjectResult("string exception");
+            var expected = new BadRequestObjectResult(TestDataHelper.GetRandomWords());
             providerService.Setup(x => x.Delete(guid)).ThrowsAsync(new ArgumentNullException());
 
             // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -105,7 +105,20 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         }
 
         [Test]
-        public async Task GetProvidersById_WhenIdIsValid_ReturnsOkObjectResult()
+        public async Task GetProviders_WhenNoRecordsInDB_ReturnsNoContentResult()
+        {
+            // Arrange
+            serviceProvider.Setup(x => x.GetAll()).ReturnsAsync(Enumerable.Empty<ProviderDto>());
+
+            // Act
+            var result = await controller.Get().ConfigureAwait(false);
+
+            // Assert
+            Assert.IsInstanceOf<NoContentResult>(result);
+        }
+
+        [Test]
+        public async Task GetProviderById_WhenIdIsValid_ReturnsOkObjectResult()
         {
             // Arrange
             var existingGuid = Guid.Parse(FakeProviderIdTestCase);
@@ -119,7 +132,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         }
 
         [Test]
-        public async Task GetProvidersById_WhenIdIsInvalid_ReturnsBadRequest()
+        public async Task GetProviderById_WhenIdIsInvalid_ReturnsBadRequest()
         {
             // Arrange
             var invalidUserId = Guid.NewGuid();
@@ -178,7 +191,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         }
 
         [Test]
-        public async Task UpdateProvider_WhenUserIsNotAdminAndUpdateNotOwnProvider_ReturnsBadRequestResult()
+        public async Task UpdateProvider_WhenUserUpdateNotOwnProvider_ReturnsBadRequestResult()
         {
             // Arrange
             var providerEntityToUpdate = new ProviderDto()

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -1,519 +1,519 @@
-﻿//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Security.Claims;
-//using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
 
-//using Microsoft.AspNetCore.Http;
-//using Microsoft.AspNetCore.Mvc;
-//using Microsoft.Extensions.Localization;
-//using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
 
-//using Moq;
-//using NUnit.Framework;
+using Moq;
+using NUnit.Framework;
 
-//using OutOfSchool.Services.Enums;
-//using OutOfSchool.Tests.Common;
-//using OutOfSchool.WebApi.Controllers.V1;
-//using OutOfSchool.WebApi.Models;
-//using OutOfSchool.WebApi.Services;
+using OutOfSchool.Services.Enums;
+using OutOfSchool.Tests.Common;
+using OutOfSchool.WebApi.Controllers.V1;
+using OutOfSchool.WebApi.Models;
+using OutOfSchool.WebApi.Services;
 
-//namespace OutOfSchool.WebApi.Tests.Controllers
-//{
-//    [TestFixture]
-//    public class ProviderControllerTests
-//    {
-//        private const int OkStatusCode = 200;
-//        private const int CreateStatusCode = 201;
-//        private const int NoContentStatusCode = 204;
-//        private const int BadRequestStatusCode = 400;
-//        private const string FakeUserId = "de909f35-5eb7-4b7a-bda8-40a5bfda67a6";
-//        private ProviderController controller;
-//        private Mock<IProviderService> serviceProvider;
-//        private ClaimsPrincipal user;
-//        private Mock<IStringLocalizer<SharedResource>> localizer;
+namespace OutOfSchool.WebApi.Tests.Controllers
+{
+    [TestFixture]
+    public class ProviderControllerTests
+    {
+        private const int OkStatusCode = 200;
+        private const int CreateStatusCode = 201;
+        private const int NoContentStatusCode = 204;
+        private const int BadRequestStatusCode = 400;
+        private const string FakeProviderIdTestCase = "69c0a240-728f-452e-807f-70074e261a8f";
+        private const string FakeUserId = "de909f35-5eb7-4b7a-bda8-40a5bfda67a6";
+        private ProviderController controller;
+        private Mock<IProviderService> serviceProvider;
+        private ClaimsPrincipal user;
+        private Mock<IStringLocalizer<SharedResource>> localizer;
 
-//        private List<ProviderDto> providers;
-//        private ProviderDto provider;
+        private List<ProviderDto> providers;
+        private Guid[] guids;
+        private ProviderDto provider;
 
-//        [SetUp]
-//        public void Setup()
-//        {
-//            serviceProvider = new Mock<IProviderService>();
-//            localizer = new Mock<IStringLocalizer<SharedResource>>();
+        [SetUp]
+        public void Setup()
+        {
+            serviceProvider = new Mock<IProviderService>();
+            localizer = new Mock<IStringLocalizer<SharedResource>>();
 
-//            controller = new ProviderController(serviceProvider.Object, localizer.Object, new Mock<ILogger<ProviderController>>().Object);
-//            user = new ClaimsPrincipal(new ClaimsIdentity(
-//                new Claim[]
-//                {
-//                    new Claim("sub", FakeUserId),
-//                    new Claim("role", "provider"),
-//                }, "sub"));
-//            controller.ControllerContext.HttpContext = new DefaultHttpContext { User = user };
+            controller = new ProviderController(serviceProvider.Object, localizer.Object, new Mock<ILogger<ProviderController>>().Object);
+            user = new ClaimsPrincipal(new ClaimsIdentity(
+                new Claim[]
+                {
+                    new Claim("sub", FakeUserId),
+                    new Claim("role", "provider"),
+                }, "sub"));
+            controller.ControllerContext.HttpContext = new DefaultHttpContext { User = user };
+            guids = new Guid[]
+            {
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                Guid.Parse(FakeProviderIdTestCase),
+            };
+            providers = FakeProviders(guids);
+            provider = FakeProvider();
+        }
 
-//            providers = FakeProviders();
-//            provider = FakeProvider();
-//        }
+        [Test]
+        public async Task GetProfile_WhenNoProviderWithSuchUserId_ReturnsNoContent()
+        {
+            // Arrange
+            ProviderDto nullProvider = null;
+            serviceProvider.Setup(x => x.GetByUserId(FakeUserId)).ReturnsAsync(nullProvider);
 
-//        [Test]
-//        public async Task GetProfile_WhenCalledForEmptyRepository_ReturnsNoContent()
-//        {
-//            // Arrange
-//            serviceProvider.Setup(x => x.GetAll()).ReturnsAsync(Enumerable.Empty<ProviderDto>());
+            // Act
+            var result = await controller.GetProfile().ConfigureAwait(false);
 
-//            // Act
-//            var result = await controller.GetProfile().ConfigureAwait(false);
+            // Assert
+            Assert.That(result, Is.InstanceOf<NoContentResult>());
+        }
 
-//            // Assert
-//            Assert.That(result, Is.InstanceOf<NoContentResult>());
-//        }
+        [Test]
+        public async Task GetProviders_WhenCalled_ReturnsOkResultObject()
+        {
+            // Arrange
+            serviceProvider.Setup(x => x.GetAll()).ReturnsAsync(providers);
 
-//        [Test]
-//        public async Task GetProfile_NoRepositoryForUser_ReturnsNoContent()
-//        {
-//            // Arrange
-//            serviceProvider.Setup(x => x.GetAll()).ReturnsAsync(providers);
+            // Act
+            var result = await controller.Get().ConfigureAwait(false) as OkObjectResult;
 
-//            // Act
-//            var result = await controller.GetProfile().ConfigureAwait(false);
+            // Assert
+            Assert.NotNull(result);
+            Assert.AreEqual(OkStatusCode, result.StatusCode);
+        }
 
-//            // Assert
-//            Assert.That(result, Is.InstanceOf<NoContentResult>());
-//        }
+        [Test]
+        [TestCase(FakeProviderIdTestCase)]
+        public async Task GetProvidersById_WhenIdIsValid_ReturnsOkObjectResult(string id)
+        {
+            // Arrange
+            var existingGuid = Guid.Parse(id);
+            serviceProvider.Setup(x => x.GetById(existingGuid)).ReturnsAsync(providers.SingleOrDefault(x => x.Id == existingGuid));
 
-//        [Test]
-//        public async Task GetProviders_WhenCalled_ReturnsOkResultObject()
-//        {
-//            // Arrange
-//            serviceProvider.Setup(x => x.GetAll()).ReturnsAsync(providers);
+            // Act
+            var result = await controller.GetById(existingGuid).ConfigureAwait(false) as OkObjectResult;
 
-//            // Act
-//            var result = await controller.Get().ConfigureAwait(false) as OkObjectResult;
+            // Assert
+            Assert.NotNull(result);
+            Assert.AreEqual(OkStatusCode, result.StatusCode);
+        }
 
-//            // Assert
-//            Assert.NotNull(result);
-//            Assert.AreEqual(OkStatusCode, result.StatusCode);
-//        }
+        [Test]
+        public async Task GetProvidersById_WhenIdIsInvalid_ReturnsBadRequest()
+        {
+            // Arrange
+            var invalidUserId = Guid.NewGuid();
+            serviceProvider.Setup(x => x.GetById(invalidUserId)).ThrowsAsync(new ArgumentOutOfRangeException());
 
-//        [Test]
-//        [TestCase(1)]
-//        public async Task GetProvidersById_WhenIdIsValid_ReturnsOkObjectResult(long id)
-//        {
-//            // Arrange
-//            serviceProvider.Setup(x => x.GetById(id)).ReturnsAsync(providers.SingleOrDefault(x => x.Id == id));
+            // Act
+            var result = await controller.GetById(invalidUserId).ConfigureAwait(false);
 
-//            // Act
-//            var result = await controller.GetById(id).ConfigureAwait(false) as OkObjectResult;
+            // Assert
+            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        }
 
-//            // Assert
-//            Assert.NotNull(result);
-//            Assert.AreEqual(OkStatusCode, result.StatusCode);
-//        }
+        [Test]
+        public async Task GetProviderById_WhenIdIsValid_ReturnsOkResult()
+        {
+            // Arrange
+            var existingProvider = providers.RandomItem();
+            serviceProvider.Setup(x => x.GetById(existingProvider.Id)).ReturnsAsync(existingProvider);
 
-//        [Test]
-//        public async Task GetProvidersById_WhenIdIsInvalid_ReturnsBadRequest()
-//        {
-//            // Arrange
-//            const int invalidUserId = 0;
+            // Act
+            var result = await controller.GetById(existingProvider.Id).ConfigureAwait(false);
 
-//            // Act
-//            var result = await controller.GetById(invalidUserId).ConfigureAwait(false);
+            // Assert
+            Assert.That(result, Is.InstanceOf<OkObjectResult>());
+            Assert.IsInstanceOf<ProviderDto>((result as ObjectResult).Value);
+        }
 
-//            // Assert
-//            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
-//        }
+        [Test]
+        public async Task CreateProvider_WhenModelIsValid_ReturnsCreatedAtActionResult()
+        {
+            // Arrange
+            serviceProvider.Setup(x => x.Create(provider)).ReturnsAsync(provider);
 
-//        [Test]
-//        public async Task GetProvidersById_WhenIdIsValid_ReturnsOkResult()
-//        {
-//            // Arrange
-//            var existingProvider = providers.RandomItem();
-//            serviceProvider.Setup(x => x.GetById(existingProvider.Id)).ReturnsAsync(existingProvider);
+            // Act
+            var result = await controller.Create(provider).ConfigureAwait(false) as CreatedAtActionResult;
 
-//            // Act
-//            var result = await controller.GetById(existingProvider.Id).ConfigureAwait(false) as OkObjectResult;
+            // Assert
+            Assert.NotNull(result);
+            Assert.AreEqual(CreateStatusCode, result.StatusCode);
+        }
 
-//            // Assert
-//            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-//        }
+        [Test]
+        public async Task CreateProvider_WhenModelIsInvalid_ReturnsBadRequestObjectResult()
+        {
+            // Arrange
+            controller.ModelState.AddModelError("CreateProvider", "Invalid model state.");
 
-//        [Test]
-//        public async Task CreateProvider_WhenModelIsValid_ReturnsCreatedAtActionResult()
-//        {
-//            // Arrange
-//            serviceProvider.Setup(x => x.Create(provider)).ReturnsAsync(provider);
+            // Act
+            var result = await controller.Create(provider).ConfigureAwait(false);
 
-//            // Act
-//            var result = await controller.Create(provider).ConfigureAwait(false) as CreatedAtActionResult;
+            // Assert
+            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
+            Assert.That((result as BadRequestObjectResult).StatusCode, Is.EqualTo(BadRequestStatusCode));
+        }
 
-//            // Assert
-//            Assert.NotNull(result);
-//            Assert.AreEqual(CreateStatusCode, result.StatusCode);
-//        }
+        [Test]
+        public async Task UpdateProvider_WhenModelIsValid_ReturnsOkObjectResult()
+        {
+            // Arrange
+            var changedProvider = new ProviderDto()
+            {
+                Id = Guid.NewGuid(),
+                FullTitle = "ChangedTitle",
+                UserId = FakeUserId,
+            };
+            serviceProvider.Setup(x => x.Update(changedProvider, changedProvider.UserId, "provider")).ReturnsAsync(changedProvider);
 
-//        [Test]
-//        public async Task CreateProvider_WhenModelIsInvalid_ReturnsBadRequestObjectResult()
-//        {
-//            // Arrange
-//            controller.ModelState.AddModelError("CreateProvider", "Invalid model state.");
+            // Act
+            var result = await controller.Update(changedProvider).ConfigureAwait(false);
 
-//            // Act
-//            var result = await controller.Create(provider).ConfigureAwait(false);
+            // Assert
+            Assert.IsInstanceOf<OkObjectResult>(result);
+            Assert.AreEqual(OkStatusCode, (result as ObjectResult).StatusCode);
+        }
 
-//            // Assert
-//            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
-//            Assert.That((result as BadRequestObjectResult).StatusCode, Is.EqualTo(BadRequestStatusCode));
-//        }
+        [Test]
+        public async Task UpdateProvider_WhenUserIsNotAdminAndUpdateNotOwnProvider_ReturnsBadRequestResult()
+        {
+            // Arrange
+            var changedProvider = new ProviderDto()
+            {
+                Id = Guid.NewGuid(),
+                FullTitle = "ChangedTitle",
+            };
+            serviceProvider.Setup(x => x.Update(changedProvider, "CVc4a6876a-77fb-4ecnne-9c78-a0880286ae3c", "provider")).ReturnsAsync(changedProvider);
 
-//        [Test]
-//        public async Task UpdateProvider_WhenModelIsValid_ReturnsOkObjectResult()
-//        {
-//            // Arrange
-//            var changedProvider = new ProviderDto()
-//            {
-//                Id = 1,
-//                FullTitle = "ChangedTitle",
-//                UserId = FakeUserId,
-//            };
-//            serviceProvider.Setup(x => x.Update(changedProvider, changedProvider.UserId, "provider")).ReturnsAsync(changedProvider);
+            // Act
+            var result = await controller.Update(changedProvider).ConfigureAwait(false);
 
-//            // Act
-//            var result = await controller.Update(changedProvider).ConfigureAwait(false) as OkObjectResult;
+            // Assert
+            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
+            Assert.That((result as BadRequestObjectResult).StatusCode, Is.EqualTo(BadRequestStatusCode));
+        }
 
-//            // Assert
-//            Assert.NotNull(result);
-//            Assert.AreEqual(OkStatusCode, result.StatusCode);
-//        }
+        [Test]
+        public async Task UpdateProvider_WhenModelIsInvalid_ReturnsBadRequestObjectResult()
+        {
+            // Arrange
+            controller.ModelState.AddModelError("UpdateProvider", "Invalid model state.");
 
-//        [Test]
-//        public async Task UpdateProvider_WhenUserIsNotAdminAndUpdateNotOwnProvider_ReturnsBadRequestResult()
-//        {
-//            // Arrange
-//            var changedProvider = new ProviderDto()
-//            {
-//                Id = 1,
-//                FullTitle = "ChangedTitle",
-//            };
-//            serviceProvider.Setup(x => x.Update(changedProvider, "CVc4a6876a-77fb-4ecnne-9c78-a0880286ae3c", "provider")).ReturnsAsync(changedProvider);
+            // Act
+            var result = await controller.Update(provider).ConfigureAwait(false);
 
-//            // Act
-//            var result = await controller.Update(changedProvider).ConfigureAwait(false);
+            // Assert
+            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
+            Assert.That((result as BadRequestObjectResult).StatusCode, Is.EqualTo(BadRequestStatusCode));
+        }
 
-//            // Assert
-//            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
-//            Assert.That((result as BadRequestObjectResult).StatusCode, Is.EqualTo(BadRequestStatusCode));
-//        }
+        [Test]
+        [TestCase(FakeProviderIdTestCase)]
+        public async Task DeleteProvider_WhenIdIsValid_ReturnsNoContentResult(string id)
+        {
+            // Arrange
+            var guid = Guid.Parse(id);
+            serviceProvider.Setup(x => x.Delete(guid));
 
-//        [Test]
-//        public async Task UpdateProvider_WhenModelIsInvalid_ReturnsBadRequestObjectResult()
-//        {
-//            // Arrange
-//            controller.ModelState.AddModelError("UpdateProvider", "Invalid model state.");
+            // Act
+            var result = await controller.Delete(guid) as NoContentResult;
 
-//            // Act
-//            var result = await controller.Update(provider).ConfigureAwait(false);
+            // Assert
+            Assert.NotNull(result);
+            Assert.AreEqual(NoContentStatusCode, result.StatusCode);
+        }
 
-//            // Assert
-//            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
-//            Assert.That((result as BadRequestObjectResult).StatusCode, Is.EqualTo(BadRequestStatusCode));
-//        }
+        //[Test]
+        //[TestCase(0)]
+        //public void DeleteProvider_WhenIdIsInvalid_ReturnsBadRequestObjectResult(long id)
+        //{
+        //    // Arrange
+        //    serviceProvider.Setup(x => x.Delete(id));
 
-//        [Test]
-//        [TestCase(1)]
-//        public async Task DeleteProvider_WhenIdIsValid_ReturnsNoContentResult(long id)
-//        {
-//            // Arrange
-//            serviceProvider.Setup(x => x.Delete(id));
+        //    // Act and Assert
+        //    Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+        //        async () => await controller.Delete(id).ConfigureAwait(false));
+        //}
 
-//            // Act
-//            var result = await controller.Delete(id) as NoContentResult;
+        //[Test]
+        //[TestCase(10)]
+        //public async Task DeleteProvider_WhenIdIsInvalid_ReturnsNull(long id)
+        //{
+        //    // Arrange
+        //    serviceProvider.Setup(x => x.Delete(id));
 
-//            // Assert
-//            Assert.NotNull(result);
-//            Assert.AreEqual(NoContentStatusCode, result.StatusCode);
-//        }
+        //    // Act
+        //    var result = await controller.Delete(id) as OkObjectResult;
 
-//        [Test]
-//        [TestCase(0)]
-//        public void DeleteProvider_WhenIdIsInvalid_ReturnsBadRequestObjectResult(long id)
-//        {
-//            // Arrange
-//            serviceProvider.Setup(x => x.Delete(id));
+        //    // Assert
+        //    Assert.That(result, Is.Null);
+        //}
 
-//            // Act and Assert
-//            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-//                async () => await controller.Delete(id).ConfigureAwait(false));
-//        }
+        private ProviderDto FakeProvider()
+        {
+            return new ProviderDto()
+            {
+                Id = Guid.Parse(FakeProviderIdTestCase),
+                FullTitle = "Title6",
+                ShortTitle = "ShortTitle6",
+                Website = "Website6",
+                Facebook = "Facebook6",
+                Email = "user6@example.com",
+                Instagram = "Instagram6",
+                Description = "Description6",
+                DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
+                EdrpouIpn = "12345656",
+                PhoneNumber = "1111111111",
+                Founder = "Founder",
+                Ownership = OwnershipType.Private,
+                Type = ProviderType.TOV,
+                Status = false,
+                UserId = FakeUserId,
+                LegalAddress = new AddressDto
+                {
+                    Id = 11,
+                    Region = "Region11",
+                    District = "District11",
+                    City = "City11",
+                    Street = "Street11",
+                    BuildingNumber = "BuildingNumber11",
+                    Latitude = 0,
+                    Longitude = 0,
+                },
+                ActualAddress = new AddressDto
+                {
+                    Id = 12,
+                    Region = "Region12",
+                    District = "District12",
+                    City = "City12",
+                    Street = "Street12",
+                    BuildingNumber = "BuildingNumber12",
+                    Latitude = 0,
+                    Longitude = 0,
+                },
+            };
+        }
 
-//        [Test]
-//        [TestCase(10)]
-//        public async Task DeleteProvider_WhenIdIsInvalid_ReturnsNull(long id)
-//        {
-//            // Arrange
-//            serviceProvider.Setup(x => x.Delete(id));
-
-//            // Act
-//            var result = await controller.Delete(id) as OkObjectResult;
-
-//            // Assert
-//            Assert.That(result, Is.Null);
-//        }
-
-//        private ProviderDto FakeProvider()
-//        {
-//            return new ProviderDto()
-//            {
-//                Id = 6,
-//                FullTitle = "Title6",
-//                ShortTitle = "ShortTitle6",
-//                Website = "Website6",
-//                Facebook = "Facebook6",
-//                Email = "user6@example.com",
-//                Instagram = "Instagram6",
-//                Description = "Description6",
-//                DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-//                EdrpouIpn = "12345656",
-//                PhoneNumber = "1111111111",
-//                Founder = "Founder",
-//                Ownership = OwnershipType.Private,
-//                Type = ProviderType.TOV,
-//                Status = false,
-//                UserId = FakeUserId,
-//                LegalAddress = new AddressDto
-//                {
-//                    Id = 11,
-//                    Region = "Region11",
-//                    District = "District11",
-//                    City = "City11",
-//                    Street = "Street11",
-//                    BuildingNumber = "BuildingNumber11",
-//                    Latitude = 0,
-//                    Longitude = 0,
-//                },
-//                ActualAddress = new AddressDto
-//                {
-//                    Id = 12,
-//                    Region = "Region12",
-//                    District = "District12",
-//                    City = "City12",
-//                    Street = "Street12",
-//                    BuildingNumber = "BuildingNumber12",
-//                    Latitude = 0,
-//                    Longitude = 0,
-//                },
-//            };
-//        }
-
-//        private List<ProviderDto> FakeProviders()
-//        {
-//            return new List<ProviderDto>()
-//            {
-//                new ProviderDto()
-//                {
-//                        Id = 1,
-//                        FullTitle = "Title1",
-//                        ShortTitle = "ShortTitle1",
-//                        Website = "Website1",
-//                        Facebook = "Facebook1",
-//                        Email = "user1@example.com",
-//                        Instagram = "Instagram1",
-//                        Description = "Description1",
-//                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-//                        EdrpouIpn = "12345678",
-//                        PhoneNumber = "1111111111",
-//                        Founder = "Founder",
-//                        Ownership = OwnershipType.Private,
-//                        Type = ProviderType.TOV,
-//                        Status = false,
-//                        UserId = "de909f35-5eb7-4b7a-bda8-40a5bfda96a6",
-//                        LegalAddress = new AddressDto
-//                        {
-//                            Id = 1,
-//                            Region = "Region1",
-//                            District = "District1",
-//                            City = "City1",
-//                            Street = "Street1",
-//                            BuildingNumber = "BuildingNumber1",
-//                            Latitude = 0,
-//                            Longitude = 0,
-//                        },
-//                        ActualAddress = new AddressDto
-//                        {
-//                            Id = 2,
-//                            Region = "Region2",
-//                            District = "District2",
-//                            City = "City2",
-//                            Street = "Street2",
-//                            BuildingNumber = "BuildingNumber2",
-//                            Latitude = 0,
-//                            Longitude = 0,
-//                        },
-//                },
-//                new ProviderDto()
-//                {
-//                        Id = 2,
-//                        FullTitle = "Title2",
-//                        ShortTitle = "ShortTitle2",
-//                        Website = "Website2",
-//                        Facebook = "Facebook2",
-//                        Email = "user2@example.com",
-//                        Instagram = "Instagram2",
-//                        Description = "Description2",
-//                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-//                        EdrpouIpn = "12345645",
-//                        PhoneNumber = "1111111111",
-//                        Founder = "Founder",
-//                        Ownership = OwnershipType.Private,
-//                        Type = ProviderType.TOV,
-//                        Status = false,
-//                        UserId = "de909VV5-5eb7-4b7a-bda8-40a5bfda96a6",
-//                        LegalAddress = new AddressDto
-//                        {
-//                            Id = 3,
-//                            Region = "Region3",
-//                            District = "District3",
-//                            City = "City3",
-//                            Street = "Street3",
-//                            BuildingNumber = "BuildingNumber3",
-//                            Latitude = 0,
-//                            Longitude = 0,
-//                        },
-//                        ActualAddress = new AddressDto
-//                        {
-//                            Id = 4,
-//                            Region = "Region4",
-//                            District = "District4",
-//                            City = "City4",
-//                            Street = "Street4",
-//                            BuildingNumber = "BuildingNumber4",
-//                            Latitude = 0,
-//                            Longitude = 0,
-//                        },
-//                },
-//                new ProviderDto()
-//                {
-//                        Id = 3,
-//                        FullTitle = "Title3",
-//                        ShortTitle = "ShortTitle3",
-//                        Website = "Website3",
-//                        Facebook = "Facebook3",
-//                        Email = "user3@example.com",
-//                        Instagram = "Instagram3",
-//                        Description = "Description3",
-//                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-//                        EdrpouIpn = "12345000",
-//                        PhoneNumber = "1111111111",
-//                        Founder = "Founder",
-//                        Ownership = OwnershipType.Private,
-//                        Type = ProviderType.TOV,
-//                        Status = false,
-//                        UserId = "de909f35-5eb7-4b7a-bda8-40a5bfda96a6",
-//                        LegalAddress = new AddressDto
-//                        {
-//                            Id = 5,
-//                            Region = "Region5",
-//                            District = "District5",
-//                            City = "City5",
-//                            Street = "Street5",
-//                            BuildingNumber = "BuildingNumber5",
-//                            Latitude = 0,
-//                            Longitude = 0,
-//                        },
-//                        ActualAddress = new AddressDto
-//                        {
-//                            Id = 6,
-//                            Region = "Region6",
-//                            District = "District6",
-//                            City = "City6",
-//                            Street = "Street6",
-//                            BuildingNumber = "BuildingNumber6",
-//                            Latitude = 0,
-//                            Longitude = 0,
-//                        },
-//                },
-//                new ProviderDto()
-//                {
-//                        Id = 4,
-//                        FullTitle = "Title4",
-//                        ShortTitle = "ShortTitle4",
-//                        Website = "Website4",
-//                        Facebook = "Facebook4",
-//                        Email = "user4@example.com",
-//                        Instagram = "Instagram4",
-//                        Description = "Description4",
-//                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-//                        EdrpouIpn = "10045678",
-//                        PhoneNumber = "1111111111",
-//                        Founder = "Founder",
-//                        Ownership = OwnershipType.Private,
-//                        Type = ProviderType.TOV,
-//                        Status = false,
-//                        UserId = "de909f35-5eb7-4BBa-bda8-40a5bfda96a6",
-//                        LegalAddress = new AddressDto
-//                        {
-//                            Id = 7,
-//                            Region = "Region7",
-//                            District = "District7",
-//                            City = "City7",
-//                            Street = "Street7",
-//                            BuildingNumber = "BuildingNumber7",
-//                            Latitude = 0,
-//                            Longitude = 0,
-//                        },
-//                        ActualAddress = new AddressDto
-//                        {
-//                            Id = 8,
-//                            Region = "Region8",
-//                            District = "District8",
-//                            City = "City8",
-//                            Street = "Street8",
-//                            BuildingNumber = "BuildingNumber8",
-//                            Latitude = 0,
-//                            Longitude = 0,
-//                        },
-//                },
-//                new ProviderDto()
-//                {
-//                        Id = 5,
-//                        FullTitle = "Title5",
-//                        ShortTitle = "ShortTitle5",
-//                        Website = "Website5",
-//                        Facebook = "Facebook5",
-//                        Email = "user5@example.com",
-//                        Instagram = "Instagram5",
-//                        Description = "Description5",
-//                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-//                        EdrpouIpn = "12374678",
-//                        PhoneNumber = "1111111111",
-//                        Founder = "Founder",
-//                        Ownership = OwnershipType.Private,
-//                        Type = ProviderType.TOV,
-//                        Status = false,
-//                        UserId = "de909f35-5eb7-4b7a-bda8-40a5bfdaEEa6",
-//                        LegalAddress = new AddressDto
-//                        {
-//                            Id = 9,
-//                            Region = "Region9",
-//                            District = "District9",
-//                            City = "City9",
-//                            Street = "Street9",
-//                            BuildingNumber = "BuildingNumber9",
-//                            Latitude = 0,
-//                            Longitude = 0,
-//                        },
-//                        ActualAddress = new AddressDto
-//                        {
-//                            Id = 10,
-//                            Region = "Region10",
-//                            District = "District10",
-//                            City = "City10",
-//                            Street = "Street10",
-//                            BuildingNumber = "BuildingNumber10",
-//                            Latitude = 0,
-//                            Longitude = 0,
-//                        },
-//                },
-//            };
-//        }
-//    }
-//}
+        private List<ProviderDto> FakeProviders(params Guid[] guids)
+        {
+            return new List<ProviderDto>()
+            {
+                new ProviderDto()
+                {
+                        Id = guids[0],
+                        FullTitle = "Title1",
+                        ShortTitle = "ShortTitle1",
+                        Website = "Website1",
+                        Facebook = "Facebook1",
+                        Email = "user1@example.com",
+                        Instagram = "Instagram1",
+                        Description = "Description1",
+                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
+                        EdrpouIpn = "12345678",
+                        PhoneNumber = "1111111111",
+                        Founder = "Founder",
+                        Ownership = OwnershipType.Private,
+                        Type = ProviderType.TOV,
+                        Status = false,
+                        UserId = "de909f35-5eb7-4b7a-bda8-40a5bfda96a6",
+                        LegalAddress = new AddressDto
+                        {
+                            Id = 1,
+                            Region = "Region1",
+                            District = "District1",
+                            City = "City1",
+                            Street = "Street1",
+                            BuildingNumber = "BuildingNumber1",
+                            Latitude = 0,
+                            Longitude = 0,
+                        },
+                        ActualAddress = new AddressDto
+                        {
+                            Id = 2,
+                            Region = "Region2",
+                            District = "District2",
+                            City = "City2",
+                            Street = "Street2",
+                            BuildingNumber = "BuildingNumber2",
+                            Latitude = 0,
+                            Longitude = 0,
+                        },
+                },
+                new ProviderDto()
+                {
+                        Id = guids[1],
+                        FullTitle = "Title2",
+                        ShortTitle = "ShortTitle2",
+                        Website = "Website2",
+                        Facebook = "Facebook2",
+                        Email = "user2@example.com",
+                        Instagram = "Instagram2",
+                        Description = "Description2",
+                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
+                        EdrpouIpn = "12345645",
+                        PhoneNumber = "1111111111",
+                        Founder = "Founder",
+                        Ownership = OwnershipType.Private,
+                        Type = ProviderType.TOV,
+                        Status = false,
+                        UserId = "de909VV5-5eb7-4b7a-bda8-40a5bfda96a6",
+                        LegalAddress = new AddressDto
+                        {
+                            Id = 3,
+                            Region = "Region3",
+                            District = "District3",
+                            City = "City3",
+                            Street = "Street3",
+                            BuildingNumber = "BuildingNumber3",
+                            Latitude = 0,
+                            Longitude = 0,
+                        },
+                        ActualAddress = new AddressDto
+                        {
+                            Id = 4,
+                            Region = "Region4",
+                            District = "District4",
+                            City = "City4",
+                            Street = "Street4",
+                            BuildingNumber = "BuildingNumber4",
+                            Latitude = 0,
+                            Longitude = 0,
+                        },
+                },
+                new ProviderDto()
+                {
+                        Id = guids[2],
+                        FullTitle = "Title3",
+                        ShortTitle = "ShortTitle3",
+                        Website = "Website3",
+                        Facebook = "Facebook3",
+                        Email = "user3@example.com",
+                        Instagram = "Instagram3",
+                        Description = "Description3",
+                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
+                        EdrpouIpn = "12345000",
+                        PhoneNumber = "1111111111",
+                        Founder = "Founder",
+                        Ownership = OwnershipType.Private,
+                        Type = ProviderType.TOV,
+                        Status = false,
+                        UserId = "de909f35-5eb7-4b7a-bda8-40a5bfda96a6",
+                        LegalAddress = new AddressDto
+                        {
+                            Id = 5,
+                            Region = "Region5",
+                            District = "District5",
+                            City = "City5",
+                            Street = "Street5",
+                            BuildingNumber = "BuildingNumber5",
+                            Latitude = 0,
+                            Longitude = 0,
+                        },
+                        ActualAddress = new AddressDto
+                        {
+                            Id = 6,
+                            Region = "Region6",
+                            District = "District6",
+                            City = "City6",
+                            Street = "Street6",
+                            BuildingNumber = "BuildingNumber6",
+                            Latitude = 0,
+                            Longitude = 0,
+                        },
+                },
+                new ProviderDto()
+                {
+                        Id = guids[3],
+                        FullTitle = "Title4",
+                        ShortTitle = "ShortTitle4",
+                        Website = "Website4",
+                        Facebook = "Facebook4",
+                        Email = "user4@example.com",
+                        Instagram = "Instagram4",
+                        Description = "Description4",
+                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
+                        EdrpouIpn = "10045678",
+                        PhoneNumber = "1111111111",
+                        Founder = "Founder",
+                        Ownership = OwnershipType.Private,
+                        Type = ProviderType.TOV,
+                        Status = false,
+                        UserId = "de909f35-5eb7-4BBa-bda8-40a5bfda96a6",
+                        LegalAddress = new AddressDto
+                        {
+                            Id = 7,
+                            Region = "Region7",
+                            District = "District7",
+                            City = "City7",
+                            Street = "Street7",
+                            BuildingNumber = "BuildingNumber7",
+                            Latitude = 0,
+                            Longitude = 0,
+                        },
+                        ActualAddress = new AddressDto
+                        {
+                            Id = 8,
+                            Region = "Region8",
+                            District = "District8",
+                            City = "City8",
+                            Street = "Street8",
+                            BuildingNumber = "BuildingNumber8",
+                            Latitude = 0,
+                            Longitude = 0,
+                        },
+                },
+                new ProviderDto()
+                {
+                        Id = Guid.NewGuid(),
+                        FullTitle = "Title5",
+                        ShortTitle = "ShortTitle5",
+                        Website = "Website5",
+                        Facebook = "Facebook5",
+                        Email = "user5@example.com",
+                        Instagram = "Instagram5",
+                        Description = "Description5",
+                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
+                        EdrpouIpn = "12374678",
+                        PhoneNumber = "1111111111",
+                        Founder = "Founder",
+                        Ownership = OwnershipType.Private,
+                        Type = ProviderType.TOV,
+                        Status = false,
+                        UserId = "de909f35-5eb7-4b7a-bda8-40a5bfdaEEa6",
+                        LegalAddress = new AddressDto
+                        {
+                            Id = 9,
+                            Region = "Region9",
+                            District = "District9",
+                            City = "City9",
+                            Street = "Street9",
+                            BuildingNumber = "BuildingNumber9",
+                            Latitude = 0,
+                            Longitude = 0,
+                        },
+                        ActualAddress = new AddressDto
+                        {
+                            Id = 10,
+                            Region = "Region10",
+                            District = "District10",
+                            City = "City10",
+                            Street = "Street10",
+                            BuildingNumber = "BuildingNumber10",
+                            Latitude = 0,
+                            Longitude = 0,
+                        },
+                },
+            };
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -11,10 +11,12 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 using NUnit.Framework;
-
+using OutOfSchool.Common;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Tests.Common;
+using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Controllers.V1;
+using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 
@@ -23,40 +25,34 @@ namespace OutOfSchool.WebApi.Tests.Controllers
     [TestFixture]
     public class ProviderControllerTests
     {
-        private const string FakeProviderIdTestCase = "69c0a240-728f-452e-807f-70074e261a8f";
-        private const string FakeUserId = "de909f35-5eb7-4b7a-bda8-40a5bfda67a6";
-        private ProviderController controller;
-        private Mock<IProviderService> serviceProvider;
-        private ClaimsPrincipal user;
-        private Mock<IStringLocalizer<SharedResource>> localizer;
 
-        private List<ProviderDto> providers;
-        private Guid[] guids;
-        private ProviderDto provider;
+        private ProviderController providerController;
+        private Mock<IProviderService> providerService;
+        private List<ProviderDto> providerDtos;
+        private ProviderDto providerDto;
 
         [SetUp]
         public void Setup()
         {
-            serviceProvider = new Mock<IProviderService>();
-            localizer = new Mock<IStringLocalizer<SharedResource>>();
 
-            controller = new ProviderController(serviceProvider.Object, localizer.Object, new Mock<ILogger<ProviderController>>().Object);
-            user = new ClaimsPrincipal(new ClaimsIdentity(
-                new Claim[]
-                {
-                    new Claim("sub", FakeUserId),
-                    new Claim("role", "provider"),
-                }, "sub"));
-            controller.ControllerContext.HttpContext = new DefaultHttpContext { User = user };
-            guids = new Guid[]
-            {
-                Guid.NewGuid(),
-                Guid.NewGuid(),
-                Guid.NewGuid(),
-                Guid.Parse(FakeProviderIdTestCase),
-            };
-            providers = FakeProviders(guids);
-            provider = FakeProvider();
+            var localizer = new Mock<IStringLocalizer<SharedResource>>();
+            var user = new ClaimsPrincipal
+                (new ClaimsIdentity(
+                    new Claim[]
+                    {
+                        new Claim(IdentityResourceClaimsTypes.Sub, Guid.NewGuid().ToString()),
+                        new Claim(IdentityResourceClaimsTypes.Role, Role.Provider.ToString()),
+                    },
+                    IdentityResourceClaimsTypes.Sub));
+
+            providerService = new Mock<IProviderService>();
+            providerController = new ProviderController(providerService.Object, localizer.Object, new Mock<ILogger<ProviderController>>().Object);
+
+
+
+            providerController.ControllerContext.HttpContext = new DefaultHttpContext { User = user };
+            providerDtos = ProviderDtoGenerator.Generate(10);
+            providerDto = ProviderDtoGenerator.Generate();
         }
 
         [Test]
@@ -64,10 +60,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             // Arrange
             ProviderDto nullProvider = null;
-            serviceProvider.Setup(x => x.GetByUserId(FakeUserId)).ReturnsAsync(nullProvider);
+            providerService.Setup(x => x.GetByUserId(It.IsAny<string>())).ReturnsAsync(nullProvider);
 
             // Act
-            var result = await controller.GetProfile().ConfigureAwait(false);
+            var result = await providerController.GetProfile().ConfigureAwait(false);
 
             // Assert
             Assert.IsInstanceOf<NoContentResult>(result);
@@ -77,11 +73,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task GetProfile_WhenProviderForUserIdExists_ReturnsOkObjectResult()
         {
             // Arrange
-            var existingProvider = provider;
-            serviceProvider.Setup(x => x.GetByUserId(FakeUserId)).ReturnsAsync(existingProvider);
+            providerService.Setup(x => x.GetByUserId(It.IsAny<string>())).ReturnsAsync(providerDto);
 
             // Act
-            var result = await controller.GetProfile().ConfigureAwait(false);
+            var result = await providerController.GetProfile().ConfigureAwait(false);
 
             // Assert
             result.GetAssertedResponseOkAndValidValue<ProviderDto>();
@@ -91,64 +86,72 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task GetProviders_WhenCalled_ReturnsOkResultObject()
         {
             // Arrange
-            serviceProvider.Setup(x => x.GetAll()).ReturnsAsync(providers);
+            providerService.Setup(x => x.GetAll()).ReturnsAsync(providerDtos);
 
             // Act
-            var result = await controller.Get().ConfigureAwait(false);
+            var result = await providerController.Get().ConfigureAwait(false);
 
             // Assert
             result.GetAssertedResponseOkAndValidValue<IEnumerable<ProviderDto>>();
+        }
+
+
+        // write test to compare collection returned
+        [Test]
+        public async Task GetProviders_ReturnsExpectedCollectionOfDtos()
+        {
+
         }
 
         [Test]
         public async Task GetProviders_WhenNoRecordsInDB_ReturnsNoContentResult()
         {
             // Arrange
-            serviceProvider.Setup(x => x.GetAll()).ReturnsAsync(Enumerable.Empty<ProviderDto>());
+            providerService.Setup(x => x.GetAll()).ReturnsAsync(Enumerable.Empty<ProviderDto>());
 
             // Act
-            var result = await controller.Get().ConfigureAwait(false);
+            var result = await providerController.Get().ConfigureAwait(false);
 
             // Assert
             Assert.IsInstanceOf<NoContentResult>(result);
         }
 
         [Test]
-        public async Task GetProviderById_WhenIdIsValid_ReturnsOkObjectResult()
+        public async Task GetProviderById_WhenProviderWithIdExistsInDb_ReturnsOkObjectResultWithDtoAsValue()
         {
             // Arrange
-            var existingGuid = Guid.Parse(FakeProviderIdTestCase);
-            serviceProvider.Setup(x => x.GetById(existingGuid)).ReturnsAsync(providers.SingleOrDefault(x => x.Id == existingGuid));
+            var existingId = providerDtos.Select(x => x.Id).FirstOrDefault();
+            providerService.Setup(x => x.GetById(It.IsAny<Guid>())).ReturnsAsync(providerDtos.SingleOrDefault(x => x.Id == existingId));
 
             // Act
-            var result = await controller.GetById(existingGuid).ConfigureAwait(false);
+            var result = await providerController.GetById(existingId).ConfigureAwait(false);
 
             // Assert
             result.GetAssertedResponseOkAndValidValue<ProviderDto>();
         }
 
         [Test]
-        public async Task GetProviderById_WhenIdIsInvalid_ReturnsBadRequest()
+        public async Task GetProviderById_WhenIdDoesntExistsInDb_ReturnsNotFoundResult()
         {
             // Arrange
             var invalidUserId = Guid.NewGuid();
-            serviceProvider.Setup(x => x.GetById(invalidUserId)).ThrowsAsync(new ArgumentOutOfRangeException());
+            providerService.Setup(x => x.GetById(It.IsAny<Guid>())).ReturnsAsync(null as ProviderDto);
 
             // Act
-            var result = await controller.GetById(invalidUserId).ConfigureAwait(false);
+            var result = await providerController.GetById(invalidUserId).ConfigureAwait(false);
 
             // Assert
-            result.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
+            result.GetAssertedResponseValidateValueNotEmpty<NotFoundObjectResult>();
         }
 
         [Test]
         public async Task CreateProvider_WhenModelIsValid_ReturnsCreatedAtActionResult()
         {
             // Arrange
-            serviceProvider.Setup(x => x.Create(provider)).ReturnsAsync(provider);
+            providerService.Setup(x => x.Create(It.IsAny<ProviderDto>())).ReturnsAsync(providerDto);
 
             // Act
-            var result = await controller.Create(provider).ConfigureAwait(false);
+            var result = await providerController.Create(providerDto).ConfigureAwait(false);
 
             // Assert
             result.GetAssertedResponseValidateValueNotEmpty<CreatedAtActionResult>();
@@ -158,29 +161,28 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task CreateProvider_WhenModelIsInvalid_ReturnsBadRequestObjectResult()
         {
             // Arrange
-            controller.ModelState.AddModelError("CreateProvider", "Invalid model state.");
+            providerController.ModelState.AddModelError("CreateProvider", "Invalid model state.");
 
             // Act
-            var result = await controller.Create(provider).ConfigureAwait(false);
+            var result = await providerController.Create(providerDto).ConfigureAwait(false);
 
             // Assert
             result.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
         }
 
+        /// TO DO ????
+        /// Since we have a mock here - we also must check that controller received a proper argument when updating the provider.
         [Test]
-        public async Task UpdateProvider_WhenModelIsValid_ReturnsOkObjectResult()
+        public async Task UpdateProvider_WhenModelIsValidAndProviderExists_ReturnsOkObjectResult()
         {
             // Arrange
-            var changedProvider = new ProviderDto()
-            {
-                Id = Guid.NewGuid(),
-                FullTitle = "ChangedTitle",
-                UserId = FakeUserId,
-            };
-            serviceProvider.Setup(x => x.Update(changedProvider, changedProvider.UserId)).ReturnsAsync(changedProvider);
+            var providerToUpdateDto = providerDtos.FirstOrDefault();
+            providerToUpdateDto.FullTitle = "New Title for changed provider";
+            providerService.Setup(x => x.Update(providerToUpdateDto, It.IsAny<string>()))
+                .ReturnsAsync(providerToUpdateDto);
 
             // Act
-            var result = await controller.Update(changedProvider).ConfigureAwait(false);
+            var result = await providerController.Update(providerToUpdateDto).ConfigureAwait(false);
 
             // Assert
             result.GetAssertedResponseOkAndValidValue<ProviderDto>();
@@ -190,15 +192,12 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task UpdateProvider_WhenUserUpdateNotOwnProvider_ReturnsBadRequestResult()
         {
             // Arrange
-            var providerEntityToUpdate = new ProviderDto()
-            {
-                Id = Guid.NewGuid(),
-                FullTitle = "ChangedTitle",
-            };
-            serviceProvider.Setup(x => x.Update(providerEntityToUpdate, "CVc4a6876a-77fb-4ecnne-9c78-a0880286ae3c")).ReturnsAsync(providerEntityToUpdate);
+            var providerToUpdateDto = providerDtos.FirstOrDefault();
+            providerToUpdateDto.FullTitle = "New Title for changed provider";
+            providerService.Setup(x => x.Update(providerToUpdateDto, It.IsAny<string>())).ReturnsAsync(null as ProviderDto);
 
             // Act
-            var result = await controller.Update(providerEntityToUpdate).ConfigureAwait(false);
+            var result = await providerController.Update(providerToUpdateDto).ConfigureAwait(false);
 
             // Assert
             result.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
@@ -208,10 +207,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task UpdateProvider_WhenModelIsInvalid_ReturnsBadRequestObjectResult()
         {
             // Arrange
-            controller.ModelState.AddModelError("UpdateProvider", "Invalid model state.");
+            providerController.ModelState.AddModelError("UpdateProvider", "Invalid model state.");
 
             // Act
-            var result = await controller.Update(provider).ConfigureAwait(false);
+            var result = await providerController.Update(providerDto).ConfigureAwait(false);
 
             // Assert
             result.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
@@ -221,11 +220,11 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         public async Task DeleteProvider_WhenIdIsValid_ReturnsNoContentResult()
         {
             // Arrange
-            var guid = Guid.Parse(FakeProviderIdTestCase);
-            serviceProvider.Setup(x => x.Delete(guid));
+            var existingProviderGuid = providerDtos.Select(p => p.Id).FirstOrDefault();
+            providerService.Setup(x => x.Delete(existingProviderGuid));
 
             // Act
-            var result = await controller.Delete(guid);
+            var result = await providerController.Delete(existingProviderGuid);
 
             // Assert
             Assert.IsInstanceOf<NoContentResult>(result);
@@ -236,270 +235,13 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             // Arrange
             var guid = Guid.NewGuid();
-            serviceProvider.Setup(x => x.Delete(guid)).ThrowsAsync(new ArgumentNullException());
+            providerService.Setup(x => x.Delete(guid)).ThrowsAsync(new ArgumentNullException());
 
             // Act
-            var result = await controller.Delete(guid).ConfigureAwait(false);
+            var result = await providerController.Delete(guid).ConfigureAwait(false);
 
             // Assert
             result.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
-        }
-
-        private ProviderDto FakeProvider()
-        {
-            return new ProviderDto()
-            {
-                Id = Guid.Parse(FakeProviderIdTestCase),
-                FullTitle = "Title6",
-                ShortTitle = "ShortTitle6",
-                Website = "Website6",
-                Facebook = "Facebook6",
-                Email = "user6@example.com",
-                Instagram = "Instagram6",
-                Description = "Description6",
-                DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-                EdrpouIpn = "12345656",
-                PhoneNumber = "1111111111",
-                Founder = "Founder",
-                Ownership = OwnershipType.Private,
-                Type = ProviderType.TOV,
-                Status = false,
-                UserId = FakeUserId,
-                LegalAddress = new AddressDto
-                {
-                    Id = 11,
-                    Region = "Region11",
-                    District = "District11",
-                    City = "City11",
-                    Street = "Street11",
-                    BuildingNumber = "BuildingNumber11",
-                    Latitude = 0,
-                    Longitude = 0,
-                },
-                ActualAddress = new AddressDto
-                {
-                    Id = 12,
-                    Region = "Region12",
-                    District = "District12",
-                    City = "City12",
-                    Street = "Street12",
-                    BuildingNumber = "BuildingNumber12",
-                    Latitude = 0,
-                    Longitude = 0,
-                },
-            };
-        }
-
-        private List<ProviderDto> FakeProviders(params Guid[] guids)
-        {
-            return new List<ProviderDto>()
-            {
-                new ProviderDto()
-                {
-                        Id = guids[0],
-                        FullTitle = "Title1",
-                        ShortTitle = "ShortTitle1",
-                        Website = "Website1",
-                        Facebook = "Facebook1",
-                        Email = "user1@example.com",
-                        Instagram = "Instagram1",
-                        Description = "Description1",
-                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-                        EdrpouIpn = "12345678",
-                        PhoneNumber = "1111111111",
-                        Founder = "Founder",
-                        Ownership = OwnershipType.Private,
-                        Type = ProviderType.TOV,
-                        Status = false,
-                        UserId = "de909f35-5eb7-4b7a-bda8-40a5bfda96a6",
-                        LegalAddress = new AddressDto
-                        {
-                            Id = 1,
-                            Region = "Region1",
-                            District = "District1",
-                            City = "City1",
-                            Street = "Street1",
-                            BuildingNumber = "BuildingNumber1",
-                            Latitude = 0,
-                            Longitude = 0,
-                        },
-                        ActualAddress = new AddressDto
-                        {
-                            Id = 2,
-                            Region = "Region2",
-                            District = "District2",
-                            City = "City2",
-                            Street = "Street2",
-                            BuildingNumber = "BuildingNumber2",
-                            Latitude = 0,
-                            Longitude = 0,
-                        },
-                },
-                new ProviderDto()
-                {
-                        Id = guids[1],
-                        FullTitle = "Title2",
-                        ShortTitle = "ShortTitle2",
-                        Website = "Website2",
-                        Facebook = "Facebook2",
-                        Email = "user2@example.com",
-                        Instagram = "Instagram2",
-                        Description = "Description2",
-                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-                        EdrpouIpn = "12345645",
-                        PhoneNumber = "1111111111",
-                        Founder = "Founder",
-                        Ownership = OwnershipType.Private,
-                        Type = ProviderType.TOV,
-                        Status = false,
-                        UserId = "de909VV5-5eb7-4b7a-bda8-40a5bfda96a6",
-                        LegalAddress = new AddressDto
-                        {
-                            Id = 3,
-                            Region = "Region3",
-                            District = "District3",
-                            City = "City3",
-                            Street = "Street3",
-                            BuildingNumber = "BuildingNumber3",
-                            Latitude = 0,
-                            Longitude = 0,
-                        },
-                        ActualAddress = new AddressDto
-                        {
-                            Id = 4,
-                            Region = "Region4",
-                            District = "District4",
-                            City = "City4",
-                            Street = "Street4",
-                            BuildingNumber = "BuildingNumber4",
-                            Latitude = 0,
-                            Longitude = 0,
-                        },
-                },
-                new ProviderDto()
-                {
-                        Id = guids[2],
-                        FullTitle = "Title3",
-                        ShortTitle = "ShortTitle3",
-                        Website = "Website3",
-                        Facebook = "Facebook3",
-                        Email = "user3@example.com",
-                        Instagram = "Instagram3",
-                        Description = "Description3",
-                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-                        EdrpouIpn = "12345000",
-                        PhoneNumber = "1111111111",
-                        Founder = "Founder",
-                        Ownership = OwnershipType.Private,
-                        Type = ProviderType.TOV,
-                        Status = false,
-                        UserId = "de909f35-5eb7-4b7a-bda8-40a5bfda96a6",
-                        LegalAddress = new AddressDto
-                        {
-                            Id = 5,
-                            Region = "Region5",
-                            District = "District5",
-                            City = "City5",
-                            Street = "Street5",
-                            BuildingNumber = "BuildingNumber5",
-                            Latitude = 0,
-                            Longitude = 0,
-                        },
-                        ActualAddress = new AddressDto
-                        {
-                            Id = 6,
-                            Region = "Region6",
-                            District = "District6",
-                            City = "City6",
-                            Street = "Street6",
-                            BuildingNumber = "BuildingNumber6",
-                            Latitude = 0,
-                            Longitude = 0,
-                        },
-                },
-                new ProviderDto()
-                {
-                        Id = guids[3],
-                        FullTitle = "Title4",
-                        ShortTitle = "ShortTitle4",
-                        Website = "Website4",
-                        Facebook = "Facebook4",
-                        Email = "user4@example.com",
-                        Instagram = "Instagram4",
-                        Description = "Description4",
-                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-                        EdrpouIpn = "10045678",
-                        PhoneNumber = "1111111111",
-                        Founder = "Founder",
-                        Ownership = OwnershipType.Private,
-                        Type = ProviderType.TOV,
-                        Status = false,
-                        UserId = "de909f35-5eb7-4BBa-bda8-40a5bfda96a6",
-                        LegalAddress = new AddressDto
-                        {
-                            Id = 7,
-                            Region = "Region7",
-                            District = "District7",
-                            City = "City7",
-                            Street = "Street7",
-                            BuildingNumber = "BuildingNumber7",
-                            Latitude = 0,
-                            Longitude = 0,
-                        },
-                        ActualAddress = new AddressDto
-                        {
-                            Id = 8,
-                            Region = "Region8",
-                            District = "District8",
-                            City = "City8",
-                            Street = "Street8",
-                            BuildingNumber = "BuildingNumber8",
-                            Latitude = 0,
-                            Longitude = 0,
-                        },
-                },
-                new ProviderDto()
-                {
-                        Id = Guid.NewGuid(),
-                        FullTitle = "Title5",
-                        ShortTitle = "ShortTitle5",
-                        Website = "Website5",
-                        Facebook = "Facebook5",
-                        Email = "user5@example.com",
-                        Instagram = "Instagram5",
-                        Description = "Description5",
-                        DirectorDateOfBirth = new DateTime(1975, month: 10, 5),
-                        EdrpouIpn = "12374678",
-                        PhoneNumber = "1111111111",
-                        Founder = "Founder",
-                        Ownership = OwnershipType.Private,
-                        Type = ProviderType.TOV,
-                        Status = false,
-                        UserId = "de909f35-5eb7-4b7a-bda8-40a5bfdaEEa6",
-                        LegalAddress = new AddressDto
-                        {
-                            Id = 9,
-                            Region = "Region9",
-                            District = "District9",
-                            City = "City9",
-                            Street = "Street9",
-                            BuildingNumber = "BuildingNumber9",
-                            Latitude = 0,
-                            Longitude = 0,
-                        },
-                        ActualAddress = new AddressDto
-                        {
-                            Id = 10,
-                            Region = "Region10",
-                            District = "District10",
-                            City = "City10",
-                            Street = "Street10",
-                            BuildingNumber = "BuildingNumber10",
-                            Latitude = 0,
-                            Longitude = 0,
-                        },
-                },
-            };
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -74,7 +74,21 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             var result = await controller.GetProfile().ConfigureAwait(false);
 
             // Assert
-            Assert.That(result, Is.InstanceOf<NoContentResult>());
+            Assert.IsInstanceOf<NoContentResult>(result);
+        }
+
+        [Test]
+        public async Task GetProfile_WhenProviderForUserIdExists_ReturnsOkObjectResult()
+        {
+            // Arrange
+            var existingProvider = provider;
+            serviceProvider.Setup(x => x.GetByUserId(FakeUserId)).ReturnsAsync(existingProvider);
+
+            // Act
+            var result = await controller.GetProfile().ConfigureAwait(false);
+
+            // Assert
+            result.GetAssertedResponseOkAndValidValue<ProviderDto>();
         }
 
         [Test]
@@ -84,11 +98,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             serviceProvider.Setup(x => x.GetAll()).ReturnsAsync(providers);
 
             // Act
-            var result = await controller.Get().ConfigureAwait(false) as OkObjectResult;
+            var result = await controller.Get().ConfigureAwait(false);
 
             // Assert
-            Assert.NotNull(result);
-            Assert.AreEqual(OkStatusCode, result.StatusCode);
+            result.GetAssertedResponseOkAndValidValue<IEnumerable<ProviderDto>>();
         }
 
         [Test]
@@ -100,11 +113,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             serviceProvider.Setup(x => x.GetById(existingGuid)).ReturnsAsync(providers.SingleOrDefault(x => x.Id == existingGuid));
 
             // Act
-            var result = await controller.GetById(existingGuid).ConfigureAwait(false) as OkObjectResult;
+            var result = await controller.GetById(existingGuid).ConfigureAwait(false);
 
             // Assert
-            Assert.NotNull(result);
-            Assert.AreEqual(OkStatusCode, result.StatusCode);
+            result.GetAssertedResponseOkAndValidValue<ProviderDto>();
         }
 
         [Test]
@@ -118,22 +130,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             var result = await controller.GetById(invalidUserId).ConfigureAwait(false);
 
             // Assert
-            Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
-        }
-
-        [Test]
-        public async Task GetProviderById_WhenIdIsValid_ReturnsOkResult()
-        {
-            // Arrange
-            var existingProvider = providers.RandomItem();
-            serviceProvider.Setup(x => x.GetById(existingProvider.Id)).ReturnsAsync(existingProvider);
-
-            // Act
-            var result = await controller.GetById(existingProvider.Id).ConfigureAwait(false);
-
-            // Assert
-            Assert.That(result, Is.InstanceOf<OkObjectResult>());
-            Assert.IsInstanceOf<ProviderDto>((result as ObjectResult).Value);
+            result.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
         }
 
         [Test]
@@ -143,11 +140,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             serviceProvider.Setup(x => x.Create(provider)).ReturnsAsync(provider);
 
             // Act
-            var result = await controller.Create(provider).ConfigureAwait(false) as CreatedAtActionResult;
+            var result = await controller.Create(provider).ConfigureAwait(false);
 
             // Assert
-            Assert.NotNull(result);
-            Assert.AreEqual(CreateStatusCode, result.StatusCode);
+            result.GetAssertedResponseValidateValueNotEmpty<CreatedAtActionResult>();
         }
 
         [Test]
@@ -160,8 +156,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             var result = await controller.Create(provider).ConfigureAwait(false);
 
             // Assert
-            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
-            Assert.That((result as BadRequestObjectResult).StatusCode, Is.EqualTo(BadRequestStatusCode));
+            result.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
         }
 
         [Test]
@@ -180,27 +175,26 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             var result = await controller.Update(changedProvider).ConfigureAwait(false);
 
             // Assert
-            Assert.IsInstanceOf<OkObjectResult>(result);
-            Assert.AreEqual(OkStatusCode, (result as ObjectResult).StatusCode);
+            result.GetAssertedResponseOkAndValidValue<ProviderDto>();
         }
 
         [Test]
         public async Task UpdateProvider_WhenUserIsNotAdminAndUpdateNotOwnProvider_ReturnsBadRequestResult()
         {
             // Arrange
-            var changedProvider = new ProviderDto()
+            var providerEntityToUpdate = new ProviderDto()
             {
                 Id = Guid.NewGuid(),
                 FullTitle = "ChangedTitle",
             };
-            serviceProvider.Setup(x => x.Update(changedProvider, "CVc4a6876a-77fb-4ecnne-9c78-a0880286ae3c", "provider")).ReturnsAsync(changedProvider);
+            ProviderDto nullProvider = null;
+            serviceProvider.Setup(x => x.Update(providerEntityToUpdate, "CVc4a6876a-77fb-4ecnne-9c78-a0880286ae3c", "provider")).ReturnsAsync(nullProvider);
 
             // Act
-            var result = await controller.Update(changedProvider).ConfigureAwait(false);
+            var result = await controller.Update(providerEntityToUpdate).ConfigureAwait(false);
 
             // Assert
-            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
-            Assert.That((result as BadRequestObjectResult).StatusCode, Is.EqualTo(BadRequestStatusCode));
+            result.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
         }
 
         [Test]
@@ -213,8 +207,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             var result = await controller.Update(provider).ConfigureAwait(false);
 
             // Assert
-            Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
-            Assert.That((result as BadRequestObjectResult).StatusCode, Is.EqualTo(BadRequestStatusCode));
+            result.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
         }
 
         [Test]
@@ -226,11 +219,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             serviceProvider.Setup(x => x.Delete(guid));
 
             // Act
-            var result = await controller.Delete(guid) as NoContentResult;
+            var result = await controller.Delete(guid);
 
             // Assert
-            Assert.NotNull(result);
-            Assert.AreEqual(NoContentStatusCode, result.StatusCode);
+            Assert.IsInstanceOf<NoContentResult>(result);
         }
 
         //[Test]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -105,11 +105,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         }
 
         [Test]
-        [TestCase(FakeProviderIdTestCase)]
-        public async Task GetProvidersById_WhenIdIsValid_ReturnsOkObjectResult(string id)
+        public async Task GetProvidersById_WhenIdIsValid_ReturnsOkObjectResult()
         {
             // Arrange
-            var existingGuid = Guid.Parse(id);
+            var existingGuid = Guid.Parse(FakeProviderIdTestCase);
             serviceProvider.Setup(x => x.GetById(existingGuid)).ReturnsAsync(providers.SingleOrDefault(x => x.Id == existingGuid));
 
             // Act
@@ -211,11 +210,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         }
 
         [Test]
-        [TestCase(FakeProviderIdTestCase)]
-        public async Task DeleteProvider_WhenIdIsValid_ReturnsNoContentResult(string id)
+        public async Task DeleteProvider_WhenIdIsValid_ReturnsNoContentResult()
         {
             // Arrange
-            var guid = Guid.Parse(id);
+            var guid = Guid.Parse(FakeProviderIdTestCase);
             serviceProvider.Setup(x => x.Delete(guid));
 
             // Act
@@ -225,31 +223,19 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             Assert.IsInstanceOf<NoContentResult>(result);
         }
 
-        //[Test]
-        //[TestCase(0)]
-        //public void DeleteProvider_WhenIdIsInvalid_ReturnsBadRequestObjectResult(long id)
-        //{
-        //    // Arrange
-        //    serviceProvider.Setup(x => x.Delete(id));
+        [Test]
+        public async Task DeleteProvider_WhenIdIsInvalid_ReturnsBadRequestObjectResultAsync()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            serviceProvider.Setup(x => x.Delete(guid)).ThrowsAsync(new ArgumentNullException());
 
-        //    // Act and Assert
-        //    Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-        //        async () => await controller.Delete(id).ConfigureAwait(false));
-        //}
+            // Act
+            var result = await controller.Delete(guid).ConfigureAwait(false);
 
-        //[Test]
-        //[TestCase(10)]
-        //public async Task DeleteProvider_WhenIdIsInvalid_ReturnsNull(long id)
-        //{
-        //    // Arrange
-        //    serviceProvider.Setup(x => x.Delete(id));
-
-        //    // Act
-        //    var result = await controller.Delete(id) as OkObjectResult;
-
-        //    // Assert
-        //    Assert.That(result, Is.Null);
-        //}
+            // Assert
+            result.GetAssertedResponseValidateValueNotEmpty<BadRequestObjectResult>();
+        }
 
         private ProviderDto FakeProvider()
         {

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -177,7 +177,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                 FullTitle = "ChangedTitle",
                 UserId = FakeUserId,
             };
-            serviceProvider.Setup(x => x.Update(changedProvider, changedProvider.UserId, "provider")).ReturnsAsync(changedProvider);
+            serviceProvider.Setup(x => x.Update(changedProvider, changedProvider.UserId)).ReturnsAsync(changedProvider);
 
             // Act
             var result = await controller.Update(changedProvider).ConfigureAwait(false);
@@ -195,7 +195,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                 Id = Guid.NewGuid(),
                 FullTitle = "ChangedTitle",
             };
-            serviceProvider.Setup(x => x.Update(providerEntityToUpdate, "CVc4a6876a-77fb-4ecnne-9c78-a0880286ae3c", "provider")).ReturnsAsync(providerEntityToUpdate);
+            serviceProvider.Setup(x => x.Update(providerEntityToUpdate, "CVc4a6876a-77fb-4ecnne-9c78-a0880286ae3c")).ReturnsAsync(providerEntityToUpdate);
 
             // Act
             var result = await controller.Update(providerEntityToUpdate).ConfigureAwait(false);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -23,10 +23,6 @@ namespace OutOfSchool.WebApi.Tests.Controllers
     [TestFixture]
     public class ProviderControllerTests
     {
-        private const int OkStatusCode = 200;
-        private const int CreateStatusCode = 201;
-        private const int NoContentStatusCode = 204;
-        private const int BadRequestStatusCode = 400;
         private const string FakeProviderIdTestCase = "69c0a240-728f-452e-807f-70074e261a8f";
         private const string FakeUserId = "de909f35-5eb7-4b7a-bda8-40a5bfda67a6";
         private ProviderController controller;

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -186,8 +186,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                 Id = Guid.NewGuid(),
                 FullTitle = "ChangedTitle",
             };
-            ProviderDto nullProvider = null;
-            serviceProvider.Setup(x => x.Update(providerEntityToUpdate, "CVc4a6876a-77fb-4ecnne-9c78-a0880286ae3c", "provider")).ReturnsAsync(nullProvider);
+            serviceProvider.Setup(x => x.Update(providerEntityToUpdate, "CVc4a6876a-77fb-4ecnne-9c78-a0880286ae3c", "provider")).ReturnsAsync(providerEntityToUpdate);
 
             // Act
             var result = await controller.Update(providerEntityToUpdate).ConfigureAwait(false);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/PermissionsForRoleServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/PermissionsForRoleServiceTests.cs
@@ -58,10 +58,10 @@ namespace OutOfSchool.WebApi.Tests.Services
         }
 
         [Test]
-        [TestCase("Admin")]
-        public async Task GetByRole_WhenIdIsValid_ReturnsPermissionsForRole(string roleName)
+        public async Task GetByRole_WhenIdIsValid_ReturnsPermissionsForRole()
         {
             // Arrange
+            var roleName = Role.Admin.ToString();
             var expected = (await repository.GetByFilter(r => r.RoleName == roleName))
                 .FirstOrDefault().ToModel();
 
@@ -73,10 +73,10 @@ namespace OutOfSchool.WebApi.Tests.Services
         }
 
         [Test]
-        [TestCase("User")]
-        public void GetByRole_WhenNoSuchRole_ThrowsArgumentNullException(string roleName)
+        public void GetByRole_WhenNoSuchRole_ThrowsArgumentNullException()
         {
             // Arrange
+            var roleName = TestDataHelper.GetRandomRole();
             var taskToGetPermissionsForRole = service.GetByRole(roleName);
 
             // Act and Assert
@@ -96,7 +96,7 @@ namespace OutOfSchool.WebApi.Tests.Services
             var entityToBeCreated = new PermissionsForRole()
             {
                 Id = 4,
-                RoleName = "workshopAdmin",
+                RoleName = TestDataHelper.GetRandomRole(),
                 PackedPermissions = permissions.PackPermissionsIntoString(),
             };
 
@@ -152,7 +152,7 @@ namespace OutOfSchool.WebApi.Tests.Services
             // Arrange
             var changedEntity = new PermissionsForRoleDTO()
             {
-                RoleName = "TestName",
+                RoleName = TestDataHelper.GetRandomRole(),
             };
 
             // Act and Assert
@@ -184,19 +184,19 @@ namespace OutOfSchool.WebApi.Tests.Services
                     {
                     Id = 1,
                     RoleName = Role.Admin.ToString(),
-                    PackedPermissions = PermissionsSeeder.SeedPermissions(Role.Admin.ToString()),
+                    PackedPermissions = TestDataHelper.GetFakePackedPermissions(),
                     },
                     new PermissionsForRole()
                     {
                     Id = 2,
                     RoleName = Role.Provider.ToString(),
-                    PackedPermissions = PermissionsSeeder.SeedPermissions(Role.Provider.ToString()),
+                    PackedPermissions = TestDataHelper.GetFakePackedPermissions(),
                     },
                     new PermissionsForRole()
                     {
                     Id = 3,
                     RoleName = Role.Parent.ToString(),
-                    PackedPermissions = PermissionsSeeder.SeedPermissions(Role.Parent.ToString()),
+                    PackedPermissions = TestDataHelper.GetFakePackedPermissions(),
 
                     },
                 };

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
@@ -37,7 +37,7 @@ namespace OutOfSchool.WebApi.Tests.Services
         public void SetUp()
         {
             fakeProviders = ProvidersGenerator.Generate(10);
-            fakeUser = CreateFakeUser();
+            fakeUser = UserGenerator.Generate();
 
             providersRepositoryMock = CreateProvidersRepositoryMock(fakeProviders);
             usersRepositoryMock = CreateUsersRepositoryMock(fakeUser);
@@ -304,35 +304,5 @@ namespace OutOfSchool.WebApi.Tests.Services
 
             return providersRepository;
         }
-
-        private static User CreateFakeUser()
-        {
-            return new User()
-            {
-                Id = Guid.NewGuid().ToString(),
-                CreatingTime = default,
-                LastLogin = default,
-                MiddleName = "MiddleName",
-                FirstName = "FirstName",
-                LastName = "LastName",
-                UserName = "user@gmail.com",
-                NormalizedUserName = "USER@GMAIL.COM",
-                Email = "user@gmail.com",
-                NormalizedEmail = "USER@GMAIL.COM",
-                EmailConfirmed = false,
-                PasswordHash = "AQAAAAECcQAAAAEPXMPMbzuDZIKJUN4pBhRWMtf35Q3RN4QOll7UfnTdmfXHEcgswabznBezJmeTMvEw==",
-                SecurityStamp = "   CCCJIYDFRG236HXFKGYS7H6QT2DE2LFF",
-                ConcurrencyStamp = "cb54f60f-6282-4416-874c-d1edce844d07",
-                PhoneNumber = "0965679725",
-                Role = "provider",
-                PhoneNumberConfirmed = false,
-                TwoFactorEnabled = false,
-                LockoutEnabled = true,
-                AccessFailedCount = 0,
-                IsRegistered = false,
-            };
-        }
-
-
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
@@ -184,13 +184,17 @@ namespace OutOfSchool.WebApi.Tests.Services
         }
 
         [Test]
-        public void GetById_WhenIdIsInvalid_ThrowsArgumentOutOfRangeException()
+        public async Task GetById_WhenNoRecordsInDbWithSuchId_ReturnsNullAsync()
         {
+            // Arrange
             var noneExistingId = Guid.NewGuid();
 
+            // Act
+            var result = await providerService.GetById(noneExistingId).ConfigureAwait(false);
+
+
             // Act and Assert
-            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-                async () => await providerService.GetById(noneExistingId).ConfigureAwait(false));
+            Assert.That(result, Is.Null);
         }
 
         // TODO: providerService.Update method should be fixed before

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
@@ -22,7 +22,6 @@ namespace OutOfSchool.WebApi.Tests.Services
     [TestFixture]
     public class ProviderServiceTests
     {
-        private const string FakeUserId = "cqQQ876a-BBfb-4e9e-9c78-a0880286ae3c";
 
         private IProviderService providerService;
 
@@ -71,12 +70,12 @@ namespace OutOfSchool.WebApi.Tests.Services
         public async Task Create_ValidEntity_UpdatesOwnerIsRegisteredField()
         {
             // Arrange
-            var provider = ProvidersGenerator.Generate();
+            var provider = ProviderDtoGenerator.Generate();
             provider.UserId = fakeUser.Id;
             fakeUser.IsRegistered = false;
 
             // Act
-            await providerService.Create(provider.ToModel()).ConfigureAwait(false);
+            await providerService.Create(provider).ConfigureAwait(false);
 
             // Assert
             Assert.That(fakeUser.IsRegistered, Is.True);
@@ -93,12 +92,12 @@ namespace OutOfSchool.WebApi.Tests.Services
         public void Create_WhenUserIdExists_ThrowsInvalidOperationException()
         {
             // Arrange
-            var expected = ProvidersGenerator.Generate();
+            var expected = ProviderDtoGenerator.Generate();
             fakeProviders.RandomItem().UserId = expected.UserId;
 
             // Act and Assert
             Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await providerService.Create(expected.ToModel()).ConfigureAwait(false));
+                async () => await providerService.Create(expected).ConfigureAwait(false));
         }
 
         [Test]
@@ -129,7 +128,8 @@ namespace OutOfSchool.WebApi.Tests.Services
             // Act
             await providerService.Create(expected.ToModel());
 
-            // Act & Assert
+            // Assert
+            Assert.That(receivedProvider.ActualAddress, Is.Not.Null);
             AssertAdressesAreEqual(expected.ActualAddress, receivedProvider.ActualAddress);
         }
 
@@ -138,15 +138,10 @@ namespace OutOfSchool.WebApi.Tests.Services
         {
             // Arrange
             providersRepositoryMock.Setup(r => r.SameExists(It.IsAny<Provider>())).Returns(true);
-
             var randomProvider = fakeProviders.RandomItem();
-            var existingProvider = new ProviderDto
-            {
-                LegalAddress = new AddressDto(),
-            };
 
             // Act & Assert
-            Assert.ThrowsAsync<InvalidOperationException>(async () => await providerService.Create(existingProvider));
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await providerService.Create(randomProvider.ToModel()));
         }
 
         [Test]
@@ -197,7 +192,6 @@ namespace OutOfSchool.WebApi.Tests.Services
             Assert.That(result, Is.Null);
         }
 
-        // TODO: providerService.Update method should be fixed before
         [Test]
         public async Task Update_UserCanUpdateExistingEntityOfRelatedProvider_UpdatesExistedEntity()
         {
@@ -318,7 +312,7 @@ namespace OutOfSchool.WebApi.Tests.Services
         {
             return new User()
             {
-                Id = FakeUserId,
+                Id = Guid.NewGuid().ToString(),
                 CreatingTime = default,
                 LastLogin = default,
                 MiddleName = "MiddleName",

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
@@ -1,354 +1,369 @@
-﻿//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Linq.Expressions;
-//using System.Threading.Tasks;
-//using Microsoft.Extensions.Localization;
-//using Microsoft.Extensions.Logging;
-//using Moq;
-//using NUnit.Framework;
-//using OutOfSchool.Services.Enums;
-//using OutOfSchool.Services.Models;
-//using OutOfSchool.Services.Repository;
-//using OutOfSchool.Tests.Common;
-//using OutOfSchool.Tests.Common.TestDataGenerators;
-//using OutOfSchool.WebApi.Extensions;
-//using OutOfSchool.WebApi.Models;
-//using OutOfSchool.WebApi.Services;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using OutOfSchool.Services.Enums;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Services.Repository;
+using OutOfSchool.Tests.Common;
+using OutOfSchool.Tests.Common.TestDataGenerators;
+using OutOfSchool.WebApi.Extensions;
+using OutOfSchool.WebApi.Models;
+using OutOfSchool.WebApi.Services;
 
-//namespace OutOfSchool.WebApi.Tests.Services
-//{
-//    [TestFixture]
-//    public class ProviderServiceTests
-//    {
-//        private const string FakeUserId = "cqQQ876a-BBfb-4e9e-9c78-a0880286ae3c";
+namespace OutOfSchool.WebApi.Tests.Services
+{
+    [TestFixture]
+    public class ProviderServiceTests
+    {
+        private const string FakeUserId = "cqQQ876a-BBfb-4e9e-9c78-a0880286ae3c";
 
-//        private IProviderService providerService;
+        private IProviderService providerService;
 
-//        private Mock<IProviderRepository> providersRepositoryMock;
-//        private Mock<IEntityRepository<User>> usersRepositoryMock;
-//        private Mock<IRatingService> ratingService;
-//        private Mock<IStringLocalizer<SharedResource>> localizer;
-//        private Mock<ILogger<ProviderService>> logger;
+        private Mock<IProviderRepository> providersRepositoryMock;
+        private Mock<IEntityRepository<User>> usersRepositoryMock;
+        private Mock<IRatingService> ratingService;
+        private Mock<IMapper> mapper;
 
-//        private List<Provider> fakeProviders;
-//        private User fakeUser;
+        private List<Provider> fakeProviders;
+        private User fakeUser;
 
-//        [SetUp]
-//        public void SetUp()
-//        {
-//            fakeProviders = ProvidersGenerator.Generate(10);
-//            fakeUser = CreateFakeUser();
+        [SetUp]
+        public void SetUp()
+        {
+            fakeProviders = ProvidersGenerator.Generate(10);
+            fakeUser = CreateFakeUser();
 
-//            providersRepositoryMock = CreateProvidersRepositoryMock(fakeProviders);
-//            usersRepositoryMock = CreateUsersRepositoryMock(fakeUser);
+            providersRepositoryMock = CreateProvidersRepositoryMock(fakeProviders);
+            usersRepositoryMock = CreateUsersRepositoryMock(fakeUser);
+            var addressRepo = new Mock<IEntityRepository<Address>>();
+            ratingService = new Mock<IRatingService>();
+            var localizer = new Mock<IStringLocalizer<SharedResource>>();
+            var logger = new Mock<ILogger<ProviderService>>();
+            mapper = new Mock<IMapper>();
 
-//            ratingService = new Mock<IRatingService>();
-//            localizer = new Mock<IStringLocalizer<SharedResource>>();
-//            logger = new Mock<ILogger<ProviderService>>();
-//            providerService = new ProviderService(providersRepositoryMock.Object, usersRepositoryMock.Object, ratingService.Object, logger.Object, localizer.Object);
-//        }
 
-//        private static Mock<IEntityRepository<User>> CreateUsersRepositoryMock(User fakeUser)
-//        {
-//            var usersRepository = new Mock<IEntityRepository<User>>();
-//            usersRepository.Setup(r => r.GetAll()).Returns(Task.FromResult<IEnumerable<User>>(new List<User> { fakeUser }));
-//            usersRepository.Setup(r => r.GetByFilter(It.IsAny<Expression<Func<User, bool>>>(), string.Empty)).Returns(Task.FromResult<IEnumerable<User>>(new List<User> { fakeUser }));
+            providerService = new ProviderService(providersRepositoryMock.Object, usersRepositoryMock.Object, ratingService.Object, logger.Object, localizer.Object, mapper.Object, addressRepo.Object);
+        }
 
-//            return usersRepository;
-//        }
+        [Test]
+        public async Task Create_WhenEntityIsValid_ReturnsCreatedEntity()
+        {
+            // Arrange
+            var expected = ProvidersGenerator.Generate();
+            providersRepositoryMock.Setup(r => r.Create(It.IsAny<Provider>())).Returns(Task.FromResult(expected));
 
-//        private static Mock<IProviderRepository> CreateProvidersRepositoryMock(IEnumerable<Provider> providersCollection)
-//        {
-//            var providersRepository = new Mock<IProviderRepository>();
-//            var userExistsResult = false;
+            // Act
+            var result = await providerService.Create(expected.ToModel()).ConfigureAwait(false);
+            var actualProvider = result.ToDomain();
 
-//            bool UserExist(string userId)
-//            {
-//                userExistsResult = providersCollection.Any(p => p.UserId.Equals(userId));
-//                return userExistsResult;
-//            }
+            // Assert
+            AssertProvidersAreEqual(expected, actualProvider);
+        }
 
-//            providersRepository.Setup(r => r.GetAll()).Returns(Task.FromResult(providersCollection));
-//            providersRepository.Setup(r => r.ExistsUserId(It.IsAny<string>())).Callback<string>(user => UserExist(user)).Returns(() => userExistsResult);
+        [Test]
+        public async Task Create_ValidEntity_UpdatesOwnerIsRegisteredField()
+        {
+            // Arrange
+            var provider = ProvidersGenerator.Generate();
+            provider.UserId = fakeUser.Id;
+            fakeUser.IsRegistered = false;
 
-//            return providersRepository;
-//        }
+            // Act
+            await providerService.Create(provider.ToModel()).ConfigureAwait(false);
 
-//        [Test]
-//        public async Task Create_WhenEntityIsValid_ReturnsCreatedEntity()
-//        {
-//            // Arrange
-//            var expected = ProvidersGenerator.Generate();
-//            providersRepositoryMock.Setup(r => r.Create(It.IsAny<Provider>())).Returns(Task.FromResult(expected));
+            // Assert
+            Assert.That(fakeUser.IsRegistered, Is.True);
+        }
 
-//            // Act
-//            var result = await providerService.Create(expected.ToModel()).ConfigureAwait(false);
-//            var actualProvider = result.ToDomain();
+        [Test]
+        public void Create_WhenInputProviderIsNull_ThrowsArgumentNullException()
+        {
+            // Arrange & Act & Assert
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await providerService.Create(default).ConfigureAwait(false));
+        }
 
-//            // Assert
-//            AssertProvidersAreEqual(expected, actualProvider);
-//        }
+        [Test]
+        public void Create_WhenUserIdExists_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var expected = ProvidersGenerator.Generate();
+            fakeProviders.RandomItem().UserId = expected.UserId;
 
-//        [Test]
-//        public async Task Create_ValidEntity_UpdatesOwnerIsRegisteredField()
-//        {
-//            // Arrange
-//            var provider = ProvidersGenerator.Generate();
-//            provider.UserId = fakeUser.Id;
-//            fakeUser.IsRegistered = false;
+            // Act and Assert
+            Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await providerService.Create(expected.ToModel()).ConfigureAwait(false));
+        }
 
-//            // Act
-//            await providerService.Create(provider.ToModel()).ConfigureAwait(false);
+        [Test]
+        public async Task Create_WhenActualAddressIsTheSameAsLegal_ActualAddressIsCleared()
+        {
+            // Arrange
+            var expected = ProvidersGenerator.Generate();
+            expected.ActualAddress = expected.LegalAddress;
+            Provider receivedProvider = default;
+            providersRepositoryMock.Setup(x => x.Create(It.IsAny<Provider>())).Callback<Provider>(p => receivedProvider = p);
 
-//            // Assert
-//            Assert.That(fakeUser.IsRegistered, Is.True);
-//        }
+            // Act
+            await providerService.Create(expected.ToModel()).ConfigureAwait(false);
 
-//        [Test]
-//        public void Create_WhenInputProviderIsNull_ThrowsArgumentNullException()
-//        {
-//            // Arrange & Act & Assert
-//            Assert.ThrowsAsync<ArgumentNullException>(async () => await providerService.Create(default).ConfigureAwait(false));
-//        }
+            // Assert
+            Assert.That(receivedProvider.ActualAddress, Is.Null);
+        }
 
-//        [Test]
-//        public void Create_WhenUserIdExists_ThrowsInvalidOperationException()
-//        {
-//            // Arrange
-//            var expected = ProvidersGenerator.Generate();
-//            fakeProviders.RandomItem().UserId = expected.UserId;
+        [Test]
+        public async Task Create_WhenActualAddressDiffersFromTheLegal_ActualAddressIsSaved()
+        {
+            // Arrange
+            var expected = ProvidersGenerator.Generate();
 
-//            // Act and Assert
-//            Assert.ThrowsAsync<InvalidOperationException>(
-//                async () => await providerService.Create(expected.ToModel()).ConfigureAwait(false));
-//        }
+            Provider receivedProvider = default;
+            providersRepositoryMock.Setup(x => x.Create(It.IsAny<Provider>())).Callback<Provider>(p => receivedProvider = p);
 
-//        [Test]
-//        public async Task Create_WhenActualAddressIsTheSameAsLegal_ActualAddressIsCleared()
-//        {
-//            // Arrange
-//            var expected = ProvidersGenerator.Generate();
-//            expected.ActualAddress = expected.LegalAddress;
-//            Provider receivedProvider = default;
-//            providersRepositoryMock.Setup(x => x.Create(It.IsAny<Provider>())).Callback<Provider>(p => receivedProvider = p);
+            // Act
+            await providerService.Create(expected.ToModel());
 
-//            // Act
-//            await providerService.Create(expected.ToModel()).ConfigureAwait(false);
+            // Act & Assert
+            AssertAdressesAreEqual(expected.ActualAddress, receivedProvider.ActualAddress);
+        }
 
-//            // Assert
-//            Assert.That(receivedProvider.ActualAddress, Is.Null);
-//        }
+        [Test]
+        public void Create_WhenProviderWithTheSameEdrpouOrIpnExist_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            providersRepositoryMock.Setup(r => r.SameExists(It.IsAny<Provider>())).Returns(true);
 
-//        [Test]
-//        public async Task Create_WhenActualAddressIsDiffersFromTheLegal_ActualAddressIsSaved()
-//        {
-//            // Arrange
-//            var expected = ProvidersGenerator.Generate();
+            var randomProvider = fakeProviders.RandomItem();
+            var existingProvider = new ProviderDto
+            {
+                LegalAddress = new AddressDto(),
+            };
 
-//            Provider receivedProvider = default;
-//            providersRepositoryMock.Setup(x => x.Create(It.IsAny<Provider>())).Callback<Provider>(p => receivedProvider = p);
+            // Act & Assert
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await providerService.Create(existingProvider));
+        }
 
-//            // Act
-//            await providerService.Create(expected.ToModel());
+        [Test]
+        public async Task GetAll_WhenCalled_ReturnsAllEntities()
+        {
+            // Arrange
+            providersRepositoryMock.Setup(r => r.GetAll()).Returns(Task.FromResult(fakeProviders.AsEnumerable()));
+            ratingService
+                .Setup(r => r.GetAverageRatingForRange(It.IsAny<IEnumerable<Guid>>(), RatingType.Provider))
+                .Returns(RatingsGenerator.GetAverageRatingForRange(fakeProviders.Select(p => p.Id)));
 
-//            // Act & Assert
-//            AssertAdressesAreEqual(expected.ActualAddress, receivedProvider.ActualAddress);
-//        }
+            // Act
+            var providers = await providerService.GetAll().ConfigureAwait(false);
+            var actualProviders = providers.Select(p => p.ToDomain()).ToList();
+            var providersToCompare = fakeProviders.Zip(actualProviders, (f, a) => new { Fake = f, Actual = a }).ToList();
 
-//        [Test]
-//        public void Create_WhenProviderWithTheSameEdrpouOrIpnExist_ThrowsInvalidOperationException()
-//        {
-//            // Arrange
-//            providersRepositoryMock.Setup(r => r.SameExists(It.IsAny<Provider>())).Returns(true);
+            // Assert
+            providersToCompare.ForEach(pair => AssertProvidersAreEqual(pair.Fake, pair.Actual));
+        }
 
-//            var randomProvider = fakeProviders.RandomItem();
-//            var existingProvider = new ProviderDto
-//            {
-//                LegalAddress = new AddressDto(),
-//            };
+        [Test]
+        public async Task GetById_WhenIdIsValid_ReturnsEntity()
+        {
+            // Arrange
+            var existingProvider = fakeProviders.RandomItem();
+            var existingProviderId = existingProvider.Id;
+            providersRepositoryMock.Setup(r => r.GetById(It.IsAny<Guid>())).Returns(Task.FromResult(existingProvider));
 
-//            // Act & Assert
-//            Assert.ThrowsAsync<InvalidOperationException>(async () => await providerService.Create(existingProvider));
-//        }
+            // Act
+            var actualProviderDto = await providerService.GetById(existingProviderId).ConfigureAwait(false);
+            var actualProvider = actualProviderDto.ToDomain();
 
-//        [Test]
-//        public async Task GetAll_WhenCalled_ReturnsAllEntities()
-//        {
-//            // Arrange
-//            providersRepositoryMock.Setup(r => r.GetAll()).Returns(Task.FromResult(fakeProviders.AsEnumerable()));
-//            ratingService
-//                .Setup(r => r.GetAverageRatingForRange(It.IsAny<IEnumerable<long>>(), RatingType.Provider))
-//                .Returns(RatingsGenerator.GetAverageRatingForRange(fakeProviders.Select(p => p.Id)));
+            // Assert
+            AssertProvidersAreEqual(existingProvider, actualProvider);
+        }
 
-//            // Act
-//            var providers = await providerService.GetAll().ConfigureAwait(false);
-//            var actualProviders = providers.Select(p => p.ToDomain()).ToList();
-//            var providersToCompare = fakeProviders.Zip(actualProviders, (f, a) => new { Fake = f, Actual = a }).ToList();
+        [Test]
+        public void GetById_WhenIdIsInvalid_ThrowsArgumentOutOfRangeException()
+        {
+            var noneExistingId = Guid.NewGuid();
 
-//            // Assert
-//            providersToCompare.ForEach(pair => AssertProvidersAreEqual(pair.Fake, pair.Actual));
-//        }
+            // Act and Assert
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                async () => await providerService.GetById(noneExistingId).ConfigureAwait(false));
+        }
 
-//        [Test]
-//        public async Task GetById_WhenIdIsValid_ReturnsEntity()
-//        {
-//            // Arrange
-//            var existingProvider = fakeProviders.RandomItem();
-//            var existingProviderId = existingProvider.Id;
-//            providersRepositoryMock.Setup(r => r.GetById(It.IsAny<long>())).Returns(Task.FromResult(existingProvider));
+        // TODO: providerService.Update method should be fixed before
+        [Test]
+        public async Task Update_UserCanUpdateExistingEntityOfRelatedProvider_UpdatesExistedEntity()
+        {
+            // Arrange
+            var providerToUpdate = fakeProviders.RandomItem();
+            IEnumerable<Provider> filteredCollection = new List<Provider>() { providerToUpdate };
+            var updatedTitle = Guid.NewGuid().ToString();
+            var providerToUpdateDto = providerToUpdate.ToModel();
+            providerToUpdateDto.FullTitle = updatedTitle;
+            providersRepositoryMock.Setup(r => r.GetByFilter(It.IsAny<Expression<Func<Provider, bool>>>(), string.Empty)).Returns(Task.FromResult(filteredCollection));
+            mapper.Setup(mapper => mapper.Map(providerToUpdateDto, It.IsAny<Provider>())).Returns(providerToUpdateDto.ToDomain());
+            providersRepositoryMock.Setup(r => r.UnitOfWork.CompleteAsync()).ReturnsAsync(1);
+            mapper.Setup(mapper => mapper.Map<ProviderDto>(It.IsAny<Provider>())).Returns(providerToUpdateDto);
 
-//            // Act
-//            var actualProviderDto = await providerService.GetById(existingProviderId).ConfigureAwait(false);
-//            var actualProvider = actualProviderDto.ToDomain();
 
-//            // Assert
-//            AssertProvidersAreEqual(existingProvider, actualProvider);
-//        }
+            // Act
+            var result = await providerService.Update(providerToUpdateDto, providerToUpdateDto.UserId).ConfigureAwait(false);
 
-//        [Test]
-//        public void GetById_WhenIdIsInvalid_ThrowsArgumentOutOfRangeException()
-//        {
-//            var noneExistingId = fakeProviders.Select(p => p.Id).Max() + 1;
+            // Assert
+            Assert.AreEqual(result.FullTitle, updatedTitle);
+        }
 
-//            // Act and Assert
-//            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-//                async () => await providerService.GetById(noneExistingId).ConfigureAwait(false));
-//        }
+        [Test]
+        public async Task Update_WhenUsersIdAndProvidersIdDoesntMatch_ReturnsNull()
+        {
+            // Arrange
+            var changedEntity = new ProviderDto();
+            var noneExistingUserId = Guid.NewGuid().ToString();
 
-//        // TODO: providerService.Update method should be fixed before
+            // Act
+            var result = await providerService.Update(changedEntity, noneExistingUserId).ConfigureAwait(false);
 
-//        //[TestCase("provider")]
-//        //[TestCase("admin")]
-//        //public async Task Update_ValidRoleCanUpdateExistingEntity_UpdatesExistedEntity(string validRole)
-//        //{
-//        //    // Arrange
-//        //    var providerToUpdateDto = fakeProviders.RandomItem().ToModel();
-//        //    var updatedTitle = Guid.NewGuid().ToString();
-//        //    var providerToUpdate = providerToUpdateDto.ToDomain();
-//        //    providerToUpdateDto.FullTitle = updatedTitle;
+            // Assert
+            Assert.Null(result);
+        }
 
-//        //    providersRepositoryMock
-//        //        .Setup(r => r.GetByFilterNoTracking(It.IsAny<Expression<Func<Provider, bool>>>(), string.Empty))
-//        //        .Returns(new[] { providerToUpdate }.AsQueryable());
+        [Test]
+        public async Task Delete_WhenIdIsValid_CalledProvidersRepositoryDeleteMethod()
+        {
+            // Arrange
+            var providerToDelete = fakeProviders.RandomItem();
+            var deleteMethodArguments = new List<Provider>();
+            providersRepositoryMock.Setup(r => r.GetById(It.IsAny<Guid>())).Returns(Task.FromResult(providerToDelete));
+            providersRepositoryMock.Setup(r => r.Delete(Capture.In(deleteMethodArguments)));
 
-//        //    // Act
-//        //    var result = await providerService.Update(providerToUpdateDto, providerToUpdateDto.UserId, validRole).ConfigureAwait(false);
+            // Act
+            await providerService.Delete(providerToDelete.Id).ConfigureAwait(false);
 
-//        //    // Assert
-//        //    Assert.AreEqual(providerToUpdateDto.FullTitle, result.FullTitle);
-//        //}
+            // Assert
+            AssertProvidersAreEqual(deleteMethodArguments.Single(), providerToDelete);
+        }
 
-//        [TestCase("provider")]
-//        [TestCase("admin")]
-//        public async Task Update_WhenValidRoleNonExistingUserId_ReturnsNull(string validRole)
-//        {
-//            // Arrange
-//            var changedEntity = new ProviderDto();
-//            var noneExistingUserId = Guid.NewGuid().ToString();
+        // TODO: providerService.Delete method should be fixed before
 
-//            // Act
-//            var result = await providerService.Update(changedEntity, noneExistingUserId, validRole).ConfigureAwait(false);
+        [Test]
+        public void Delete_WhenIdIsInvalid_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var fakeProviderInvalidId = Guid.NewGuid();
+            var provider = new Provider()
+            {
+                Id = fakeProviderInvalidId,
+            };
+            providersRepositoryMock.Setup(p => p.Delete(provider)).Returns(Task.CompletedTask);
+            providersRepositoryMock.Setup(p => p.GetById(provider.Id)).ThrowsAsync(new ArgumentNullException());
 
-//            // Assert
-//            Assert.Null(result);
-//        }
 
-//        [Test]
-//        public async Task Delete_WhenIdIsValid_CalledProvidersRepositoryDeleteMethod()
-//        {
-//            // Arrange
-//            var providerToDelete = fakeProviders.RandomItem();
-//            var deleteMethodArguments = new List<Provider>();
-//            providersRepositoryMock.Setup(r => r.GetById(It.IsAny<long>())).Returns(Task.FromResult(providerToDelete));
-//            providersRepositoryMock.Setup(r => r.Delete(Capture.In(deleteMethodArguments)));
+            // Act and Assert
+            Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await providerService.Delete(fakeProviderInvalidId).ConfigureAwait(false));
+        }
 
-//            // Act
-//            await providerService.Delete(providerToDelete.Id).ConfigureAwait(false);
+        // TODO: move random test data creation to Tests.Common
 
-//            // Assert
-//            AssertProvidersAreEqual(deleteMethodArguments.Single(), providerToDelete);
-//        }
+        private static void AssertProvidersAreEqual(Provider expected, Provider result)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expected.FullTitle, result.FullTitle);
+                Assert.AreEqual(expected.ShortTitle, result.ShortTitle);
+                Assert.AreEqual(expected.Website, result.Website);
+                Assert.AreEqual(expected.Facebook, result.Facebook);
+                Assert.AreEqual(expected.Email, result.Email);
+                Assert.AreEqual(expected.Instagram, result.Instagram);
+                Assert.AreEqual(expected.Description, result.Description);
+                Assert.AreEqual(expected.DirectorDateOfBirth, result.DirectorDateOfBirth);
+                Assert.AreEqual(expected.EdrpouIpn, result.EdrpouIpn);
+                Assert.AreEqual(expected.PhoneNumber, result.PhoneNumber);
+                Assert.AreEqual(expected.Founder, result.Founder);
+                Assert.AreEqual(expected.Ownership, result.Ownership);
+                Assert.AreEqual(expected.Type, result.Type);
+                Assert.AreEqual(expected.Status, result.Status);
+                Assert.AreEqual(expected.UserId, result.UserId);
+                Assert.AreEqual(expected.LegalAddress.City, result.LegalAddress.City);
+                Assert.AreEqual(expected.LegalAddress.BuildingNumber, result.LegalAddress.BuildingNumber);
+                Assert.AreEqual(expected.LegalAddress.Street, result.LegalAddress.Street);
+                Assert.AreEqual(expected.ActualAddress.City, result.ActualAddress.City);
+                Assert.AreEqual(expected.ActualAddress.BuildingNumber, result.ActualAddress.BuildingNumber);
+                Assert.AreEqual(expected.ActualAddress.Street, result.ActualAddress.Street);
+            });
+        }
 
-//        // TODO: providerService.Delete method should be fixed before
+        private static void AssertAdressesAreEqual(Address expected, Address actual)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expected.Region, actual.Region);
+                Assert.AreEqual(expected.District, actual.District);
+                Assert.AreEqual(expected.City, actual.City);
+                Assert.AreEqual(expected.Street, actual.Street);
+                Assert.AreEqual(expected.BuildingNumber, actual.BuildingNumber);
+                Assert.AreEqual(expected.Latitude, actual.Latitude);
+                Assert.AreEqual(expected.Longitude, actual.Longitude);
+            });
+        }
 
-//        //[TestCase(10)]
-//        //public void Delete_WhenIdIsInvalid_ThrowsArgumentNullException(long id)
-//        //{
-//        //    // Act and Assert
-//        //    Assert.ThrowsAsync<ArgumentNullException>(
-//        //        async () => await providerService.Delete(id).ConfigureAwait(false));
-//        //}
+        private static User CreateFakeUser()
+        {
+            return new User()
+            {
+                Id = FakeUserId,
+                CreatingTime = default,
+                LastLogin = default,
+                MiddleName = "MiddleName",
+                FirstName = "FirstName",
+                LastName = "LastName",
+                UserName = "user@gmail.com",
+                NormalizedUserName = "USER@GMAIL.COM",
+                Email = "user@gmail.com",
+                NormalizedEmail = "USER@GMAIL.COM",
+                EmailConfirmed = false,
+                PasswordHash = "AQAAAAECcQAAAAEPXMPMbzuDZIKJUN4pBhRWMtf35Q3RN4QOll7UfnTdmfXHEcgswabznBezJmeTMvEw==",
+                SecurityStamp = "   CCCJIYDFRG236HXFKGYS7H6QT2DE2LFF",
+                ConcurrencyStamp = "cb54f60f-6282-4416-874c-d1edce844d07",
+                PhoneNumber = "0965679725",
+                Role = "provider",
+                PhoneNumberConfirmed = false,
+                TwoFactorEnabled = false,
+                LockoutEnabled = true,
+                AccessFailedCount = 0,
+                IsRegistered = false,
+            };
+        }
 
-//        // TODO: move random test data creation to Tests.Common
-//        private static User CreateFakeUser()
-//        {
-//            return new User()
-//            {
-//                Id = FakeUserId,
-//                CreatingTime = default,
-//                LastLogin = default,
-//                MiddleName = "MiddleName",
-//                FirstName = "FirstName",
-//                LastName = "LastName",
-//                UserName = "user@gmail.com",
-//                NormalizedUserName = "USER@GMAIL.COM",
-//                Email = "user@gmail.com",
-//                NormalizedEmail = "USER@GMAIL.COM",
-//                EmailConfirmed = false,
-//                PasswordHash = "AQAAAAECcQAAAAEPXMPMbzuDZIKJUN4pBhRWMtf35Q3RN4QOll7UfnTdmfXHEcgswabznBezJmeTMvEw==",
-//                SecurityStamp = "   CCCJIYDFRG236HXFKGYS7H6QT2DE2LFF",
-//                ConcurrencyStamp = "cb54f60f-6282-4416-874c-d1edce844d07",
-//                PhoneNumber = "0965679725",
-//                Role = "provider",
-//                PhoneNumberConfirmed = false,
-//                TwoFactorEnabled = false,
-//                LockoutEnabled = true,
-//                AccessFailedCount = 0,
-//                IsRegistered = false,
-//            };
-//        }
+        private static Mock<IEntityRepository<User>> CreateUsersRepositoryMock(User fakeUser)
+        {
+            var usersRepository = new Mock<IEntityRepository<User>>();
+            usersRepository.Setup(r => r.GetAll()).Returns(Task.FromResult<IEnumerable<User>>(new List<User> { fakeUser }));
+            usersRepository.Setup(r => r.GetByFilter(It.IsAny<Expression<Func<User, bool>>>(), string.Empty)).Returns(Task.FromResult<IEnumerable<User>>(new List<User> { fakeUser }));
 
-//        private static void AssertProvidersAreEqual(Provider expected, Provider result)
-//        {
-//            Assert.Multiple(() =>
-//            {
-//                Assert.AreEqual(expected.FullTitle, result.FullTitle);
-//                Assert.AreEqual(expected.ShortTitle, result.ShortTitle);
-//                Assert.AreEqual(expected.Website, result.Website);
-//                Assert.AreEqual(expected.Facebook, result.Facebook);
-//                Assert.AreEqual(expected.Email, result.Email);
-//                Assert.AreEqual(expected.Instagram, result.Instagram);
-//                Assert.AreEqual(expected.Description, result.Description);
-//                Assert.AreEqual(expected.DirectorDateOfBirth, result.DirectorDateOfBirth);
-//                Assert.AreEqual(expected.EdrpouIpn, result.EdrpouIpn);
-//                Assert.AreEqual(expected.PhoneNumber, result.PhoneNumber);
-//                Assert.AreEqual(expected.Founder, result.Founder);
-//                Assert.AreEqual(expected.Ownership, result.Ownership);
-//                Assert.AreEqual(expected.Type, result.Type);
-//                Assert.AreEqual(expected.Status, result.Status);
-//                Assert.AreEqual(expected.UserId, result.UserId);
-//                Assert.AreEqual(expected.LegalAddress.City, result.LegalAddress.City);
-//                Assert.AreEqual(expected.LegalAddress.BuildingNumber, result.LegalAddress.BuildingNumber);
-//                Assert.AreEqual(expected.LegalAddress.Street, result.LegalAddress.Street);
-//                Assert.AreEqual(expected.ActualAddress.City, result.ActualAddress.City);
-//                Assert.AreEqual(expected.ActualAddress.BuildingNumber, result.ActualAddress.BuildingNumber);
-//                Assert.AreEqual(expected.ActualAddress.Street, result.ActualAddress.Street);
-//            });
-//        }
+            return usersRepository;
+        }
 
-//        private static void AssertAdressesAreEqual(Address expected, Address actual)
-//        {
-//            Assert.Multiple(() =>
-//            {
-//                Assert.AreEqual(expected.Region, actual.Region);
-//                Assert.AreEqual(expected.District, actual.District);
-//                Assert.AreEqual(expected.City, actual.City);
-//                Assert.AreEqual(expected.Street, actual.Street);
-//                Assert.AreEqual(expected.BuildingNumber, actual.BuildingNumber);
-//                Assert.AreEqual(expected.Latitude, actual.Latitude);
-//                Assert.AreEqual(expected.Longitude, actual.Longitude);
-//            });
-//        }
-//    }
-//}
+        private static Mock<IProviderRepository> CreateProvidersRepositoryMock(IEnumerable<Provider> providersCollection)
+        {
+            var providersRepository = new Mock<IProviderRepository>();
+            var userExistsResult = false;
+
+            bool UserExist(string userId)
+            {
+                userExistsResult = providersCollection.Any(p => p.UserId.Equals(userId));
+                return userExistsResult;
+            }
+
+            providersRepository.Setup(r => r.GetAll()).Returns(Task.FromResult(providersCollection));
+            providersRepository.Setup(r => r.ExistsUserId(It.IsAny<string>())).Callback<string>(user => UserExist(user)).Returns(() => userExistsResult);
+
+            return providersRepository;
+        }
+
+
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
@@ -55,15 +55,16 @@ namespace OutOfSchool.WebApi.Tests.Services
         public async Task Create_WhenEntityIsValid_ReturnsCreatedEntity()
         {
             // Arrange
-            var entityToBeCreated = ProviderDtoGenerator.Generate(); // argument for service's Create method
-            providersRepositoryMock.Setup(r => r.Create(It.IsAny<Provider>())).ReturnsAsync(entityToBeCreated.ToDomain());
+            var entityToBeCreated = ProvidersGenerator.Generate(); // argument for service's Create method
+            var expected = entityToBeCreated.ToModel();
+            providersRepositoryMock.Setup(r => r.Create(It.IsAny<Provider>())).ReturnsAsync(entityToBeCreated);
 
             // Act
-            var result = await providerService.Create(entityToBeCreated).ConfigureAwait(false);
+            var result = await providerService.Create(entityToBeCreated.ToModel()).ConfigureAwait(false);
             var actualProvider = result;
 
             // Assert
-            TestHelper.AssertDtosAreEqual(entityToBeCreated, actualProvider);
+            TestHelper.AssertDtosAreEqual(expected, actualProvider);
         }
 
         [Test]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
@@ -1,187 +1,195 @@
-﻿//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Text;
-//using System.Threading.Tasks;
-//using Microsoft.EntityFrameworkCore;
-//using Microsoft.Extensions.Localization;
-//using Microsoft.Extensions.Logging;
-//using Moq;
-//using NUnit.Framework;
-//using OutOfSchool.Services;
-//using OutOfSchool.Services.Models;
-//using OutOfSchool.Services.Repository;
-//using OutOfSchool.WebApi.Models;
-//using OutOfSchool.WebApi.Services;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using OutOfSchool.Services;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Services.Repository;
+using OutOfSchool.Tests.Common;
+using OutOfSchool.WebApi.Extensions;
+using OutOfSchool.WebApi.Models;
+using OutOfSchool.WebApi.Services;
 
-//namespace OutOfSchool.WebApi.Tests.Services
-//{
-//    [TestFixture]
-//    public class StatusServiceTests
-//    {
-//        private IStatusService service;
-//        private OutOfSchoolDbContext context;
-//        private IEntityRepository<InstitutionStatus> repository;
-//        private Mock<IStringLocalizer<SharedResource>> localizer;
-//        private Mock<ILogger<StatusService>> logger;
-//        private DbContextOptions<OutOfSchoolDbContext> options;
+namespace OutOfSchool.WebApi.Tests.Services
+{
+    [TestFixture]
+    public class StatusServiceTests
+    {
+        private IStatusService service;
+        private OutOfSchoolDbContext context;
+        private IEntityRepository<InstitutionStatus> repository;
+        private DbContextOptions<OutOfSchoolDbContext> options;
 
-//        [SetUp]
-//        public void SetUp()
-//        {
-//            var builder =
-//                new DbContextOptionsBuilder<OutOfSchoolDbContext>().UseInMemoryDatabase(
-//                    databaseName: "OutOfSchoolTestDB");
+        [SetUp]
+        public void SetUp()
+        {
+            var builder =
+                new DbContextOptionsBuilder<OutOfSchoolDbContext>().UseInMemoryDatabase(
+                    databaseName: "OutOfSchoolTestDB");
 
-//            options = builder.Options;
-//            context = new OutOfSchoolDbContext(options);
-//            localizer = new Mock<IStringLocalizer<SharedResource>>();
-//            repository = new EntityRepository<InstitutionStatus>(context);
-//            logger = new Mock<ILogger<StatusService>>();
-//            service = new StatusService(repository, logger.Object, localizer.Object);
+            options = builder.Options;
+            context = new OutOfSchoolDbContext(options);
+            var localizer = new Mock<IStringLocalizer<SharedResource>>();
+            repository = new EntityRepository<InstitutionStatus>(context);
+            var logger = new Mock<ILogger<StatusService>>();
+            service = new StatusService(repository, logger.Object, localizer.Object);
 
-//            SeedDatabase();
-//        }
+            SeedDatabase();
+        }
 
-//        [Test]
-//        public async Task GetAll_WhenCalled_ReturnsAllInstitutionStatuses()
-//        {
-//            // Arrange
-//            var expected = await repository.GetAll();
+        [Test]
+        public async Task GetAll_WhenCalled_ReturnsAllInstitutionStatuses()
+        {
+            // Arrange
+            var expected = (await repository.GetAll()).Select(s => s.ToModel());
 
-//            // Act
-//            var result = await service.GetAll().ConfigureAwait(false);
+            // Act
+            var result = await service.GetAll().ConfigureAwait(false);
 
-//            // Assert
-//            Assert.AreEqual(result.ToList().Count(), expected.Count());
-//        }
+            // Assert
+            TestHelper.AssertTwoCollectionsEqualByValues(expected, result);
+        }
 
 
-//        [Test]
-//        [TestCase(2)]
-//        public async Task GetById_WhenIdIsValid_ReturnsInstitutionStatus(long id)
-//        {
-//            // Arrange
-//            var expected = await repository.GetById(id);
+        [Test]
+        [TestCase(2)]
+        public async Task GetById_WhenIdIsValid_ReturnsInstitutionStatus(long id)
+        {
+            // Arrange
+            var expected = (await repository.GetById(id)).ToModel();
 
-//            // Act
-//            var result = await service.GetById(id).ConfigureAwait(false);
+            // Act
+            var result = await service.GetById(id).ConfigureAwait(false);
 
-//            // Assert
-//            Assert.AreEqual(expected.Id, result.Id);
-//        }
+            // Assert
+            TestHelper.AssertDtosAreEqual(expected, result);
+        }
 
-//        [Test]
-//        [TestCase(13)]
-//        public void GetById_WhenIdIsInvalid_ThrowsArgumentOutOfRangeException(long id)
-//        {
-//            // Act and Assert
-//            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-//                async () => await service.GetById(id).ConfigureAwait(false));
-//        }
+        [Test]
+        [TestCase(13)]
+        public void GetById_WhenIdIsInvalid_ThrowsArgumentOutOfRangeException(long id)
+        {
+            // Act and Assert
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                async () => await service.GetById(id).ConfigureAwait(false));
+        }
 
-//        [Test]
-//        public async Task Create_WhenEntityIsValid_ReturnsCreatedEntity()
-//        {
-//            // Arrange
-//            var expected = new InstitutionStatusDTO() { Name = "TestName", };
+        [Test]
+        public async Task Create_WhenEntityIsValid_ReturnsCreatedEntity()
+        {
+            // Arrange
+            var entityToCreate = new InstitutionStatus() { Name = "TestName" };
+            var expected = entityToCreate.ToModel();
+            expected.Id = await repository.Count() + 1;
 
-//            // Act
-//            var result = await service.Create(expected).ConfigureAwait(false);
+            // Act
+            var result = await service.Create(entityToCreate.ToModel()).ConfigureAwait(false);
 
-//            // Assert
-//            Assert.AreEqual(expected.Name, result.Name);
-//        }
+            // Assert
+            TestHelper.AssertDtosAreEqual(expected, result);
+        }
 
-//        [Test]
-//        public async Task Update_WhenEntityIsValid_UpdatesExistedEntity()
-//        {
-//            // Arrange
-//            var changedEntity = new InstitutionStatusDTO()
-//            {
-//                Id = 1,
-//                Name = "TestName",
-//            };
+        [Test]
+        public async Task Update_WhenEntityIsValid_UpdatesExistedEntity()
+        {
+            // Arrange
+            var entityToUpdate = new InstitutionStatus()
+            {
+                Id = 1,
+                Name = "TestName",
+            };
 
-//            // Act
-//            var result = await service.Update(changedEntity).ConfigureAwait(false);
+            var expected = entityToUpdate.ToModel();
 
-//            // Assert
-//            Assert.That(changedEntity.Name, Is.EqualTo(result.Name));
-//        }
+            // Act
+            var result = await service.Update(entityToUpdate.ToModel()).ConfigureAwait(false);
 
-//        [Test]
-//        public void Update_WhenEntityIsInvalid_ThrowsDbUpdateConcurrencyException()
-//        {
-//            // Arrange
-//            var changedEntity = new InstitutionStatusDTO()
-//            {
-//                Name = "TestName",
-//            };
+            // Assert
+            TestHelper.AssertDtosAreEqual(expected, result);
+        }
 
-//            // Act and Assert
-//            Assert.ThrowsAsync<DbUpdateConcurrencyException>(
-//                async () => await service.Update(changedEntity).ConfigureAwait(false));
-//        }
+        [Test]
+        public void Update_WhenEntityIsInvalid_ThrowsDbUpdateConcurrencyException()
+        {
+            // Arrange
+            var changedEntity = new InstitutionStatusDTO()
+            {
+                Name = "TestName",
+            };
 
-//        [Test]
-//        [TestCase(1)]
-//        public async Task Delete_WhenIdIsValid_DeletesEntity(long id)
-//        {
-//            // Arrange
-//            var expected = await context.InstitutionStatuses.CountAsync();
+            // Act and Assert
+            Assert.ThrowsAsync<DbUpdateConcurrencyException>(
+                async () => await service.Update(changedEntity).ConfigureAwait(false));
+        }
 
-//            // Act
-//            await service.Delete(id).ConfigureAwait(false);
+        [Test]
+        [TestCase(1)]
+        public async Task Delete_WhenIdIsValid_DeletesEntity(long id)
+        {
+            // Arrange
+            var expected = await context.InstitutionStatuses.CountAsync();
 
-//            var result = (await service.GetAll().ConfigureAwait(false)).Count();
+            // Act
+            await service.Delete(id).ConfigureAwait(false);
 
-//            // Assert
-//            Assert.AreEqual(expected - 1, result);
-//        }
+            // Assert
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                async () => await service.GetById(id).ConfigureAwait(false));
+        }
 
-//        [Test]
-//        [TestCase(13)]
-//        public void Delete_WhenIdIsInvalid_ThrowsArgumentOutOfRangeException(long id)
-//        {
-//            // Act and Assert
-//            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-//                async () => await service.Delete(id).ConfigureAwait(false));
-//        }
+        [Test]
+        [TestCase(13)]
+        public void Delete_WhenIdIsInvalid_ThrowsArgumentOutOfRangeException(long id)
+        {
+            // Act and Assert
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                async () => await service.Delete(id).ConfigureAwait(false));
+        }
 
-//        /// <summary>
-//        /// method to seed repository with entities to test.
-//        /// </summary>
+        /// <summary>
+        /// method to seed repository with entities to test.
+        /// </summary>
 
-//        private void SeedDatabase()
-//        {
-//            using var context = new OutOfSchoolDbContext(options);
-//            {
-//                context.Database.EnsureDeleted();
-//                context.Database.EnsureCreated();
+        private void SeedDatabase()
+        {
+            using var context = new OutOfSchoolDbContext(options);
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
 
-//                var institutionStatuses = new List<InstitutionStatus>()
-//                {
-//                    new InstitutionStatus()
-//                    {
-//                    Id = 1,
-//                    Name = "NoName",
-//                    },
-//                    new InstitutionStatus()
-//                    {
-//                    Id = 2,
-//                    Name = "HaveName",
-//                    },
-//                    new InstitutionStatus()
-//                    {
-//                    Id = 3,
-//                    Name = "MissName",
-//                    },
-//                };
+                var institutionStatuses = SeedFakeStatuses();
+                context.InstitutionStatuses.AddRangeAsync(institutionStatuses);
 
-//                context.InstitutionStatuses.AddRangeAsync(institutionStatuses);
-//                context.SaveChangesAsync();
-//            }
-//        }
-//    }
-//}
+                context.SaveChangesAsync();
+            }
+        }
+
+        private IEnumerable<InstitutionStatus> SeedFakeStatuses()
+        {
+            return new List<InstitutionStatus>()
+            {
+                new InstitutionStatus()
+                {
+                    Id = 1,
+                    Name = "NoName",
+                },
+                new InstitutionStatus()
+                {
+                    Id = 2,
+                    Name = "HaveName",
+                },
+                new InstitutionStatus()
+                {
+                    Id = 3,
+                    Name = "MissName",
+                },
+            };
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
@@ -84,7 +84,7 @@ namespace OutOfSchool.WebApi.Tests.Services
         public async Task Create_WhenEntityIsValid_ReturnsCreatedEntity()
         {
             // Arrange
-            var entityToCreate = new InstitutionStatus() { Name = "TestName" };
+            var entityToCreate = new InstitutionStatus() { Name = TestDataHelper.GetRandomWords() };
             var expected = entityToCreate.ToModel();
             expected.Id = await repository.Count() + 1;
 
@@ -102,7 +102,7 @@ namespace OutOfSchool.WebApi.Tests.Services
             var entityToUpdate = new InstitutionStatus()
             {
                 Id = 1,
-                Name = "TestName",
+                Name = TestDataHelper.GetRandomWords(),
             };
 
             var expected = entityToUpdate.ToModel();
@@ -120,7 +120,7 @@ namespace OutOfSchool.WebApi.Tests.Services
             // Arrange
             var changedEntity = new InstitutionStatusDTO()
             {
-                Name = "TestName",
+                Name = TestDataHelper.GetRandomWords(),
             };
 
             // Act and Assert
@@ -177,17 +177,17 @@ namespace OutOfSchool.WebApi.Tests.Services
                 new InstitutionStatus()
                 {
                     Id = 1,
-                    Name = "NoName",
+                    Name = TestDataHelper.GetRandomWords(),
                 },
                 new InstitutionStatus()
                 {
                     Id = 2,
-                    Name = "HaveName",
+                    Name = TestDataHelper.GetRandomWords(),
                 },
                 new InstitutionStatus()
                 {
                     Id = 3,
-                    Name = "MissName",
+                    Name = TestDataHelper.GetRandomWords(),
                 },
             };
         }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
@@ -123,10 +123,7 @@ namespace OutOfSchool.WebApi.Tests.Services
         public void Update_WhenEntityIsInvalid_ThrowsDbUpdateConcurrencyException()
         {
             // Arrange
-            var changedEntity = new InstitutionStatusDTO()
-            {
-                Name = TestDataHelper.GetRandomWords(),
-            };
+            var changedEntity = InstitutionStatusGenerator.Generate().ToModel();
 
             // Act and Assert
             Assert.ThrowsAsync<DbUpdateConcurrencyException>(
@@ -170,7 +167,7 @@ namespace OutOfSchool.WebApi.Tests.Services
                 context.Database.EnsureDeleted();
                 context.Database.EnsureCreated();
 
-                var institutionStatuses = InstitutionStatusGenerator.GenerateWithoutIds(5);
+                var institutionStatuses = InstitutionStatusGenerator.Generate(5);
                 context.InstitutionStatuses.AddRangeAsync(institutionStatuses);
 
                 context.SaveChangesAsync();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
@@ -60,7 +59,8 @@ namespace OutOfSchool.WebApi.Tests.Services
         public async Task GetById_WhenIdIsValid_ReturnsInstitutionStatus()
         {
             // Arrange
-            var existingId = (await repository.GetAll()).First().Id;
+            var collection = await repository.GetAll() as ICollection<InstitutionStatus>;
+            var existingId = TestDataHelper.RandomItem(collection).Id;
             var expected = (await repository.GetById(existingId)).ToModel();
 
             // Act
@@ -88,9 +88,10 @@ namespace OutOfSchool.WebApi.Tests.Services
         public async Task Create_WhenEntityIsValid_ReturnsCreatedEntity()
         {
             // Arrange
+            var lastIndex = (await repository.GetAll()).Last().Id;
             var entityToCreate = new InstitutionStatus() { Name = TestDataHelper.GetRandomWords() };
             var expected = entityToCreate.ToModel();
-            expected.Id = (await repository.GetAll()).Last().Id + 1;
+            expected.Id = lastIndex + 1;
 
             // Act
             var result = await service.Create(entityToCreate.ToModel()).ConfigureAwait(false);
@@ -136,7 +137,8 @@ namespace OutOfSchool.WebApi.Tests.Services
         public async Task Delete_WhenIdIsValid_DeletesEntityFromRepository()
         {
             // Arrange
-            var existingId = (await repository.GetAll()).Last().Id;
+            var collection = await repository.GetAll() as ICollection<InstitutionStatus>;
+            var existingId = TestDataHelper.RandomItem(collection).Id;
             var expectedCollection = (await repository.GetByFilter(x => x.Id != existingId)).ToList();
 
             // Act
@@ -168,7 +170,7 @@ namespace OutOfSchool.WebApi.Tests.Services
                 context.Database.EnsureDeleted();
                 context.Database.EnsureCreated();
 
-                var institutionStatuses = InstitutionStatusGenerator.Generate(5);
+                var institutionStatuses = InstitutionStatusGenerator.GenerateWithoutIds(5);
                 context.InstitutionStatuses.AddRangeAsync(institutionStatuses);
 
                 context.SaveChangesAsync();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
@@ -160,9 +160,6 @@ namespace OutOfSchool.WebApi.Tests.Services
                 async () => await service.Delete(notExistingId).ConfigureAwait(false));
         }
 
-        /// <summary>
-        /// method to seed in memory db to retrieve entities with repository methods.
-        /// </summary>
 
         private void SeedDatabase()
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/InstitutionStatusController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/InstitutionStatusController.cs
@@ -74,7 +74,7 @@ namespace OutOfSchool.WebApi.Controllers.V1
             }
             catch (ArgumentOutOfRangeException e)
             {
-                return BadRequest(new { e.Message });
+                return BadRequest(e.Message);
             }
 
         }
@@ -136,7 +136,7 @@ namespace OutOfSchool.WebApi.Controllers.V1
             }
             catch (ArgumentOutOfRangeException e)
             {
-                return BadRequest(new { e.Message });
+                return BadRequest(e.Message);
             }
 
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PermissionsForRoleController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PermissionsForRoleController.cs
@@ -127,6 +127,6 @@ namespace OutOfSchool.WebApi.Controllers.V1
         public IActionResult GetAllPermissions() =>
             Ok(Enum.GetValues(typeof(Permissions))
                 .Cast<Permissions>()
-                .Select(p => new { permission = p.ToString(), code = p }));
+                .Select(p => (p, p.ToString())));
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PermissionsForRoleController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PermissionsForRoleController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using OutOfSchool.Common.PermissionsModule;
 using OutOfSchool.WebApi.Models;
@@ -68,7 +69,7 @@ namespace OutOfSchool.WebApi.Controllers.V1
             }
             catch (ArgumentNullException e)
             {
-                return BadRequest(new { e.ParamName });
+                return BadRequest(e.Message);
             }
 
         }
@@ -105,8 +106,15 @@ namespace OutOfSchool.WebApi.Controllers.V1
         [HttpPut]
         public async Task<IActionResult> Update(PermissionsForRoleDTO dto)
         {
-            return Ok(await service.Update(dto).ConfigureAwait(false));
-        }
+            try
+            {
+                return Ok(await service.Update(dto).ConfigureAwait(false));
+            }
+            catch (DbUpdateConcurrencyException e)
+            {
+                return BadRequest(e.Message);
+            }
+         }
 
         /// <summary>
         /// Gets all currently existing permissions from system and returns friendly response for admin person.

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
@@ -85,9 +85,9 @@ namespace OutOfSchool.WebApi.Controllers.V1
 
             return Ok(provider);
             }
-            catch (ArgumentOutOfRangeException e)
+            catch (ArgumentOutOfRangeException ex)
             {
-                return BadRequest(new {e.Message});
+                return BadRequest(ex.Message);
             }
         }
 
@@ -220,7 +220,7 @@ namespace OutOfSchool.WebApi.Controllers.V1
             }
             catch (ArgumentNullException ex)
             {
-                return BadRequest(ex);
+                return BadRequest(ex.Message);
             }
 
             return NoContent();

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
@@ -75,14 +75,20 @@ namespace OutOfSchool.WebApi.Controllers.V1
         [AllowAnonymous]
         public async Task<IActionResult> GetById(Guid providerId)
         {
+            try
+            { 
             var provider = await providerService.GetById(providerId).ConfigureAwait(false);
-
             if (provider == null)
             {
                 return NoContent();
             }
 
             return Ok(provider);
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                return BadRequest(new {e.Message});
+            }
         }
 
         /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
@@ -75,15 +75,13 @@ namespace OutOfSchool.WebApi.Controllers.V1
         [AllowAnonymous]
         public async Task<IActionResult> GetById(Guid providerId)
         {
-            try
-            {
             var provider = await providerService.GetById(providerId).ConfigureAwait(false);
-            return Ok(provider);
-            }
-            catch (ArgumentOutOfRangeException ex)
+            if (provider == null)
             {
-                return BadRequest(ex.Message);
+                return NotFound($"There is no Provider in DB with {nameof(provider.Id)} - {providerId}");
             }
+
+            return Ok(provider);
         }
 
         /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 
@@ -179,16 +180,26 @@ namespace OutOfSchool.WebApi.Controllers.V1
             {
                 return BadRequest(ModelState);
             }
-            var userId = User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub);
-            var provider = await providerService.Update(providerModel, userId).ConfigureAwait(false);
 
-            if (provider == null)
+            try
             {
-                return BadRequest("Can't change Provider with such parameters.\n" +
-                    "Please check that information are valid.");
+                var userId = User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub);
+                var provider = await providerService.Update(providerModel, userId).ConfigureAwait(false);
+
+                if (provider == null)
+                {
+                    return BadRequest("Can't change Provider with such parameters.\n" +
+                        "Please check that information are valid.");
+                }
+
+                return Ok(provider);
+            }
+            catch (DbUpdateConcurrencyException e)
+            {
+                return BadRequest(e);
             }
 
-            return Ok(provider);
+
         }
 
         /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
@@ -76,13 +76,8 @@ namespace OutOfSchool.WebApi.Controllers.V1
         public async Task<IActionResult> GetById(Guid providerId)
         {
             try
-            { 
-            var provider = await providerService.GetById(providerId).ConfigureAwait(false);
-            if (provider == null)
             {
-                return NoContent();
-            }
-
+            var provider = await providerService.GetById(providerId).ConfigureAwait(false);
             return Ok(provider);
             }
             catch (ArgumentOutOfRangeException ex)

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
@@ -214,7 +214,14 @@ namespace OutOfSchool.WebApi.Controllers.V1
         [HttpDelete("{uid:guid}")]
         public async Task<IActionResult> Delete(Guid uid)
         {
-            await providerService.Delete(uid).ConfigureAwait(false);
+            try 
+            {
+                await providerService.Delete(uid).ConfigureAwait(false);
+            }
+            catch (ArgumentNullException ex)
+            {
+                return BadRequest(ex);
+            }
 
             return NoContent();
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
@@ -181,12 +181,8 @@ namespace OutOfSchool.WebApi.Controllers.V1
             {
                 return BadRequest(ModelState);
             }
-
             var userId = User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub);
-
-            var userRole = User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Role);
-
-            var provider = await providerService.Update(providerModel, userId, userRole).ConfigureAwait(false);
+            var provider = await providerService.Update(providerModel, userId).ConfigureAwait(false);
 
             if (provider == null)
             {

--- a/OutOfSchool/OutOfSchool.WebApi/Services/IProviderService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/IProviderService.cs
@@ -43,9 +43,8 @@ namespace OutOfSchool.WebApi.Services
         /// </summary>
         /// <param name="providerDto">Provider entity to add.</param>
         /// <param name="userId">Id of user that request update.</param>
-        /// <param name="userRole">User Role.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        Task<ProviderDto> Update(ProviderDto providerDto, string userId, string userRole);
+        Task<ProviderDto> Update(ProviderDto providerDto, string userId);
 
         /// <summary>
         ///  Delete entity.

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderService.cs
@@ -128,14 +128,11 @@ namespace OutOfSchool.WebApi.Services
         public async Task<ProviderDto> GetById(Guid id)
         {
             logger.LogInformation($"Getting Provider by Id started. Looking Id = {id}.");
-
             var provider = await providerRepository.GetById(id).ConfigureAwait(false);
 
             if (provider == null)
             {
-                throw new ArgumentOutOfRangeException(
-                    nameof(id),
-                    localizer["The id cannot be greater than number of table entities."]);
+                return null;
             }
 
             logger.LogInformation($"Successfully got a Provider with Id = {id}.");

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderService.cs
@@ -20,7 +20,6 @@ namespace OutOfSchool.WebApi.Services
     /// </summary>
     public class ProviderService : IProviderService
     {
-        private const string AdminRole = "admin";
         private readonly IProviderRepository providerRepository;
         private readonly IRatingService ratingService;
         private readonly ILogger<ProviderService> logger;
@@ -171,7 +170,7 @@ namespace OutOfSchool.WebApi.Services
         }
 
         /// <inheritdoc/>
-        public async Task<ProviderDto> Update(ProviderDto providerDto, string userId, string userRole)
+        public async Task<ProviderDto> Update(ProviderDto providerDto, string userId)
         {
             logger.LogDebug($"Updating Provider with Id = {providerDto?.Id} started.");
 
@@ -181,7 +180,7 @@ namespace OutOfSchool.WebApi.Services
                     (await providerRepository.GetByFilter(p => p.Id == providerDto.Id).ConfigureAwait(false))
                     .FirstOrDefault();
 
-                if (checkProvider?.UserId != userId && userRole != AdminRole)
+                if (checkProvider?.UserId != userId)
                 {
                     return null;
                 }

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/InstitutionStatusGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/InstitutionStatusGenerator.cs
@@ -13,7 +13,6 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
     {
 
         private static Faker<InstitutionStatus> faker = new Faker<InstitutionStatus>()
-            .RuleFor(x => x.Id, f => f.IndexFaker)
             .RuleFor(x => x.Name, f => f.Name.JobDescriptor())
             .RuleFor(x => x.Providers, ProvidersGenerator.Generate(3));
 
@@ -21,7 +20,15 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
         /// Generates new instance of the <see cref="InstitutionStatus"/> class.
         /// </summary>
         /// <returns><see cref="InstitutionStatus"/> object with random data.</returns>
-        public static InstitutionStatus Generate() => faker.Generate();
+        public static InstitutionStatus Generate() => faker.RuleFor(x => x.Id, f => f.IndexVariable++)
+            .Generate();
+
+        /// <summary>
+        /// Generates a list of the <see cref="InstitutionStatus"/> objects without Id.
+        /// For using with in-memory DB and repository, where indexes are generated automatically
+        /// </summary>
+        /// <returns><see cref="InstitutionStatus"/> object with random data.</returns>
+        public static List<InstitutionStatus> GenerateWithoutIds(int count) => faker.Generate(count);
 
         /// <summary>
         /// Generates a list of the <see cref="InstitutionStatus"/> objects.

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/InstitutionStatusGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/InstitutionStatusGenerator.cs
@@ -1,0 +1,32 @@
+﻿using Bogus;
+using OutOfSchool.Services.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OutOfSchool.Tests.Common.TestDataGenerators
+{
+    /// <summary>
+    /// Contains methods to generate fake <see cref="InstitutionStatus"/> objects.
+    /// </summary>
+    public class InstitutionStatusGenerator
+    {
+
+        private static Faker<InstitutionStatus> faker = new Faker<InstitutionStatus>()
+            .RuleFor(x => x.Id, f => f.IndexFaker)
+            .RuleFor(x => x.Name, f => f.Name.JobDescriptor());
+
+        /// <summary>
+        /// Generates new instance of the <see cref="InstitutionStatus"/> class.
+        /// </summary>
+        /// <returns><see cref="InstitutionStatus"/> object with random data.</returns>
+        public static InstitutionStatus Generate() => faker.Generate();
+
+        /// <summary>
+        /// Generates a list of the <see cref="InstitutionStatus"/> objects.
+        /// </summary>
+        /// <param name="count">count of instances to generate.</param>
+        /// <returns>A <see cref="List{T}"/> of <see cref="InstitutionStatus"/> objects.</returns>
+        public static List<InstitutionStatus> Generate(int count) => faker.Generate(count);
+    }
+}

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/InstitutionStatusGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/InstitutionStatusGenerator.cs
@@ -14,7 +14,8 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
 
         private static Faker<InstitutionStatus> faker = new Faker<InstitutionStatus>()
             .RuleFor(x => x.Id, f => f.IndexFaker)
-            .RuleFor(x => x.Name, f => f.Name.JobDescriptor());
+            .RuleFor(x => x.Name, f => f.Name.JobDescriptor())
+            .RuleFor(x => x.Providers, ProvidersGenerator.Generate(3));
 
         /// <summary>
         /// Generates new instance of the <see cref="InstitutionStatus"/> class.

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/InstitutionStatusGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/InstitutionStatusGenerator.cs
@@ -13,6 +13,7 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
     {
 
         private static Faker<InstitutionStatus> faker = new Faker<InstitutionStatus>()
+            .RuleFor(x => x.Id, f => f.IndexVariable++)
             .RuleFor(x => x.Name, f => f.Name.JobDescriptor())
             .RuleFor(x => x.Providers, ProvidersGenerator.Generate(3));
 
@@ -20,15 +21,7 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
         /// Generates new instance of the <see cref="InstitutionStatus"/> class.
         /// </summary>
         /// <returns><see cref="InstitutionStatus"/> object with random data.</returns>
-        public static InstitutionStatus Generate() => faker.RuleFor(x => x.Id, f => f.IndexVariable++)
-            .Generate();
-
-        /// <summary>
-        /// Generates a list of the <see cref="InstitutionStatus"/> objects without Id.
-        /// For using with in-memory DB and repository, where indexes are generated automatically
-        /// </summary>
-        /// <returns><see cref="InstitutionStatus"/> object with random data.</returns>
-        public static List<InstitutionStatus> GenerateWithoutIds(int count) => faker.Generate(count);
+        public static InstitutionStatus Generate() => faker.Generate();
 
         /// <summary>
         /// Generates a list of the <see cref="InstitutionStatus"/> objects.

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/PermissionsForRolesGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/PermissionsForRolesGenerator.cs
@@ -1,0 +1,56 @@
+﻿using Bogus;
+using OutOfSchool.Services.Enums;
+using OutOfSchool.Services.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OutOfSchool.Tests.Common.TestDataGenerators
+{
+    public class PermissionsForRolesGenerator
+    {
+        private static Faker<PermissionsForRole> faker = new Faker<PermissionsForRole>()
+            .RuleFor(x => x.Id, f => f.IndexFaker)
+            .RuleFor(x => x.RoleName, _ => TestDataHelper.GetRandomRole())
+            .RuleFor(x => x.PackedPermissions, _ => TestDataHelper.GetFakePackedPermissions())
+            .RuleFor(x => x.Description, _ => TestDataHelper.GetRandomWords());
+
+        /// <summary>
+        /// Generates new instance of the <see cref="PermissionsForRole"/> class.
+        /// </summary>
+        /// <returns><see cref="PermissionsForRole"/> object with random data for one of the existing roles.</returns>
+        public static PermissionsForRole Generate() => faker.Generate();
+
+        /// <summary>
+        /// Generates a list of the <see cref="PermissionsForRole"/> objects with random role names.
+        /// </summary>
+        /// <param name="count">count of instances to generate.</param>
+        /// <returns>A <see cref="List{T}"/> of <see cref="PermissionsForRole"/> objects.</returns>
+        public static List<PermissionsForRole> Generate(int count) => faker.Generate(count);
+
+
+        /// <summary>
+        /// Generates new instance of the <see cref="PermissionsForRole"/> class for predifined role.
+        /// </summary>
+        /// <returns><see cref="PermissionsForRole"/> object with random data.</returns>
+        private static PermissionsForRole Generate(string roleName) => faker
+            .RuleFor(x => x.RoleName, _ => roleName);
+
+        /// <summary>
+        /// Generates a list of the <see cref="PermissionsForRole"/> objects for existing roles.
+        /// </summary>
+        /// <param name="count">count of instances to generate.</param>
+        /// <returns>A <see cref="List{T}"/> of <see cref="PermissionsForRole"/> objects.</returns>
+        public static List<PermissionsForRole> GenerateForExistingRoles()
+        {
+            var list = new List<PermissionsForRole>();
+            var roles = (Role[])Enum.GetValues(typeof(Role));
+            foreach (var role in roles)
+            {
+                list.Add(Generate(role.ToString()));
+            }
+            return list;
+        }
+    }
+}
+

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/PermissionsForRolesGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/PermissionsForRolesGenerator.cs
@@ -10,8 +10,6 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
     public class PermissionsForRolesGenerator
     {
         private static Faker<PermissionsForRole> faker = new Faker<PermissionsForRole>()
-            .RuleFor(x => x.Id, f => f.IndexFaker)
-            .RuleFor(x => x.RoleName, _ => TestDataHelper.GetRandomRole())
             .RuleFor(x => x.PackedPermissions, _ => TestDataHelper.GetFakePackedPermissions())
             .RuleFor(x => x.Description, _ => TestDataHelper.GetRandomWords());
 
@@ -19,7 +17,9 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
         /// Generates new instance of the <see cref="PermissionsForRole"/> class.
         /// </summary>
         /// <returns><see cref="PermissionsForRole"/> object with random data for one of the existing roles.</returns>
-        public static PermissionsForRole Generate() => faker.Generate();
+        public static PermissionsForRole Generate() => faker
+            .RuleFor(x => x.RoleName, _ => TestDataHelper.GetRandomRole())
+            .Generate();
 
         /// <summary>
         /// Generates a list of the <see cref="PermissionsForRole"/> objects with random role names.
@@ -33,7 +33,7 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
         /// Generates new instance of the <see cref="PermissionsForRole"/> class for predifined role.
         /// </summary>
         /// <returns><see cref="PermissionsForRole"/> object with random data.</returns>
-        private static PermissionsForRole Generate(string roleName) => faker
+        public static PermissionsForRole Generate(string roleName) => faker
             .RuleFor(x => x.RoleName, _ => roleName);
 
         /// <summary>

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/RatingsGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/RatingsGenerator.cs
@@ -13,7 +13,7 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
         public static Tuple<float, int> GetAverageRatingForProvider()
             => new Tuple<float, int>(faker.Random.Float(), faker.Random.Int());
 
-        public static Dictionary<long, Tuple<float, int>> GetAverageRatingForRange(IEnumerable<long> items)
+        public static Dictionary<Guid, Tuple<float, int>> GetAverageRatingForRange(IEnumerable<Guid> items)
             => items.ToDictionary(i => i, i => GetAverageRatingForProvider());
     }
 }

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/UserGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/UserGenerator.cs
@@ -1,0 +1,60 @@
+﻿using Bogus;
+using OutOfSchool.Services.Enums;
+using OutOfSchool.Services.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OutOfSchool.Tests.Common.TestDataGenerators
+{
+    /// <summary>
+    /// Contains methods to generate fake <see cref="User"/> objects.
+    /// </summary>
+    public static class UserGenerator
+    {
+        private static readonly string PhoneFormat = "##########";
+
+        private static readonly Faker<User> faker = new Faker<User>()
+            .RuleFor(x => x.Id, _ => Guid.NewGuid().ToString())
+            .RuleFor(x => x.CreatingTime, f => f.Date.PastOffset())
+            .RuleFor(x => x.LastLogin, f => f.Date.PastOffset())
+            .RuleFor(x => x.MiddleName, f => f.Name.FirstName())
+            .RuleFor(x => x.FirstName, f => f.Name.FirstName())
+            .RuleFor(x => x.LastName, f => f.Name.LastName())
+            .RuleFor(x => x.EmailConfirmed, _ => false)
+            .RuleFor(x => x.PasswordHash, f => f.Random.Hash())
+            .RuleFor(x => x.SecurityStamp,f => f.Random.Hash())
+            .RuleFor(x => x.ConcurrencyStamp, _ => Guid.NewGuid().ToString())
+            .RuleFor(x => x.PhoneNumber, f => f.Phone.PhoneNumber(PhoneFormat))
+            .RuleFor(x => x.Role, f => f.Random.ArrayElement((Role[])Enum.GetValues(typeof(Role))).ToString())
+            .RuleFor(x => x.PhoneNumberConfirmed, _ => false)
+            .RuleFor(x => x.TwoFactorEnabled, _ => false)
+            .RuleFor(x => x.LockoutEnabled, _ => true)
+            .RuleFor(x => x.AccessFailedCount, _ => 0)
+            ;
+
+        /// <summary>
+        /// Creates new instance of the <see cref="User"/> class with random data.
+        /// </summary>
+        /// <returns><see cref="User"/> object.</returns>
+        public static User Generate()
+        {
+            var email = TestDataHelper.GetRandomEmail();
+            var normalisedEmail = email.ToUpper();
+            return faker
+                .RuleFor(x => x.UserName, _ => email)
+                .RuleFor(x => x.Email, _ => email)
+                .RuleFor(x => x.NormalizedUserName,_ => normalisedEmail)
+                .RuleFor(x => x.NormalizedEmail,_ => normalisedEmail)
+                .Generate();
+        }
+
+        /// <summary>
+        /// Generates a list of the <see cref="User"/> objects.
+        /// </summary>
+        /// <param name="count">count of instances to generate.</param>
+        public static List<User> Generate(int count) => faker.Generate(count);
+    }
+}
+
+

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Bogus;
+using OutOfSchool.Common.PermissionsModule;
 
 namespace OutOfSchool.Tests.Common
 {
@@ -95,5 +96,13 @@ namespace OutOfSchool.Tests.Common
         /// Gets random Edrpou/Ipn string.
         /// </summary>
         public static string EdrpouIpnString => faker.Random.ReplaceNumbers(faker.PickRandom(EdrpouIpnFormats));
+
+        /// <summary>
+        /// Gets random "job area" string to use as fake role name in our test cases
+        /// </summary>
+        public static string GetRandomRole() => faker.Name.JobArea();
+        public static string GetRandomWords() => faker.Random.Words(3);
+        public static string GetFakePackedPermissions() =>
+            faker.Random.ArrayElements((Permissions[])Enum.GetValues(typeof(Permissions)), 10).PackPermissionsIntoString();
     }
 }

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataHelper.cs
@@ -102,6 +102,8 @@ namespace OutOfSchool.Tests.Common
         /// </summary>
         public static string GetRandomRole() => faker.Name.JobArea();
         public static string GetRandomWords() => faker.Random.Words(3);
+
+        public static string GetRandomEmail() => faker.Internet.Email();
         public static string GetFakePackedPermissions() =>
             faker.Random.ArrayElements((Permissions[])Enum.GetValues(typeof(Permissions)), 10).PackPermissionsIntoString();
     }

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using Bogus;
 using OutOfSchool.Common.PermissionsModule;
 
@@ -29,8 +30,6 @@ namespace OutOfSchool.Tests.Common
                 ? throw new ArgumentNullException(nameof(collection))
                 : faker.Random.CollectionItem(collection);
 
-
-
         /// <summary>
         /// Gets the negative (int.MinValue .. -1) number.
         /// </summary>
@@ -56,6 +55,7 @@ namespace OutOfSchool.Tests.Common
         /// Gets the collection of the positive (1 .. int.MaxValue) numbers.
         /// </summary>
         public static int[] GetPositiveInts(int count) => faker.Random.Digits(count, 1, 9);
+
 
         /// <summary>
         /// Applies an <paramref name="setter"/> on the given <paramref name="item"/>

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataHelper.cs
@@ -29,10 +29,23 @@ namespace OutOfSchool.Tests.Common
                 ? throw new ArgumentNullException(nameof(collection))
                 : faker.Random.CollectionItem(collection);
 
+
+
+        /// <summary>
+        /// Gets the negative (int.MinValue .. -1) number.
+        /// </summary>
+        public static int GetNegativeInt() => faker.Random.Number(int.MinValue, -1);
+
         /// <summary>
         /// Gets the positive (1 .. int.MaxValue) number.
         /// </summary>
         public static int GetPositiveInt() => faker.Random.Number(1, int.MaxValue);
+
+        /// <summary>
+        /// Gets the positive (min .. max) number.
+        /// </summary>
+        public static int GetPositiveInt(int min,int max) => faker.Random.Number(min, max);
+
 
         /// <summary>
         /// Gets the positive (1 .. max) number.

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
@@ -1,28 +1,86 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
+using OutOfSchool.Services.Models;
 using OutOfSchool.WebApi.Models;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace OutOfSchool.Tests.Common
 {
     public static class TestHelper
     {
-        public static void GetAssertedResponseOkAndValidValue<TExpectedValue>(this IActionResult response)
+        public static void AssertResponseOkResultAndValidateValue<TExpectedValue>(this IActionResult response, TExpectedValue expected)
         {
-            Assert.IsInstanceOf<OkObjectResult>(response);
-            var okResult = response as OkObjectResult;
-            Assert.IsInstanceOf<TExpectedValue>(okResult.Value);
-            Assert.That(okResult.Value, Is.Not.Null);
+            var actual = (response as ObjectResult).Value;
+            Assert.Multiple(() =>
+            {
+                Assert.IsInstanceOf<OkObjectResult>(response);
+                Assert.IsInstanceOf<TExpectedValue>(actual);
+                AssertDtosAreEqual(expected, (TExpectedValue)actual);
+            });
         }
 
-        public static void GetAssertedResponseValidateValueNotEmpty<TExpectedResponseType>(this IActionResult response)
+        public static void AssertResponseOkResultAndValidateValue<TExpectedValue>(this IActionResult response, IEnumerable<TExpectedValue> expected)
         {
-            Assert.IsInstanceOf<TExpectedResponseType>(response);
-            var objectResult = response as ObjectResult;
-            Assert.That(objectResult.Value, Is.Not.Null);
+            var actual = (response as ObjectResult).Value;
+            Assert.Multiple(() =>
+            {
+                Assert.IsInstanceOf<OkObjectResult>(response);
+                Assert.IsInstanceOf<IEnumerable<TExpectedValue>>(actual);
+                AssertTwoCollectionsEqualByValues(expected, (IEnumerable<TExpectedValue>)actual);
+            });
+
         }
 
+        public static void AssertExpectedResponseTypeAndCheckDataInside<TExpectedResponseType>(this IActionResult response, ObjectResult expected)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.IsInstanceOf<TExpectedResponseType>(response);
+                var objectResult = response as ObjectResult;
+                var type = expected.Value.GetType();
+                Assert.That(objectResult.Value.GetType(), Is.EqualTo(type));
+                Assert.That(objectResult.Value, Is.Not.Null);
+            });
+        }
+
+        public static void AssertTwoCollectionsEqualByValues<TValue>(IEnumerable<TValue> expected, IEnumerable<TValue> actual)
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var collection in expected.Zip(actual))
+                {
+                    AssertDtosAreEqual<TValue>(collection.First, collection.Second);
+                }
+            }
+            );
+        }
+
+        public static void AssertDtosAreEqual<TValue>(TValue expected, TValue actual)
+        {
+            var tuppledProperties = GetTuppledProperties<TValue>(expected, actual);
+            tuppledProperties.AssertPropertiesAreEqual();
+        }
+
+        private static IEnumerable<(object , object)> GetTuppledProperties<TValue>(TValue expected, TValue actual)
+        {
+            return expected.GetType().GetProperties()
+                .Select(p => p.GetValue(expected))
+                .Zip(actual.GetType().GetProperties()
+                .Select(r => r.GetValue(actual)));
+        }
+
+        private static void AssertPropertiesAreEqual(this IEnumerable<(object, object)> tuppledProperties)
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var property in tuppledProperties)
+                {
+                    Assert.AreEqual(property.Item1, property.Item2);
+                }
+            });
+        }
     }
 }

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
@@ -52,7 +52,7 @@ namespace OutOfSchool.Tests.Common
             {
                 foreach (var collection in expected.Zip(actual))
                 {
-                    AssertDtosAreEqual<TValue>(collection.First, collection.Second);
+                    AssertDtosAreEqual(collection.First, collection.Second);
                 }
             }
             );

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
@@ -14,7 +14,6 @@ namespace OutOfSchool.Tests.Common
             var okResult = response as OkObjectResult;
             Assert.IsInstanceOf<TExpectedValue>(okResult.Value);
             Assert.That(okResult.Value, Is.Not.Null);
-            Assert.AreEqual(200, okResult.StatusCode);
         }
 
         public static void GetAssertedResponseValidateValueNotEmpty<TExpectedResponseType>(this IActionResult response)

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
@@ -24,49 +24,5 @@ namespace OutOfSchool.Tests.Common
             Assert.That(objectResult.Value, Is.Not.Null);
         }
 
-        public static ProviderDto GetDeepCopyProviderDto(this ProviderDto originalDto)
-        {
-            var copiedEntity = new ProviderDto();
-            copiedEntity.Id = originalDto.Id;
-            copiedEntity.FullTitle = originalDto.FullTitle;
-            copiedEntity.ShortTitle = originalDto.ShortTitle;
-            copiedEntity.Website = originalDto.Website;
-            copiedEntity.Email = originalDto.Email;
-            copiedEntity.PhoneNumber = originalDto.PhoneNumber;
-            copiedEntity.Facebook = originalDto.Facebook;
-            copiedEntity.Instagram = originalDto.Instagram;
-            copiedEntity.Description = originalDto.Description;
-            copiedEntity.Director = originalDto.Director;
-            copiedEntity.DirectorDateOfBirth = originalDto.DirectorDateOfBirth;
-            copiedEntity.EdrpouIpn = originalDto.EdrpouIpn;
-            copiedEntity.UserId = originalDto.UserId;
-            copiedEntity.Ownership = originalDto.Ownership;
-            copiedEntity.Founder = originalDto.Founder;
-            copiedEntity.Status = originalDto.Status;
-            copiedEntity.Type = originalDto.Type;
-            copiedEntity.Rating = originalDto.Rating;
-            copiedEntity.NumberOfRatings = originalDto.NumberOfRatings;
-
-
-            copiedEntity.ActualAddress = new AddressDto
-            {
-                Region = originalDto.ActualAddress.Region,
-                District = originalDto.ActualAddress.District,
-                Street = originalDto.ActualAddress.Street,
-                City = originalDto.ActualAddress.City,
-                BuildingNumber = originalDto.ActualAddress.BuildingNumber,
-            };
-
-            copiedEntity.LegalAddress = new AddressDto
-            {
-                Region = originalDto.LegalAddress.Region,
-                District = originalDto.LegalAddress.District,
-                Street = originalDto.LegalAddress.Street,
-                City = originalDto.LegalAddress.City,
-                BuildingNumber = originalDto.LegalAddress.BuildingNumber,
-            };
-
-            return copiedEntity;
-        }
     }
 }

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
+using OutOfSchool.WebApi.Models;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -21,6 +22,51 @@ namespace OutOfSchool.Tests.Common
             Assert.IsInstanceOf<TExpectedResponseType>(response);
             var objectResult = response as ObjectResult;
             Assert.That(objectResult.Value, Is.Not.Null);
+        }
+
+        public static ProviderDto GetDeepCopyProviderDto(this ProviderDto originalDto)
+        {
+            var copiedEntity = new ProviderDto();
+            copiedEntity.Id = originalDto.Id;
+            copiedEntity.FullTitle = originalDto.FullTitle;
+            copiedEntity.ShortTitle = originalDto.ShortTitle;
+            copiedEntity.Website = originalDto.Website;
+            copiedEntity.Email = originalDto.Email;
+            copiedEntity.PhoneNumber = originalDto.PhoneNumber;
+            copiedEntity.Facebook = originalDto.Facebook;
+            copiedEntity.Instagram = originalDto.Instagram;
+            copiedEntity.Description = originalDto.Description;
+            copiedEntity.Director = originalDto.Director;
+            copiedEntity.DirectorDateOfBirth = originalDto.DirectorDateOfBirth;
+            copiedEntity.EdrpouIpn = originalDto.EdrpouIpn;
+            copiedEntity.UserId = originalDto.UserId;
+            copiedEntity.Ownership = originalDto.Ownership;
+            copiedEntity.Founder = originalDto.Founder;
+            copiedEntity.Status = originalDto.Status;
+            copiedEntity.Type = originalDto.Type;
+            copiedEntity.Rating = originalDto.Rating;
+            copiedEntity.NumberOfRatings = originalDto.NumberOfRatings;
+
+
+            copiedEntity.ActualAddress = new AddressDto
+            {
+                Region = originalDto.ActualAddress.Region,
+                District = originalDto.ActualAddress.District,
+                Street = originalDto.ActualAddress.Street,
+                City = originalDto.ActualAddress.City,
+                BuildingNumber = originalDto.ActualAddress.BuildingNumber,
+            };
+
+            copiedEntity.LegalAddress = new AddressDto
+            {
+                Region = originalDto.LegalAddress.Region,
+                District = originalDto.LegalAddress.District,
+                Street = originalDto.LegalAddress.Street,
+                City = originalDto.LegalAddress.City,
+                BuildingNumber = originalDto.LegalAddress.BuildingNumber,
+            };
+
+            return copiedEntity;
         }
     }
 }

--- a/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/ProviderServiceIntergrationTests/ProviderServiceUpdate.cs
+++ b/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/ProviderServiceIntergrationTests/ProviderServiceUpdate.cs
@@ -21,8 +21,6 @@ namespace OutOfSchool.WebApi.IntegrationTests.ProviderServiceIntergrationTests
     [TestFixture]
     public class ProviderServiceUpdate
     {
-        private const string NOT_ADMIN_USER_ROLE = "Provider";
-
         private IProviderService providerService;
 
         private Mapper mapper;
@@ -71,7 +69,7 @@ namespace OutOfSchool.WebApi.IntegrationTests.ProviderServiceIntergrationTests
 
             // Act
             var result = await this.providerService
-                .Update(this.mapper.Map<ProviderDto>(provider), provider.UserId, NOT_ADMIN_USER_ROLE)
+                .Update(this.mapper.Map<ProviderDto>(provider), provider.UserId)
                 .ConfigureAwait(false);
 
             // Assert
@@ -95,7 +93,7 @@ namespace OutOfSchool.WebApi.IntegrationTests.ProviderServiceIntergrationTests
             providerDto.ActualAddress = null;
 
             // Act
-            var result = await this.providerService.Update(providerDto, provider.UserId, NOT_ADMIN_USER_ROLE)
+            var result = await this.providerService.Update(providerDto, provider.UserId)
                 .ConfigureAwait(false);
 
             // Assert
@@ -120,7 +118,7 @@ namespace OutOfSchool.WebApi.IntegrationTests.ProviderServiceIntergrationTests
             var providerDto = this.mapper.Map<ProviderDto>(provider);
 
             // Act
-            var result = await this.providerService.Update(providerDto, provider.UserId, NOT_ADMIN_USER_ROLE)
+            var result = await this.providerService.Update(providerDto, provider.UserId)
                 .ConfigureAwait(false);
 
             // Assert
@@ -144,7 +142,7 @@ namespace OutOfSchool.WebApi.IntegrationTests.ProviderServiceIntergrationTests
             var providerDto = this.mapper.Map<ProviderDto>(provider);
 
             // Act
-            var result = await this.providerService.Update(providerDto, provider.UserId, NOT_ADMIN_USER_ROLE)
+            var result = await this.providerService.Update(providerDto, provider.UserId)
                 .ConfigureAwait(false);
 
             // Assert
@@ -163,7 +161,7 @@ namespace OutOfSchool.WebApi.IntegrationTests.ProviderServiceIntergrationTests
             var providerDto = this.mapper.Map<ProviderDto>(provider);
 
             // Act
-            var result = await this.providerService.Update(providerDto, provider.UserId, NOT_ADMIN_USER_ROLE)
+            var result = await this.providerService.Update(providerDto, provider.UserId)
                 .ConfigureAwait(false);
 
             // Assert


### PR DESCRIPTION
-Fixed existing and created additional unit tests to examine the logic of controllers and services, uppermost, Providers, and then also for InstitutionStatus and PermissionsForRole objects in our app. To achieve this, created the system with helper methods as data generators, randomizers, etc., following the example of similar features for other objects. Also produced generic methods for easy assertions of expected and actual results in situations, where we have to examine multiple conditions (e.g. - for controllers - check response type and also value inside it, both if it is a single object, collection or even data retrieved from bad request.

-Removed user Role from parameters of IProviderService Update method. Deleted check for the role during method execution because currently, our service allows Users with the "Admin" role to update any entity from the Providers list. My changes caused that provider entities can be edited only by the user-owner.

-Altered ProviderController actions to handle exceptions thrown during service usage and generate BadRequest response with a documented specific problem. Deleted code for getting current user's role, because we don't check role anymore. So the current flow is - we need specific "ProviderEdit" permission to use controller's "Update" action and also logged user's Id must be similar to UserId of Provider entity we want to change.

-------------------