### PR TITLE
Tatokhin/ProviderAdmins

### DIFF
--- a/OutOfSchool/OutOfSchool.Common/Models/BlockProviderAdminDto.cs
+++ b/OutOfSchool/OutOfSchool.Common/Models/BlockProviderAdminDto.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OutOfSchool.Common.Models
+{
+    public class BlockProviderAdminDto
+    {
+        public string ProviderAdminId { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.Common/Models/CreateProviderAdminDto.cs
+++ b/OutOfSchool/OutOfSchool.Common/Models/CreateProviderAdminDto.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+
+namespace OutOfSchool.Common.Models
+{
+    public class CreateProviderAdminDto
+    {
+        [Required(ErrorMessage = "FirstName is required")]
+        public string FirstName { get; set; }
+
+        [Required(ErrorMessage = "LastName is required")]
+        public string LastName { get; set; }
+
+        public string MiddleName { get; set; }
+
+        [DataType(DataType.EmailAddress)]
+        [Required(ErrorMessage = "Email is required")]
+        public string Email { get; set; }
+
+        [DataType(DataType.PhoneNumber)]
+        [Required(ErrorMessage = "Phone number is required")]
+        [RegularExpression(
+        @"([0-9]{2})([-]?)([0-9]{3})([-]?)([0-9]{2})([-]?)([0-9]{2})",
+        ErrorMessage = "Phone number format is incorrect. Example: +380XX-XXX-XX-XX")]
+        public string PhoneNumber { get; set; }
+
+        [DataType(DataType.DateTime)]
+        public DateTimeOffset CreatingTime { get; set; }
+
+        [DataType(DataType.DateTime)]
+        public DateTimeOffset? LastLogin { get; set; }
+
+        public string ReturnUrl { get; set; }
+        
+        public Guid ProviderId { get; set; }
+
+        public string UserId { get; set; }
+
+        // to specify if its assistant or deputy
+        public bool IsDeputy { get; set; }
+
+        // to specify workshops, which can be managed by provider admin
+        public List<Guid> ManagedWorkshopIds { get; set; }
+
+
+    }
+}

--- a/OutOfSchool/OutOfSchool.Common/Models/CreateProviderAdminDto.cs
+++ b/OutOfSchool/OutOfSchool.Common/Models/CreateProviderAdminDto.cs
@@ -29,11 +29,8 @@ namespace OutOfSchool.Common.Models
         [DataType(DataType.DateTime)]
         public DateTimeOffset CreatingTime { get; set; }
 
-        [DataType(DataType.DateTime)]
-        public DateTimeOffset? LastLogin { get; set; }
-
         public string ReturnUrl { get; set; }
-        
+
         public Guid ProviderId { get; set; }
 
         public string UserId { get; set; }
@@ -43,7 +40,5 @@ namespace OutOfSchool.Common.Models
 
         // to specify workshops, which can be managed by provider admin
         public List<Guid> ManagedWorkshopIds { get; set; }
-
-
     }
 }

--- a/OutOfSchool/OutOfSchool.Common/Models/DeleteProviderAdminDto.cs
+++ b/OutOfSchool/OutOfSchool.Common/Models/DeleteProviderAdminDto.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OutOfSchool.Common.Models
+{
+    public class DeleteProviderAdminDto
+    {
+        public string ProviderAdminId { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.Common/Models/ResponseDto.cs
+++ b/OutOfSchool/OutOfSchool.Common/Models/ResponseDto.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace OutOfSchool.Common
+{
+    public class ResponseDto
+    {
+        public object Result { get; set; }
+
+        public string Message { get; set; }
+
+        public HttpStatusCode HttpStatusCode { get; set; }
+
+        public bool IsSuccess { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.Common/PermissionModule/PermissionManagement/Permissions.cs
+++ b/OutOfSchool/OutOfSchool.Common/PermissionModule/PermissionManagement/Permissions.cs
@@ -71,6 +71,8 @@ namespace OutOfSchool.Common.PermissionsModule
         ProviderAddNew = 52,
         [Display(GroupName = "Provider", Name = "Remove", Description = "Can remove Provider data")]
         ProviderRemove = 53,
+        [Display(GroupName = "Provider", Name = "Provider Admins", Description = "Can create and manage provider admins")]
+        ProviderAdmins = 54,
         #endregion
 
         #region Rating control permissions #7

--- a/OutOfSchool/OutOfSchool.Common/PermissionModule/PermissionManagement/PermissionsSeeder.cs
+++ b/OutOfSchool/OutOfSchool.Common/PermissionModule/PermissionManagement/PermissionsSeeder.cs
@@ -24,10 +24,21 @@ namespace OutOfSchool.Common.PermissionsModule
             Permissions.ImpersonalDataRead,
             Permissions.AddressAddNew, Permissions.AddressEdit, Permissions.AddressRead, Permissions.AddressRemove,
             Permissions.ApplicationRead, Permissions.ApplicationEdit,
-            Permissions.ProviderAddNew, Permissions.ProviderEdit, Permissions.ProviderRead, Permissions.ProviderRemove,
+            Permissions.ProviderAddNew, Permissions.ProviderEdit, Permissions.ProviderRead, Permissions.ProviderRemove, Permissions.ProviderAdmins,
             Permissions.TeacherAddNew, Permissions.TeacherEdit, Permissions.TeacherRemove, Permissions.TeacherRead,
             Permissions.UserRead, Permissions.UserEdit,
             Permissions.WorkshopEdit, Permissions.WorkshopRemove, Permissions.WorkshopAddNew,
+        };
+
+        private static readonly IEnumerable<Permissions> SeedProviderAdminPermissions = new List<Permissions>
+        {
+            Permissions.ImpersonalDataRead,
+            Permissions.AddressAddNew, Permissions.AddressEdit, Permissions.AddressRead, Permissions.AddressRemove,
+            Permissions.ApplicationRead, Permissions.ApplicationEdit,
+            Permissions.ProviderAdmins,
+            Permissions.TeacherAddNew, Permissions.TeacherEdit, Permissions.TeacherRemove, Permissions.TeacherRead,
+            Permissions.UserRead, Permissions.UserEdit,
+            Permissions.WorkshopEdit, Permissions.WorkshopAddNew,
         };
 
         private static readonly IEnumerable<Permissions> SeedParentPermissions = new List<Permissions>
@@ -51,6 +62,9 @@ namespace OutOfSchool.Common.PermissionsModule
 
                 case "provider":
                     return SeedProviderPermissions.PackPermissionsIntoString();
+
+                case "provideradmin":
+                    return SeedProviderAdminPermissions.PackPermissionsIntoString();
 
                 case "parent":
                     return SeedParentPermissions.PackPermissionsIntoString();

--- a/OutOfSchool/OutOfSchool.DataAccess/Extensions/ModelBuilderExtension.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Extensions/ModelBuilderExtension.cs
@@ -79,7 +79,15 @@ namespace OutOfSchool.Services.Extensions
                     RoleName = Role.Parent.ToString(),
                     PackedPermissions = PermissionsSeeder.SeedPermissions(Role.Parent.ToString()),
                     Description = "parent permissions",
-                });
+                },
+                new PermissionsForRole
+                {
+                    Id = 4,
+                    RoleName = nameof(Role.Provider) + nameof(Role.Admin),
+                    PackedPermissions = PermissionsSeeder.SeedPermissions(nameof(Role.Provider) + nameof(Role.Admin)),
+                    Description = "provider admin permissions",
+                }
+                );
         }
 
         /// <summary>

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/ProviderAdminConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/ProviderAdminConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace OutOfSchool.Services.Models.Configurations
+{
+    internal class ProviderAdminConfiguration : IEntityTypeConfiguration<ProviderAdmin>
+    {
+        public void Configure(EntityTypeBuilder<ProviderAdmin> builder)
+        {
+            builder.HasKey(x => x.UserId);
+
+            builder.Property(x => x.ProviderId)
+                .IsRequired();
+
+            builder.Property(x => x.IsDeputy)
+                .IsRequired();
+
+            builder.HasOne(x => x.Provider)
+                .WithMany(x => x.ProviderAdmins)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            builder.HasMany(x => x.ManagedWorkshops)
+                .WithMany(x => x.ProviderAdmins);
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/WorkshopConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/WorkshopConfiguration.cs
@@ -22,6 +22,9 @@ namespace OutOfSchool.Services.Models.Configurations
                 .WithMany(x => x.Workshops)
                 // Note: cascade delete causes circular dependency issue
                 .OnDelete(DeleteBehavior.NoAction);
+
+            builder.HasMany(x => x.ProviderAdmins)
+                .WithMany(x => x.ManagedWorkshops);
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Provider.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Provider.cs
@@ -99,5 +99,7 @@ namespace OutOfSchool.Services.Models
         public long? InstitutionStatusId { get; set; }
 
         public virtual InstitutionStatus InstitutionStatus { get; set; }
+
+        public virtual ICollection<ProviderAdmin> ProviderAdmins { get; set; }
     }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ProviderAdmin.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ProviderAdmin.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OutOfSchool.Services.Models
+{
+    public class ProviderAdmin
+    {
+        public string UserId { get; set; }
+
+        public Guid ProviderId { get; set; }
+
+        public virtual Provider Provider { get; set; }
+
+        // we will use it to check
+        // if provider admin is able to access related to his provider objects
+        // "true" gives access to all related with base provider workshops.
+        // "false" executes further inspection into admins-to-workshops relations
+        public bool IsDeputy { get; set; }
+        public virtual List<Workshop> ManagedWorkshops { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/User.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/User.cs
@@ -28,5 +28,11 @@ namespace OutOfSchool.Services.Models
         public string Role { get; set; }
 
         public bool IsRegistered { get; set; }
+
+        // If the flag is set, that user can no longer do anything to website.
+        public bool IsEnabled { get; set; }
+
+        // for permissions managing at login and check if user is original provider or its admin
+        public bool IsDerived { get; set; } = false;
     }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -111,6 +111,8 @@ namespace OutOfSchool.Services.Models
 
         public virtual Class Class { get; set; }
 
+        public virtual List<ProviderAdmin> ProviderAdmins { get; set; }
+
         public virtual List<Teacher> Teachers { get; set; }
 
         public virtual List<Application> Applications { get; set; }

--- a/OutOfSchool/OutOfSchool.DataAccess/OutOfSchoolDbContext.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/OutOfSchoolDbContext.cs
@@ -24,6 +24,8 @@ namespace OutOfSchool.Services
 
         public DbSet<Provider> Providers { get; set; }
 
+        public DbSet<ProviderAdmin> ProviderAdmins { get; set; }
+
         public DbSet<ChatRoomWorkshop> ChatRoomWorkshops { get; set; }
 
         public DbSet<ChatMessageWorkshop> ChatMessageWorkshops { get; set; }
@@ -62,10 +64,6 @@ namespace OutOfSchool.Services
 
         public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
 
-        public DbSet<InformationAboutPortal> InformationAboutPortal { get; set; }
-
-        public DbSet<ElasticsearchSyncRecord> ElasticsearchSyncRecords { get; set; }
-
         public async Task<int> CompleteAsync() => await this.SaveChangesAsync();
 
         public int Complete() => this.SaveChanges();
@@ -83,6 +81,7 @@ namespace OutOfSchool.Services
             builder.ApplyConfiguration(new ChatRoomWorkshopConfiguration());
             builder.ApplyConfiguration(new ChildConfiguration());
             builder.ApplyConfiguration(new ProviderConfiguration());
+            builder.ApplyConfiguration(new ProviderAdminConfiguration());
             builder.ApplyConfiguration(new WorkshopConfiguration());
             builder.ApplyConfiguration(new WorkshopImagesConfiguration());
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/EntityRepositoryBase.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/EntityRepositoryBase.cs
@@ -43,24 +43,23 @@ namespace OutOfSchool.Services.Repository
         public virtual async Task<TValue> RunInTransaction(Func<Task<TValue>> operation)
         {
             var executionStrategy = dbContext.Database.CreateExecutionStrategy();
+            return await executionStrategy.Execute(async () =>
+            {
+                using IDbContextTransaction transaction = await dbContext.Database.BeginTransactionAsync();
 
-            TValue result = null;
-            await executionStrategy.ExecuteAsync(
-                async () =>
+                try
                 {
-                    await using IDbContextTransaction transaction = await dbContext.Database.BeginTransactionAsync();
-                    try
-                    {
-                        result = await operation().ConfigureAwait(false);
-                        await transaction.CommitAsync().ConfigureAwait(false);
-                    }
-                    catch (Exception)
-                    {
-                        await transaction.RollbackAsync().ConfigureAwait(false);
-                        throw;
-                    }
-                });
-            return result;
+                    var result = await operation().ConfigureAwait(false);
+                    await transaction.CommitAsync().ConfigureAwait(false);
+
+                    return result;
+                }
+                catch (Exception)
+                {
+                    await transaction.RollbackAsync().ConfigureAwait(false);
+                    throw;
+                }
+            });
         }
 
         /// <inheritdoc/>

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/IProviderAdminRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/IProviderAdminRepository.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using OutOfSchool.Services.Models;
+
+namespace OutOfSchool.Services.Repository
+{
+    public interface IProviderAdminRepository : IEntityRepository<ProviderAdmin>
+    {
+        Task<bool> IsExistProviderAdminDeputyWithUserIdAsync(Guid providerId, string userId);
+
+        Task<bool> IsExistProviderWithUserIdAsync(Guid providerId, string userId);
+
+        Task<int> GetNumberProviderAdminsAsync(Guid providerId);
+
+        Task<ProviderAdmin> GetByIdAsync(string id, Guid providerId);
+    }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/ProviderAdminRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/ProviderAdminRepository.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+
+using OutOfSchool.Services.Models;
+
+namespace OutOfSchool.Services.Repository
+{
+    public class ProviderAdminRepository : EntityRepository<ProviderAdmin>, IProviderAdminRepository
+    {
+        private readonly OutOfSchoolDbContext db;
+
+        public ProviderAdminRepository(OutOfSchoolDbContext dbContext)
+         : base(dbContext)
+        {
+            db = dbContext;
+        }
+
+        public async Task<ProviderAdmin> GetByIdAsync(string id, Guid providerId)
+        {
+            return await db.ProviderAdmins
+                .Where(pa => pa.ProviderId == providerId)
+                .SingleOrDefaultAsync(pa => pa.UserId == id);
+        }
+
+        public async Task<bool> IsExistProviderAdminDeputyWithUserIdAsync(Guid providerId, string userId)
+        {
+            var providerAdmin = await GetByIdAsync(userId, providerId);
+
+            return providerAdmin != null && providerAdmin.IsDeputy == true;
+        }
+
+        public async Task<bool> IsExistProviderWithUserIdAsync(Guid providerId, string userId)
+        {
+            var provider = await db.Providers
+                .SingleOrDefaultAsync(p => p.UserId == userId);
+
+            return provider != null;
+        }
+
+        public async Task<int> GetNumberProviderAdminsAsync(Guid providerId)
+        {
+            return await db.ProviderAdmins
+                .CountAsync(pa => pa.ProviderId == providerId);
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.IdentityServer/Controllers/AuthController.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Controllers/AuthController.cs
@@ -152,6 +152,14 @@ namespace OutOfSchool.IdentityServer.Controllers
             {
                 logger.LogInformation($"{path} Successfully logged. User(id): {userId}.");
 
+                user.LastLogin = DateTimeOffset.UtcNow;
+                var lastLoginResult = await userManager.UpdateAsync(user);
+                if (!lastLoginResult.Succeeded)
+                {
+                    throw new InvalidOperationException($"Unexpected error occurred setting the last login date" +
+                        $" ({lastLoginResult.ToString()}) for user with ID '{user.Id}'.");
+                }
+
                 return string.IsNullOrEmpty(model.ReturnUrl) ? Redirect(nameof(Login)) : Redirect(model.ReturnUrl);
             }
 

--- a/OutOfSchool/OutOfSchool.IdentityServer/Controllers/AuthController.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Controllers/AuthController.cs
@@ -137,6 +137,15 @@ namespace OutOfSchool.IdentityServer.Controllers
                 });
             }
 
+            var user = await userManager.FindByEmailAsync(model.Username);
+
+            if (user != null && !user.IsEnabled)
+            {
+                logger.LogInformation($"{path} User is blocked. Login was failed.");
+
+                return BadRequest();
+            }
+
             var result = await signInManager.PasswordSignInAsync(model.Username, model.Password, false, false);
 
             if (result.Succeeded)
@@ -169,10 +178,10 @@ namespace OutOfSchool.IdentityServer.Controllers
         /// <param name="returnUrl"> URL used to redirect user back to client.</param>
         /// <param name="providerRegistration"> bool used to prepare page for provider registration.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        [HttpGet]
         public IActionResult Register(string returnUrl = "Login", bool? providerRegistration = null)
         {
-            return View(new RegisterViewModel { ReturnUrl = returnUrl, ProviderRegistration = providerRegistration ?? GetProviderRegistrationFromUri(returnUrl) });
+            return View(new RegisterViewModel { ReturnUrl = returnUrl, ProviderRegistration = providerRegistration
+                ?? GetProviderRegistrationFromUri(returnUrl) });
         }
 
         /// <summary>
@@ -217,6 +226,7 @@ namespace OutOfSchool.IdentityServer.Controllers
                 CreatingTime = DateTimeOffset.UtcNow,
                 Role = model.Role,
                 IsRegistered = false,
+                IsEnabled = true,
             };
 
             try

--- a/OutOfSchool/OutOfSchool.IdentityServer/Controllers/AuthController.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Controllers/AuthController.cs
@@ -186,10 +186,14 @@ namespace OutOfSchool.IdentityServer.Controllers
         /// <param name="returnUrl"> URL used to redirect user back to client.</param>
         /// <param name="providerRegistration"> bool used to prepare page for provider registration.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        [HttpGet]
         public IActionResult Register(string returnUrl = "Login", bool? providerRegistration = null)
         {
-            return View(new RegisterViewModel { ReturnUrl = returnUrl, ProviderRegistration = providerRegistration
-                ?? GetProviderRegistrationFromUri(returnUrl) });
+            return View(new RegisterViewModel
+            {
+                ReturnUrl = returnUrl, ProviderRegistration = providerRegistration
+                ?? GetProviderRegistrationFromUri(returnUrl),
+            });
         }
 
         /// <summary>

--- a/OutOfSchool/OutOfSchool.IdentityServer/Controllers/ProviderAdminController.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Controllers/ProviderAdminController.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+using OutOfSchool.Common;
+using OutOfSchool.Common.Extensions;
+using OutOfSchool.Common.Models;
+using OutOfSchool.Common.PermissionsModule;
+using OutOfSchool.IdentityServer.Services.Intefaces;
+
+namespace OutOfSchool.IdentityServer.Controllers
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    [Authorize(AuthenticationSchemes = "Bearer")]
+    public class ProviderAdminController : Controller
+    {
+        private readonly ILogger<ProviderAdminController> logger;
+        private readonly IProviderAdminService providerAdminService;
+
+        private string path;
+        private string userId;
+
+        public ProviderAdminController(
+            ILogger<ProviderAdminController> logger,
+            IProviderAdminService providerAdminService)
+        {
+            this.logger = logger;
+            this.providerAdminService = providerAdminService;
+        }
+
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            path = $"{context.HttpContext.Request.Path.Value}[{context.HttpContext.Request.Method}]";
+            userId = User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub);
+        }
+
+        [HttpPost]
+        public async Task<ResponseDto> Create(CreateProviderAdminDto providerAdminDto)
+        {
+            logger.LogDebug($"Received request " +
+                $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {userId}");
+
+            return await providerAdminService
+                .CreateProviderAdminAsync(providerAdminDto, Request, Url, path, userId);
+        }
+
+        [HttpDelete]
+        [Authorize(Roles = "provider")]
+        public async Task<ResponseDto> Delete(DeleteProviderAdminDto deleteProviderAdminDto)
+        {
+            if (deleteProviderAdminDto is null)
+            {
+                throw new ArgumentNullException(nameof(deleteProviderAdminDto));
+            }
+
+            logger.LogDebug($"Received request " +
+                $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {userId}");
+
+            return await providerAdminService
+                .DeleteProviderAdminAsync(deleteProviderAdminDto, Request, path, userId);
+        }
+
+        [HttpPut]
+        [Authorize(Roles = "provider")]
+        public async Task<ResponseDto> Block(BlockProviderAdminDto blockProviderAdminDto)
+        {
+            logger.LogDebug($"Received request " +
+                $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {userId}");
+
+            return await providerAdminService
+                .BlockProviderAdminAsync(blockProviderAdminDto, Request, path, userId);
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.IdentityServer/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/MappingProfile.cs
@@ -1,0 +1,19 @@
+﻿using AutoMapper;
+using OutOfSchool.Common.Models;
+using OutOfSchool.Services.Enums;
+using OutOfSchool.Services.Models;
+
+namespace OutOfSchool.IdentityServer
+{
+    public class MappingProfile : Profile
+    {
+        public MappingProfile()
+        {
+            CreateMap<CreateProviderAdminDto, User>()
+                .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.Email));
+
+            CreateMap<CreateProviderAdminDto, ProviderAdmin>()
+                .ForMember(dest => dest.ManagedWorkshops, opt => opt.Ignore());
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.IdentityServer/OutOfSchool.IdentityServer.csproj
+++ b/OutOfSchool/OutOfSchool.IdentityServer/OutOfSchool.IdentityServer.csproj
@@ -1,21 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>23768b69-757e-4a20-894f-dcf7181971ca</UserSecretsId>
   </PropertyGroup>
-
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\StyleCopAnalyzersRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Data\Migrations\OutOfSchoolMigrations\20211101082648_InitialMigration.cs" />
     <Compile Remove="Data\Migrations\OutOfSchoolMigrations\20211101082648_InitialMigration.Designer.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+        <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="IdentityModel" Version="5.0.0" />
     <PackageReference Include="IdentityServer4" Version="4.1.1" />
@@ -41,13 +38,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OutOfSchool.DataAccess\OutOfSchool.DataAccess.csproj" />
     <ProjectReference Include="..\OutOfSchool.EmailSender\OutOfSchool.EmailSender.csproj" />
     <ProjectReference Include="..\OutOfSchool.Common\OutOfSchool.Common.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Content Remove="stylecop.json" />
     <AdditionalFiles Include="stylecop.json">
@@ -56,14 +51,12 @@
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </AdditionalFiles>
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="Data\Migrations\IdentityServer\CertificateDb\" />
     <Folder Include="Data\Migrations\IdentityServer\ConfigurationDb\" />
     <Folder Include="Data\Migrations\IdentityServer\PersistedGrantDb\" />
     <Folder Include="Data\Migrations\OutOfSchoolMigrations\" />
   </ItemGroup>
-
   <ProjectExtensions><VisualStudio><UserProperties appsettings_1development_1json__JsonSchema="https://json.schemastore.org/appsettings" appsettings_1release_1json__JsonSchema="https://json.schemastore.org/appsettings" /></VisualStudio></ProjectExtensions>
 <ItemGroup>
     <Watch Include="wwwroot/**" />

--- a/OutOfSchool/OutOfSchool.IdentityServer/ProfileService.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/ProfileService.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Identity;
 using OutOfSchool.Common;
 using OutOfSchool.Common.Extensions;
 using OutOfSchool.Common.PermissionsModule;
+using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Repository;
 
@@ -17,19 +18,24 @@ namespace OutOfSchool.IdentityServer
     public class ProfileService : IProfileService
     {
         private readonly UserManager<User> userManager;
-        private readonly IEntityRepository<PermissionsForRole> repository;
+        private readonly IEntityRepository<PermissionsForRole> permissionsForRolesRepository;
+        private readonly IProviderAdminRepository providerAdminsRepository;
 
-        public ProfileService(UserManager<User> userManager, IEntityRepository<PermissionsForRole> repository)
+        public ProfileService(
+            UserManager<User> userManager,
+            IEntityRepository<PermissionsForRole> permissionsForRolesRepository,
+            IProviderAdminRepository providerAdminsRepository)
         {
             this.userManager = userManager;
-            this.repository = repository;
+            this.permissionsForRolesRepository = permissionsForRolesRepository;
+            this.providerAdminsRepository = providerAdminsRepository;
         }
 
         public async Task GetProfileDataAsync(ProfileDataRequestContext context)
         {
             var nameClaim = context.Subject.Claims.FirstOrDefault(claim => claim.Type == "name");
             var roleClaim = context.Subject.Claims.FirstOrDefault(claim => claim.Type == "role");
-            var permissionsClaim = new Claim(IdentityResourceClaimsTypes.Permissions, await GetPermissionsForRole(roleClaim.Value));
+            var permissionsClaim = new Claim(IdentityResourceClaimsTypes.Permissions, await GetPermissionsForUser(nameClaim.Value,roleClaim.Value));
             var claims = new List<Claim>
             {
                 nameClaim,
@@ -48,15 +54,27 @@ namespace OutOfSchool.IdentityServer
         }
 
         // get's list of permissions for current user's role from db
-        private async Task<string> GetPermissionsForRole(string roleName)
+        private async Task<string> GetPermissionsForUser(string userName, string roleName)
         {
-            var permissionsForRole = (await repository.GetByFilter(p => p.RoleName == roleName)).FirstOrDefault();
-            if (permissionsForRole == null)
+            var userToLogin = await userManager.FindByNameAsync(userName);
+
+            if (userToLogin.Role == nameof(Role.Provider) && userToLogin.IsDerived)
+            {
+                // Provider-Derived set of permissions in DB excludes not allowed actions
+                // for provider admins - workshop deletion, all related to provider-level actions
+                roleName += "-Derived";
+            }
+
+            var permissionsForUser = (await permissionsForRolesRepository
+                .GetByFilter(p => p.RoleName == roleName))
+                .FirstOrDefault().PackedPermissions;
+
+            // action when no permissions for user's role existes in DB
+            if (permissionsForUser == null)
             {
                 return new List<Permissions>() { Permissions.NotSet }.PackPermissionsIntoString();
             }
-
-            return permissionsForRole.PackedPermissions;
+            return permissionsForUser;
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.IdentityServer/Services/Interfaces/IProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Services/Interfaces/IProviderAdminService.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+using OutOfSchool.Common;
+using OutOfSchool.Common.Models;
+
+namespace OutOfSchool.IdentityServer.Services.Intefaces
+{
+    public interface IProviderAdminService
+    {
+        Task<ResponseDto> CreateProviderAdminAsync(
+            CreateProviderAdminDto providerAdminDto,
+            HttpRequest request,
+            IUrlHelper url,
+            string path,
+            string userId);
+
+        Task<ResponseDto> DeleteProviderAdminAsync(
+            DeleteProviderAdminDto deleteProviderAdminDto,
+            HttpRequest request,
+            string path,
+            string userId);
+
+        Task<ResponseDto> BlockProviderAdminAsync(
+            BlockProviderAdminDto blockProviderAdminDto,
+            HttpRequest request,
+            string path,
+            string userId);
+    }
+}

--- a/OutOfSchool/OutOfSchool.IdentityServer/Services/Password/CryptoRandom.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Services/Password/CryptoRandom.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Security.Cryptography;
+
+using IdentityModel;
+
+namespace OutOfSchool.IdentityServer.Services.Password
+{
+    /// <summary>
+    /// A class that mimics the standard Random class in the .NET Framework - but uses a random number generator internally.
+    /// Taken from (ref.: https://github.com/Darkseal/PasswordGenerator/blob/master/CryptoRandom.cs ).
+    /// IdentityModel (ref.: https://github.com/IdentityModel/IdentityModel/ ).
+    /// </summary>
+    internal class CryptoRandom : Random
+    {
+        private static readonly RandomNumberGenerator Rng = RandomNumberGenerator.Create();
+        private readonly byte[] uint32Buffer = new byte[4];
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CryptoRandom"/> class.
+        /// </summary>
+        public CryptoRandom()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CryptoRandom"/> class.
+        /// </summary>
+        /// <param name="ignoredSeed">seed (ignored)</param>
+        public CryptoRandom(int ignoredSeed)
+        {
+        }
+
+        /// <summary>
+        /// Output format for unique IDs.
+        /// </summary>
+        public enum OutputFormat
+        {
+            /// <summary>
+            /// URL-safe Base64.
+            /// </summary>
+            Base64Url,
+
+            /// <summary>
+            /// Base64.
+            /// </summary>
+            Base64,
+
+            /// <summary>
+            /// Hex.
+            /// </summary>
+            Hex,
+        }
+
+        /// <summary>
+        /// Creates a random key byte array.
+        /// </summary>
+        /// <param name="length">The length.</param>
+        /// <returns>Random key byte array.</returns>
+        public static byte[] CreateRandomKey(int length)
+        {
+            var bytes = new byte[length];
+            Rng.GetBytes(bytes);
+
+            return bytes;
+        }
+
+        /// <summary>
+        /// Creates a URL safe unique identifier.
+        /// </summary>
+        /// <param name="length">The length.</param>
+        /// <param name="format">The output format</param>
+        /// <returns>URL safe unique identifier.</returns>
+        public static string CreateUniqueId(int length = 32, OutputFormat format = OutputFormat.Base64Url)
+        {
+            var bytes = CreateRandomKey(length);
+
+            switch (format)
+            {
+                case OutputFormat.Base64Url:
+                    return Base64Url.Encode(bytes);
+                case OutputFormat.Base64:
+                    return Convert.ToBase64String(bytes);
+                case OutputFormat.Hex:
+                    return BitConverter.ToString(bytes).Replace("-", "");
+                default:
+                    throw new ArgumentException("Invalid output format", nameof(format));
+            }
+        }
+
+        /// <summary>
+        /// Returns a nonnegative random number.
+        /// </summary>
+        /// <returns>
+        /// A 32-bit signed integer greater than or equal to zero and less than <see cref="F:System.Int32.MaxValue"/>.
+        /// </returns>
+        public override int Next()
+        {
+            Rng.GetBytes(uint32Buffer);
+            return BitConverter.ToInt32(uint32Buffer, 0) & 0x7FFFFFFF;
+        }
+
+        /// <summary>
+        /// Returns a nonnegative random number less than the specified maximum.
+        /// </summary>
+        /// <param name="maxValue">The exclusive upper bound of the random number to be generated. <paramref name="maxValue"/> must be greater than or equal to zero.</param>
+        /// <returns>
+        /// A 32-bit signed integer greater than or equal to zero, and less than <paramref name="maxValue"/>; that is, the range of return values ordinarily includes zero but not <paramref name="maxValue"/>. However, if <paramref name="maxValue"/> equals zero, <paramref name="maxValue"/> is returned.
+        /// </returns>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <paramref name="maxValue"/> is less than zero.
+        /// </exception>
+        public override int Next(int maxValue)
+        {
+            if (maxValue < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxValue));
+            }
+
+            return Next(0, maxValue);
+        }
+
+        /// <summary>
+        /// Returns a random number within a specified range.
+        /// </summary>
+        /// <param name="minValue">The inclusive lower bound of the random number returned.</param>
+        /// <param name="maxValue">The exclusive upper bound of the random number returned. <paramref name="maxValue"/> must be greater than or equal to <paramref name="minValue"/>.</param>
+        /// <returns>
+        /// A 32-bit signed integer greater than or equal to <paramref name="minValue"/> and less than <paramref name="maxValue"/>; that is, the range of return values includes <paramref name="minValue"/> but not <paramref name="maxValue"/>. If <paramref name="minValue"/> equals <paramref name="maxValue"/>, <paramref name="minValue"/> is returned.
+        /// </returns>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <paramref name="minValue"/> is greater than <paramref name="maxValue"/>.
+        /// </exception>
+        public override int Next(int minValue, int maxValue)
+        {
+            if (minValue > maxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minValue));
+            }
+
+            if (minValue == maxValue)
+            {
+                return minValue;
+            }
+
+            long diff = maxValue - minValue;
+
+            while (true)
+            {
+                Rng.GetBytes(uint32Buffer);
+                uint rand = BitConverter.ToUInt32(uint32Buffer, 0);
+
+                long max = 1 + (long)uint.MaxValue;
+                long remainder = max % diff;
+                if (rand < max - remainder)
+                {
+                    return (int)(minValue + (rand % diff));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a random number between 0.0 and 1.0.
+        /// </summary>
+        /// <returns>
+        /// A double-precision floating point number greater than or equal to 0.0, and less than 1.0.
+        /// </returns>
+        public override double NextDouble()
+        {
+            Rng.GetBytes(uint32Buffer);
+            uint rand = BitConverter.ToUInt32(uint32Buffer, 0);
+            return rand / (1.0 + uint.MaxValue);
+        }
+
+        /// <summary>
+        /// Fills the elements of a specified array of bytes with random numbers.
+        /// </summary>
+        /// <param name="buffer">An array of bytes to contain random numbers.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        /// <paramref name="buffer"/> is null.
+        /// </exception>
+        public override void NextBytes(byte[] buffer)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            Rng.GetBytes(buffer);
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.IdentityServer/Services/Password/PasswordGenerator.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Services/Password/PasswordGenerator.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.AspNetCore.Identity;
+
+namespace OutOfSchool.IdentityServer.Services.Password
+{
+    public static class PasswordGenerator
+    {
+        /// <summary>
+        /// Generates a Random Password
+        /// respecting the given strength requirements.
+        /// </summary>
+        /// <param name="passwordOptions">A valid PasswordOptions object
+        /// containing the password strength requirements.</param>
+        /// <returns>A random password</returns>
+        public static string GenerateRandomPassword(PasswordOptions passwordOptions)
+        {
+            string[] randomChars = new[]
+            {
+                "ABCDEFGHJKLMNOPQRSTUVWXYZ",    // uppercase
+                "abcdefghijkmnopqrstuvwxyz",    // lowercase
+                "0123456789",                   // digits
+                "!@$?_-",                       // non-alphanumeric
+            };
+
+            CryptoRandom rand = new CryptoRandom();
+
+            List<char> chars = new List<char>();
+
+            if (passwordOptions.RequireUppercase)
+            {
+                chars.Insert(
+                    rand.Next(0, chars.Count),
+                    randomChars[0][rand.Next(0, randomChars[0].Length)]);
+            }
+
+            if (passwordOptions.RequireLowercase)
+            {
+                chars.Insert(
+                    rand.Next(0, chars.Count),
+                    randomChars[1][rand.Next(0, randomChars[1].Length)]);
+            }
+
+            if (passwordOptions.RequireDigit)
+            {
+                chars.Insert(
+                    rand.Next(0, chars.Count),
+                    randomChars[2][rand.Next(0, randomChars[2].Length)]);
+            }
+
+            if (passwordOptions.RequireNonAlphanumeric)
+            {
+                chars.Insert(
+                    rand.Next(0, chars.Count),
+                    randomChars[3][rand.Next(0, randomChars[3].Length)]);
+            }
+
+            for (int i = chars.Count; i < passwordOptions.RequiredLength
+                || chars.Distinct().Count() < passwordOptions.RequiredUniqueChars; i++)
+            {
+                string rcs = randomChars[rand.Next(0, randomChars.Length)];
+                chars.Insert(
+                    rand.Next(0, chars.Count),
+                    rcs[rand.Next(0, rcs.Length)]);
+            }
+
+            return new string(chars.ToArray());
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.IdentityServer/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Services/ProviderAdminService.cs
@@ -77,9 +77,6 @@ namespace OutOfSchool.IdentityServer.Services
                             user.IsEnabled = true;
                             user.Role = nameof(Role.Provider).ToLower();
 
-                            // TODO: Delete before final commit
-                            user.MiddleName = password;
-
                             IdentityResult result = await userManager.CreateAsync(user, password);
 
                             if (!result.Succeeded)

--- a/OutOfSchool/OutOfSchool.IdentityServer/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Services/ProviderAdminService.cs
@@ -1,0 +1,298 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+using AutoMapper;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using OutOfSchool.Common;
+using OutOfSchool.Common.Models;
+using OutOfSchool.EmailSender;
+using OutOfSchool.IdentityServer.Services.Intefaces;
+using OutOfSchool.IdentityServer.Services.Password;
+using OutOfSchool.Services;
+using OutOfSchool.Services.Enums;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Services.Repository;
+
+namespace OutOfSchool.IdentityServer.Services
+{
+    public class ProviderAdminService : IProviderAdminService
+    {
+        private readonly IEmailSender emailSender;
+        private readonly IMapper mapper;
+        private readonly ILogger<ProviderAdminService> logger;
+        private readonly IProviderAdminRepository providerAdminRepository;
+
+        private readonly UserManager<User> userManager;
+        private readonly OutOfSchoolDbContext context;
+        private readonly ResponseDto response;
+
+        public ProviderAdminService(
+            IMapper mapper,
+            IProviderAdminRepository providerAdminRepository,
+            ILogger<ProviderAdminService> logger,
+            IEmailSender emailSender,
+            UserManager<User> userManager,
+            OutOfSchoolDbContext context)
+        {
+            this.mapper = mapper;
+            this.userManager = userManager;
+            this.context = context;
+            this.providerAdminRepository = providerAdminRepository;
+            this.logger = logger;
+            this.emailSender = emailSender;
+            response = new ResponseDto();
+        }
+
+        public async Task<ResponseDto> CreateProviderAdminAsync(
+            CreateProviderAdminDto providerAdminDto,
+            HttpRequest request,
+            IUrlHelper url,
+            string path,
+            string userId)
+        {
+            var user = mapper.Map<User>(providerAdminDto);
+
+            var password = PasswordGenerator
+                .GenerateRandomPassword(userManager.Options.Password);
+
+            user.MiddleName = password;
+
+            var executionStrategy = context.Database.CreateExecutionStrategy();
+            await executionStrategy.Execute(async () =>
+                {
+                    using (var transaction = context.Database.BeginTransaction())
+                    {
+                        try
+                        {
+                            user.IsDerived = true;
+                            user.IsEnabled = true;
+                            user.Role = nameof(Role.Provider).ToLower();
+
+                            // TODO: Delete before final commit
+                            user.MiddleName = password;
+
+                            IdentityResult result = await userManager.CreateAsync(user, password);
+
+                            if (!result.Succeeded)
+                            {
+                                transaction.Rollback();
+
+                                logger.LogError($"{path} Error happened while creation ProviderAdmin. Request(id): {request.Headers["X-Request-ID"]}" +
+                                    $"User(id): {userId}" +
+                                    $"{string.Join(System.Environment.NewLine, result.Errors.Select(e => e.Description))}");
+
+                                response.IsSuccess = false;
+                                response.HttpStatusCode = HttpStatusCode.InternalServerError;
+
+                                return response;
+                            }
+
+                            var roleAssignResult = await userManager.AddToRoleAsync(user, user.Role);
+
+                            if (!roleAssignResult.Succeeded)
+                            {
+                                transaction.Rollback();
+
+                                logger.LogError($"{path} Error happened while adding role to user. Request(id): {request.Headers["X-Request-ID"]}" +
+                                    $"User(id): {userId}" +
+                                    $"{string.Join(System.Environment.NewLine, result.Errors.Select(e => e.Description))}");
+
+                                response.IsSuccess = false;
+                                response.HttpStatusCode = HttpStatusCode.InternalServerError;
+
+                                return response;
+                            }
+
+                            providerAdminDto.UserId = user.Id;
+
+                            var providerAdmin = mapper.Map<ProviderAdmin>(providerAdminDto);
+                            providerAdmin.ManagedWorkshops = !providerAdmin.IsDeputy
+                                 ?
+                                 context.Workshops.Where(w => providerAdminDto.ManagedWorkshopIds.Contains(w.Id)).ToList()
+                                 :
+
+                                 // we create empty list, because deputy are not connected with each workshop, but to all related to provider
+                                 new List<Workshop>();
+
+                            await providerAdminRepository.Create(providerAdmin)
+                                    .ConfigureAwait(false);
+
+                            response.IsSuccess = true;
+                            response.Result = providerAdminDto;
+
+                            transaction.Commit();
+
+                            logger.LogInformation($"ProviderAdmin(id):{providerAdminDto.UserId} was successfully created by " +
+                                $"User(id): {userId}. Request(id): {request.Headers["X-Request-ID"]}");
+
+                            // TODO:
+                            // Endpoint with sending new password
+
+                            // TODO:
+                            // Use template instead
+                            var token = await userManager.GenerateEmailConfirmationTokenAsync(user);
+                            var confirmationLink = url.Action("EmailConfirmation", "Account", new { userId = user.Id, token = token }, request.Scheme);
+                            var subject = "Запрошення!";
+                            var htmlMessage = $"Для реєстрації на платформі перейдіть " +
+                                $"за посиланням та заповність ваші данні в особистому кабінеті.<br>" +
+                                $"{confirmationLink}<br><br>" +
+                                $"Логін: {user.Email}<br>" +
+                                $"Пароль: {password}";
+
+                            await emailSender.SendAsync(user.Email, subject, htmlMessage);
+
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            transaction.Rollback();
+
+                            logger.LogError($"{path} {ex.Message} User(id): {userId}.");
+
+                            response.IsSuccess = false;
+                            response.HttpStatusCode = HttpStatusCode.InternalServerError;
+                            return response;
+                        }
+                    }
+                });
+            return response;
+        }
+
+        public async Task<ResponseDto> DeleteProviderAdminAsync(
+            DeleteProviderAdminDto deleteProviderAdminDto,
+            HttpRequest request,
+            string path,
+            string userId)
+        {
+            var executionStrategy = context.Database.CreateExecutionStrategy();
+            await executionStrategy.Execute(async () =>
+            {
+                using (var transaction = context.Database.BeginTransaction())
+                {
+                    try
+                    {
+                        var providerAdmin = context.ProviderAdmins
+                            .SingleOrDefault(pa => pa.UserId == deleteProviderAdminDto.ProviderAdminId);
+
+                        if (providerAdmin is null)
+                        {
+                            response.IsSuccess = false;
+                            response.HttpStatusCode = HttpStatusCode.NotFound;
+
+                            logger.LogError($"{path} ProviderAdmin(id) {deleteProviderAdminDto.ProviderAdminId} not found. " +
+                                $"Request(id): {request.Headers["X-Request-ID"]}" +
+                                    $"User(id): {userId}");
+                        }
+
+                        context.ProviderAdmins.Remove(providerAdmin);
+
+                        var user = await userManager.FindByIdAsync(deleteProviderAdminDto.ProviderAdminId);
+                        var result = await userManager.DeleteAsync(user);
+
+                        if (!result.Succeeded)
+                        {
+                            transaction.Rollback();
+
+                            logger.LogError($"{path} Error happened while deleting ProviderAdmin. Request(id): {request.Headers["X-Request-ID"]}" +
+                                $"User(id): {userId}" +
+                                $"{string.Join(System.Environment.NewLine, result.Errors.Select(e => e.Description))}");
+
+                            response.IsSuccess = false;
+                            response.HttpStatusCode = HttpStatusCode.InternalServerError;
+
+                            return response;
+                        }
+
+                        response.IsSuccess = true;
+                        response.HttpStatusCode = HttpStatusCode.OK;
+
+                        transaction.Commit();
+
+                        logger.LogInformation($"ProviderAdmin(id):{deleteProviderAdminDto.ProviderAdminId} was successfully deleted by " +
+                            $"User(id): {userId}. Request(id): {request.Headers["X-Request-ID"]}");
+
+                        return response;
+                    }
+                    catch (Exception ex)
+                    {
+                        transaction.Rollback();
+
+                        logger.LogError($"{path} Error happened while deleting ProviderAdmin. Request(id): {request.Headers["X-Request-ID"]}" +
+                                $"User(id): {userId} {ex.Message}");
+
+                        response.IsSuccess = false;
+                        response.HttpStatusCode = HttpStatusCode.InternalServerError;
+
+                        return response;
+                    }
+                }
+            });
+            return response;
+        }
+
+        public async Task<ResponseDto> BlockProviderAdminAsync(
+            BlockProviderAdminDto blockProviderAdminDto,
+            HttpRequest request,
+            string path,
+            string userId)
+        {
+            var user = await userManager.FindByIdAsync(blockProviderAdminDto.ProviderAdminId);
+
+            if (user is null)
+            {
+                response.IsSuccess = false;
+                response.HttpStatusCode = HttpStatusCode.NotFound;
+
+                logger.LogError($"{path} ProviderAdmin(id) {blockProviderAdminDto.ProviderAdminId} not found. " +
+                            $"Request(id): {request.Headers["X-Request-ID"]}" +
+                                $"User(id): {userId}");
+            }
+
+            user.IsEnabled = false;
+            var updateResult = await userManager.UpdateAsync(user);
+
+            if (!updateResult.Succeeded)
+            {
+                logger.LogError($"{path} Error happened while blocking ProviderAdmin. Request(id): {request.Headers["X-Request-ID"]}" +
+                            $"User(id): {userId}" +
+                            $"{string.Join(System.Environment.NewLine, updateResult.Errors.Select(e => e.Description))}");
+
+                response.IsSuccess = false;
+                response.HttpStatusCode = HttpStatusCode.InternalServerError;
+
+                return response;
+            }
+
+            var updateSecurityStamp = await userManager.UpdateSecurityStampAsync(user);
+
+            if (!updateResult.Succeeded)
+            {
+                logger.LogError($"{path} Error happened while updating security stamp. ProviderAdmin. Request(id): {request.Headers["X-Request-ID"]}" +
+                            $"User(id): {userId}" +
+                            $"{string.Join(System.Environment.NewLine, updateResult.Errors.Select(e => e.Description))}");
+
+                response.IsSuccess = false;
+                response.HttpStatusCode = HttpStatusCode.InternalServerError;
+
+                return response;
+            }
+
+            logger.LogInformation($"ProviderAdmin(id):{blockProviderAdminDto.ProviderAdminId} was successfully blocked by " +
+                        $"User(id): {userId}. Request(id): {request.Headers["X-Request-ID"]}");
+
+            response.IsSuccess = true;
+            response.HttpStatusCode = HttpStatusCode.OK;
+
+            return response;
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.IdentityServer/Startup.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Startup.cs
@@ -100,7 +100,6 @@ namespace OutOfSchool.IdentityServer
             })
                 .AddEntityFrameworkStores<OutOfSchoolDbContext>()
                 .AddDefaultTokenProviders();
-
             services.ConfigureApplicationCookie(c =>
             {
                 c.Cookie.Name = "IdentityServer.Cookie";

--- a/OutOfSchool/OutOfSchool.IdentityServer/Startup.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Startup.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -21,9 +22,12 @@ using Microsoft.Extensions.Hosting;
 using OutOfSchool.Common;
 using OutOfSchool.Common.Config;
 using OutOfSchool.Common.Extensions.Startup;
+using OutOfSchool.Common.PermissionsModule;
 using OutOfSchool.EmailSender;
 using OutOfSchool.IdentityServer.Config;
 using OutOfSchool.IdentityServer.KeyManagement;
+using OutOfSchool.IdentityServer.Services;
+using OutOfSchool.IdentityServer.Services.Intefaces;
 using OutOfSchool.Services;
 using OutOfSchool.Services.Extensions;
 using OutOfSchool.Services.Models;
@@ -76,14 +80,24 @@ namespace OutOfSchool.IdentityServer
 
             services.AddLocalization(options => options.ResourcesPath = "Resources");
 
-            services.AddIdentity<User, IdentityRole>(options =>
+            // TODO: Move authority to config
+            services.AddAuthentication("Bearer")
+                .AddIdentityServerAuthentication("Bearer", options =>
                 {
-                    options.Password.RequireDigit = false;
-                    options.Password.RequireLowercase = false;
-                    options.Password.RequireNonAlphanumeric = false;
-                    options.Password.RequireUppercase = false;
-                    options.Password.RequiredLength = 6;
-                })
+                    options.ApiName = "outofschoolapi";
+                    options.Authority = "http://localhost:5443";
+
+                    options.RequireHttpsMetadata = false;
+                });
+
+            services.AddIdentity<User, IdentityRole>(options =>
+            {
+                options.Password.RequireDigit = true;
+                options.Password.RequireLowercase = true;
+                options.Password.RequireNonAlphanumeric = true;
+                options.Password.RequireUppercase = true;
+                options.Password.RequiredLength = 8;
+            })
                 .AddEntityFrameworkStores<OutOfSchoolDbContext>()
                 .AddDefaultTokenProviders();
 
@@ -135,9 +149,12 @@ namespace OutOfSchool.IdentityServer
                 });
 
             services.AddProxy();
-
+            services.AddAutoMapper(typeof(MappingProfile));
             services.AddTransient<IParentRepository, ParentRepository>();
             services.AddTransient<IEntityRepository<PermissionsForRole>, EntityRepository<PermissionsForRole>>();
+            services.AddTransient<IProviderAdminRepository, ProviderAdminRepository>();
+            services.AddTransient<IProviderAdminService, ProviderAdminService>();
+
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/OutOfSchool/OutOfSchool.IdentityServer/db-scripts.txt
+++ b/OutOfSchool/OutOfSchool.IdentityServer/db-scripts.txt
@@ -6,3 +6,5 @@ dotnet ef database update -c OutOfSchoolDbContext
 
 dotnet ef database update -c PersistedGrantDbContext
 dotnet ef database update -c ConfigurationDbContext
+
+dotnet ef migrations remove -c OutOfSchoolDbContext

--- a/OutOfSchool/OutOfSchool.WebApi/Config/CommunicationConfig.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Config/CommunicationConfig.cs
@@ -1,0 +1,13 @@
+﻿namespace OutOfSchool.WebApi.Config
+{
+    public class CommunicationConfig
+    {
+        public const string Name = "Communication";
+
+        public int TimeoutInSeconds { get; set; }
+
+        public int MaxNumberOfRetries { get; set; }
+
+        public string ClientName { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Config/IdentityServerConfig.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Config/IdentityServerConfig.cs
@@ -1,0 +1,9 @@
+﻿namespace OutOfSchool.WebApi.Config
+{
+    public class IdentityServerConfig
+    {
+        public const string Name = "Identity";
+
+        public System.Uri Authority { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Config/ProviderAdminConfig.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Config/ProviderAdminConfig.cs
@@ -1,0 +1,9 @@
+﻿namespace OutOfSchool.WebApi.Config
+{
+    public class ProviderAdminConfig
+    {
+        public const string Name = "ProviderAdmin";
+
+        public int MaxNumberAdmins { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
@@ -145,12 +145,11 @@ namespace OutOfSchool.WebApi.Controllers
             return StatusCode((int)response.HttpStatusCode);
         }
 
-
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<ProviderAdminDto>))]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet("{providerId}")]
-        public async Task<IActionResult> GetRelatedProviderAdmins(Guid providerId, bool deputyOnly = false, bool assistantsOnly = false)
+        public async Task<IActionResult> GetRelatedProviderAdmins(Guid providerId, bool deputyOnly, bool assistantsOnly)
         {
             var relatedAdmins = await providerAdminService.GetRelatedProviderAdmins(providerId).ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+
+using OutOfSchool.Common;
+using OutOfSchool.Common.Extensions;
+using OutOfSchool.Common.Models;
+using OutOfSchool.Common.PermissionsModule;
+using OutOfSchool.WebApi.Services;
+
+namespace OutOfSchool.WebApi.Controllers
+{
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]/[action]")]
+    [HasPermission(Permissions.ProviderAdmins)]
+    public class ProviderAdminController : Controller
+    {
+        private readonly IProviderAdminService providerAdminService;
+        private readonly ILogger<ProviderAdminController> logger;
+        private string path;
+        private string userId;
+
+        public ProviderAdminController(
+            IProviderAdminService providerAdminService,
+            ILogger<ProviderAdminController> logger)
+        {
+            this.providerAdminService = providerAdminService;
+            this.logger = logger;
+        }
+
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            path = $"{context.HttpContext.Request.Path.Value}[{context.HttpContext.Request.Method}]";
+            userId = User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub);
+        }
+
+        /// <summary>
+        /// Method for creating new ProviderAdmin.
+        /// </summary>
+        /// <param name="providerAdmin">Entity to add.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(CreateProviderAdminDto))]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [HttpPost]
+        public async Task<ActionResult> Create(CreateProviderAdminDto providerAdmin)
+        {
+            logger.LogDebug($"{path} started. User(id): {userId}.");
+
+            if (!ModelState.IsValid)
+            {
+                logger.LogError($"Input data was not valid for User(id): {userId}");
+
+                return StatusCode(StatusCodes.Status422UnprocessableEntity);
+            }
+
+            var response = await providerAdminService.CreateProviderAdminAsync(
+                    userId,
+                    providerAdmin,
+                    await HttpContext.GetTokenAsync("access_token").ConfigureAwait(false))
+                        .ConfigureAwait(false);
+
+            if (response.IsSuccess)
+            {
+                CreateProviderAdminDto providerAdminDto = (CreateProviderAdminDto)response.Result;
+
+                logger.LogInformation($"Succesfully created ProviderAdmin(id): {providerAdminDto.UserId} by User(id): {userId}.");
+
+                return Ok(providerAdminDto);
+            }
+
+            return StatusCode((int)response.HttpStatusCode);
+        }
+
+        /// <summary>
+        /// Method for deleting ProviderAdmin.
+        /// </summary>
+        /// <param name="providerAdminId">Entity's id to delete.</param>
+        /// <param name="providerId">Provider's id for which operation perform.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [HttpDelete]
+        public async Task<ActionResult> Delete(string providerAdminId, Guid providerId)
+        {
+            logger.LogDebug($"{path} started. User(id): {userId}.");
+
+            var response = await providerAdminService.DeleteProviderAdminAsync(
+                    providerAdminId,
+                    userId,
+                    providerId,
+                    await HttpContext.GetTokenAsync("access_token").ConfigureAwait(false))
+                        .ConfigureAwait(false);
+
+            if (response.IsSuccess)
+            {
+                logger.LogInformation($"Succesfully deleted ProviderAdmin(id): {providerAdminId} by User(id): {userId}.");
+
+                return Ok();
+            }
+
+            return StatusCode((int)response.HttpStatusCode);
+        }
+
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [HttpPut]
+        public async Task<ActionResult> Block(string providerAdminId, Guid providerId)
+        {
+            logger.LogDebug($"{path} started. User(id): {userId}.");
+
+            var response = await providerAdminService.BlockProviderAdminAsync(
+                    providerAdminId,
+                    userId,
+                    providerId,
+                    await HttpContext.GetTokenAsync("access_token").ConfigureAwait(false))
+                        .ConfigureAwait(false);
+
+            if (response.IsSuccess)
+            {
+                logger.LogInformation($"Succesfully blocked ProviderAdmin(id): {providerAdminId} by User(id): {userId}.");
+
+                return Ok();
+            }
+
+            return StatusCode((int)response.HttpStatusCode);
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Authentication;
@@ -12,6 +14,7 @@ using OutOfSchool.Common;
 using OutOfSchool.Common.Extensions;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Common.PermissionsModule;
+using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 
 namespace OutOfSchool.WebApi.Controllers
@@ -142,11 +145,31 @@ namespace OutOfSchool.WebApi.Controllers
             return StatusCode((int)response.HttpStatusCode);
         }
 
+
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<ProviderAdminDto>))]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet("{providerId}")]
         public async Task<IActionResult> GetRelatedProviderAdmins(Guid providerId, bool deputyOnly = false, bool assistantsOnly = false)
         {
-            var relatedWorkshops = await providerAdminService.GetRelatedProviderAdmins(providerId).ConfigureAwait(false);
-            return Ok(relatedWorkshops);
+            var relatedAdmins = await providerAdminService.GetRelatedProviderAdmins(providerId).ConfigureAwait(false);
+
+            IActionResult result = Ok(relatedAdmins);
+
+            if (assistantsOnly && deputyOnly)
+            {
+                return result;
+            }
+            else if (deputyOnly)
+            {
+                result = Ok(relatedAdmins.Where(w => w.IsDeputy));
+            }
+            else if (assistantsOnly)
+            {
+                result = Ok(relatedAdmins.Where(w => !w.IsDeputy));
+            }
+
+            return result;
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
@@ -141,5 +141,12 @@ namespace OutOfSchool.WebApi.Controllers
 
             return StatusCode((int)response.HttpStatusCode);
         }
+
+        [HttpGet("{providerId}")]
+        public async Task<IActionResult> GetRelatedProviderAdmins(Guid providerId, bool deputyOnly = false, bool assistantsOnly = false)
+        {
+            var relatedWorkshops = await providerAdminService.GetRelatedProviderAdmins(providerId).ConfigureAwait(false);
+            return Ok(relatedWorkshops);
+        }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -35,7 +35,7 @@ namespace OutOfSchool.WebApi.Controllers.V1
         /// </summary>
         /// <param name="combinedWorkshopService">Service for operations with Workshops.</param>
         /// <param name="providerService">Service for Provider model.</param>
-        /// <param name="providerService">Service for Provider admin model.</param>
+        /// <param name="providerAdminService">Service for ProviderAdmin model.</param>
         /// <param name="localizer">Localizer.</param>
         /// <param name="options">Application default values.</param>
         public WorkshopController(

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -237,7 +237,7 @@ namespace OutOfSchool.WebApi.Controllers.V1
                 return NoContent();
             }
 
-            var userHasRights = await this.IsUserProvidersOwnerOrAdmin(workshop.ProviderId, workshop.Id).ConfigureAwait(false);
+            var userHasRights = await this.IsUserProvidersOwnerOrAdmin(workshop.ProviderId).ConfigureAwait(false);
             if (!userHasRights)
             {
                 return StatusCode(403, "Forbidden to delete workshops of another providers.");
@@ -250,8 +250,6 @@ namespace OutOfSchool.WebApi.Controllers.V1
 
         private async Task<bool> IsUserProvidersOwnerOrAdmin(Guid providerId, Guid workshopId = default)
         {
-            // Provider can create/update/delete a workshop only with it's own ProviderId.
-            // Admin can create a work without checks.
             if (User.IsInRole(Role.Provider.ToString().ToLower()))
             {
                 var userId = User.FindFirst("sub")?.Value;

--- a/OutOfSchool/OutOfSchool.WebApi/Enums/AccountStatus.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Enums/AccountStatus.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace OutOfSchool.WebApi.Enums
+{
+    public enum AccountStatus
+    {
+        NeverLogged,
+        Accepted,
+        Blocked,
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/MappingExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/MappingExtensions.cs
@@ -127,6 +127,21 @@ namespace OutOfSchool.WebApi.Extensions
             return Mapper<Rating, RatingDto>(rating, cfg => { cfg.CreateMap<Rating, RatingDto>(); });
         }
 
+        public static ProviderAdminDto ToModel(this User user, ProviderAdmin providerAdmin)
+        {
+            return Mapper<User, ProviderAdminDto>(user, cfg =>
+            {
+                cfg.CreateMap<User, ProviderAdminDto>()
+                .ForMember(dest => dest.FirstName, opt => opt.MapFrom(c => c.FirstName))
+                .ForMember(dest => dest.LastName, opt => opt.MapFrom(c => c.LastName))
+                .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(c => c.MiddleName))
+                .ForMember(dest => dest.Phone, opt => opt.MapFrom(c => c.PhoneNumber))
+                .ForMember(dest => dest.Email, opt => opt.MapFrom(c => c.Email))
+                .ForMember(dest => dest.IsDeputy, opt => opt.MapFrom(c => providerAdmin.IsDeputy))
+                .ForMember(dest => dest.AccountStatus, m => m.Ignore());
+            });
+        }
+
         public static ShortUserDto ToModel(this User user)
         {
             return Mapper<User, ShortUserDto>(user, cfg =>

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/RetrievingResourcesExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/RetrievingResourcesExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Globalization;
 using System.Resources;
-using Google.Protobuf.WellKnownTypes;
-using OutOfSchool.WebApi.Common;
 using OutOfSchool.WebApi.Common.Resources;
 using OutOfSchool.WebApi.Common.Resources.Codes;
 using Enum = System.Enum;

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ProviderAdminDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ProviderAdminDto.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using OutOfSchool.WebApi.Enums;
+
+namespace OutOfSchool.WebApi.Models
+{
+    public class ProviderAdminDto
+    {
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        public string MiddleName { get; set; }
+
+        public string Email { get; set; }
+
+        public string Phone { get; set; }
+
+        public bool IsDeputy { get; set; }
+
+        public AccountStatus AccountStatus { get; set; }
+
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>1ac220b0-4848-4d5c-b0d9-b64657bd3b04</UserSecretsId>
@@ -11,10 +10,9 @@
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\StyleCopAnalyzersRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(RunConfiguration)' == 'OutOfSchool' " />
-  <PropertyGroup Condition=" '$(RunConfiguration)' == 'DevContainer' " />
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="H3Lib" Version="3.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.17" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
@@ -22,12 +20,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.11" />
     <PackageReference Include="IdentityModel" Version="5.0.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.11">
@@ -35,14 +32,16 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
+    <PackageReference Include="Microsoft.FeatureManagement" Version="2.4.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.8.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.3" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.2" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Sinks.GoogleCloudLogging" Version="3.6.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -55,9 +54,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\OutOfSchool.Common\OutOfSchool.Common.csproj" />
     <ProjectReference Include="..\OutOfSchool.DataAccess\OutOfSchool.DataAccess.csproj" />
     <ProjectReference Include="..\OutOfSchool.ElasticsearchData\OutOfSchool.ElasticsearchData.csproj" />
-    <ProjectReference Include="..\OutOfSchool.Common\OutOfSchool.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Remove="stylecop.json" />
@@ -66,6 +65,22 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </AdditionalFiles>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Common\Exceptions\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Resources\Images\ImageResource.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ImageResource.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\Images\ImageResource.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ImageResource.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
 
 

--- a/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
@@ -11,9 +11,10 @@
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\StyleCopAnalyzersRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'OutOfSchool' " />
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'DevContainer' " />
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="H3Lib" Version="3.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.17" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
@@ -21,11 +22,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.11" />
     <PackageReference Include="IdentityModel" Version="5.0.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.11">
@@ -33,16 +35,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
-    <PackageReference Include="Microsoft.FeatureManagement" Version="2.4.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.8.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.2" />
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.GoogleCloudLogging" Version="3.6.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.3" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -55,9 +55,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\OutOfSchool.Common\OutOfSchool.Common.csproj" />
     <ProjectReference Include="..\OutOfSchool.DataAccess\OutOfSchool.DataAccess.csproj" />
     <ProjectReference Include="..\OutOfSchool.ElasticsearchData\OutOfSchool.ElasticsearchData.csproj" />
+    <ProjectReference Include="..\OutOfSchool.Common\OutOfSchool.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Remove="stylecop.json" />
@@ -66,22 +66,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </AdditionalFiles>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Common\Exceptions\" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Update="Resources\Images\ImageResource.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>ImageResource.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Update="Resources\Images\ImageResource.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>ImageResource.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
   </ItemGroup>
 
 

--- a/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>1ac220b0-4848-4d5c-b0d9-b64657bd3b04</UserSecretsId>

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Communication/CommunicationConstants.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Communication/CommunicationConstants.cs
@@ -1,0 +1,13 @@
+﻿namespace OutOfSchool.WebApi.Services.Communication
+{
+    public static class CommunicationConstants
+    {
+        public const string CreateProviderAdmin = "provideradmin/create";
+
+        public const string DeleteProviderAdmin = "provideradmin/delete";
+
+        public const string BlockProviderAdmin = "provideradmin/block";
+
+        public const int BufferSize = 1024;
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Communication/CommunicationService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Communication/CommunicationService.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+
+using OutOfSchool.Common;
+using OutOfSchool.WebApi.Config;
+using OutOfSchool.WebApi.Services.Communication.ICommunication;
+
+namespace OutOfSchool.WebApi.Services.Communication
+{
+    public class CommunicationService : ICommunicationService
+    {
+        private readonly IHttpClientFactory httpClientFactory;
+        private readonly HttpClient httpClient;
+
+        public CommunicationService(
+            IHttpClientFactory httpClientFactory,
+            CommunicationConfig communicationConfig)
+        {
+            this.httpClientFactory = httpClientFactory;
+            httpClient = this.httpClientFactory.CreateClient(communicationConfig.ClientName);
+            httpClient.DefaultRequestHeaders.Clear();
+            httpClient.DefaultRequestHeaders
+                .Accept.Add(new MediaTypeWithQualityHeaderValue(System.Net.Mime.MediaTypeNames.Application.Json));
+            httpClient.Timeout = TimeSpan.FromSeconds(communicationConfig.TimeoutInSeconds);
+        }
+
+        public async Task<ResponseDto> SendRequest(Request request)
+        {
+            try
+            {
+                // TODO:
+                // Setup number of parallel requests
+                httpClient.DefaultRequestHeaders.Authorization
+                                = new AuthenticationHeaderValue("Bearer", request.Token);
+
+                httpClient.DefaultRequestHeaders
+                    .Add("X-Request-ID", request.RequestId.ToString());
+
+                using var requestMessage = new HttpRequestMessage();
+
+                requestMessage.Headers
+                    .AcceptEncoding
+                    .Add(new StringWithQualityHeaderValue("gzip"));
+
+                requestMessage.RequestUri = new System.Uri(request.Url.ToString());
+
+                if (request.Data != null)
+                {
+                    requestMessage.Content =
+                            new StringContent(
+                                JsonConvert.SerializeObject(request.Data),
+                                Encoding.UTF8,
+                                System.Net.Mime.MediaTypeNames.Application.Json);
+                }
+
+                requestMessage.Method = HttpMethodService.GetHttpMethodType(request);
+
+                var response = await httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead)
+                    .ConfigureAwait(false);
+
+                using (var stream = await response.Content.ReadAsStreamAsync()
+                    .ConfigureAwait(false))
+                {
+                    response.EnsureSuccessStatusCode();
+
+                    return stream.ReadAndDeserializeFromJson<ResponseDto>();
+                }
+            }
+            catch
+            {
+                var responseDto = new ResponseDto
+                {
+                    IsSuccess = false,
+                    HttpStatusCode = HttpStatusCode.InternalServerError,
+                };
+
+                return responseDto;
+            }
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Communication/HttpMethodService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Communication/HttpMethodService.cs
@@ -1,0 +1,30 @@
+﻿using System.Net.Http;
+
+namespace OutOfSchool.WebApi.Services.Communication
+{
+    public enum HttpMethodType
+    {
+        Post,
+        Put,
+        Delete,
+        Get,
+    }
+
+    public static class HttpMethodService
+    {
+        public static HttpMethod GetHttpMethodType(Request request)
+        {
+            switch (request.HttpMethodType)
+            {
+                case HttpMethodType.Post:
+                    return HttpMethod.Post;
+                case HttpMethodType.Put:
+                    return HttpMethod.Put;
+                case HttpMethodType.Delete:
+                    return HttpMethod.Delete;
+                default:
+                    return HttpMethod.Get;
+            }
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Communication/ICommunication/ICommunicationService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Communication/ICommunication/ICommunicationService.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+using OutOfSchool.Common;
+
+namespace OutOfSchool.WebApi.Services.Communication.ICommunication
+{
+    public interface ICommunicationService
+    {
+        Task<ResponseDto> SendRequest(Request request);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Communication/Request.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Communication/Request.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace OutOfSchool.WebApi.Services.Communication
+{
+    public class Request
+    {
+        public Guid RequestId { get; set; }
+
+        public object Data { get; set; }
+
+        public System.Uri Url { get; set; }
+
+        public string Token { get; set; }
+
+        public HttpMethodType HttpMethodType { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Communication/RetryPolicyDelegatingHandler.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Communication/RetryPolicyDelegatingHandler.cs
@@ -1,0 +1,44 @@
+﻿using System.Net.Http;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+using OutOfSchool.WebApi.Config;
+
+namespace OutOfSchool.WebApi.Services.Communication
+{
+    public class RetryPolicyDelegatingHandler : DelegatingHandler
+    {
+        private readonly int maximumAmountOfRetries = 3;
+
+        public RetryPolicyDelegatingHandler(int maximumAmountOfRetries)
+            : base()
+        {
+            this.maximumAmountOfRetries = maximumAmountOfRetries;
+        }
+
+        public RetryPolicyDelegatingHandler(HttpMessageHandler innerHandler, int maximumAmountOfRetries)
+            : base(innerHandler)
+        {
+            this.maximumAmountOfRetries = maximumAmountOfRetries;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response = null;
+
+            for (int i = 0; i < maximumAmountOfRetries; i++)
+            {
+                response = await base.SendAsync(request, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    return response;
+                }
+            }
+
+            return response;
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Communication/StreamExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Communication/StreamExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+using Newtonsoft.Json;
+
+namespace OutOfSchool.WebApi.Services.Communication
+{
+    public static class StreamExtensions
+    {
+        public static T ReadAndDeserializeFromJson<T>(this Stream stream)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            if (!stream.CanRead)
+            {
+                throw new NotSupportedException("Can't read this stream");
+            }
+
+            using (var streamReader = new StreamReader(stream))
+            {
+                using (var jsonTextReader = new JsonTextReader(streamReader))
+                {
+                    var jsonSerializer = new JsonSerializer();
+
+                    return jsonSerializer.Deserialize<T>(jsonTextReader);
+                }
+            }
+        }
+
+        public static void SerializeToJsonAndWrite<T>(this Stream stream, T objectToWrite)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            if (!stream.CanRead)
+            {
+                throw new NotSupportedException("Can't write to this stream");
+            }
+
+            using (var streamWriter = new StreamWriter(stream, new UTF8Encoding(), CommunicationConstants.BufferSize, true))
+            {
+                using (var jsonTextWriter = new JsonTextWriter(streamWriter))
+                {
+                    var jsonSerializer = new JsonSerializer();
+                    jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
+                    jsonTextWriter.Flush();
+                }
+            }
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/IProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/IProviderAdminService.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using OutOfSchool.Common;
 using OutOfSchool.Common.Models;
+using OutOfSchool.WebApi.Models;
 
 namespace OutOfSchool.WebApi.Services
 {
@@ -10,9 +12,11 @@ namespace OutOfSchool.WebApi.Services
     {
         Task<ResponseDto> CreateProviderAdminAsync(string userId, CreateProviderAdminDto providerAdmin, string token);
 
-        Task<ResponseDto> DeleteProviderAdminAsync(string providerAdminId, string userId, Guid providerAdmin, string token);
+        Task<ResponseDto> DeleteProviderAdminAsync(string providerAdminId, string userId, Guid providerId, string token);
 
-        Task<ResponseDto> BlockProviderAdminAsync(string providerAdminId, string userId, Guid providerAdmin, string token);
+        Task<ResponseDto> BlockProviderAdminAsync(string providerAdminId, string userId, Guid providerId, string token);
+
+        Task<IEnumerable<ProviderAdminDto>> GetRelatedProviderAdmins(Guid providerId);
 
         Task<bool> CheckUserIsRelatedProviderAdmin(string providerAdminId, Guid providerId, Guid workshopId = default);
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Services/IProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/IProviderAdminService.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using OutOfSchool.Common;
+using OutOfSchool.Common.Models;
+
+namespace OutOfSchool.WebApi.Services
+{
+    public interface IProviderAdminService
+    {
+        Task<ResponseDto> CreateProviderAdminAsync(string userId, CreateProviderAdminDto providerAdmin, string token);
+
+        Task<ResponseDto> DeleteProviderAdminAsync(string providerAdminId, string userId, Guid providerAdmin, string token);
+
+        Task<ResponseDto> BlockProviderAdminAsync(string providerAdminId, string userId, Guid providerAdmin, string token);
+
+        Task<bool> CheckUserIsRelatedProviderAdmin(string providerAdminId, Guid providerId, Guid workshopId = default);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
@@ -54,7 +54,7 @@ namespace OutOfSchool.WebApi.Services
         {
             logger.LogDebug($"ProviderAdmin creating was started. User(id): {userId}");
 
-            var hasAccess = await IsAllowedCreateAsync(providerAdminDto.ProviderId, userId)
+            var hasAccess = await IsAllowedCreateAsync(providerAdminDto.ProviderId, userId, providerAdminDto.IsDeputy)
                 .ConfigureAwait(true);
 
             if (!hasAccess)
@@ -239,7 +239,7 @@ namespace OutOfSchool.WebApi.Services
             return response;
         }
 
-        public async Task<bool> IsAllowedCreateAsync(Guid providerId, string userId)
+        public async Task<bool> IsAllowedCreateAsync(Guid providerId, string userId, bool isDeputy)
         {
             bool providerAdminDeputy = await providerAdminRepository.IsExistProviderAdminDeputyWithUserIdAsync(providerId, userId)
                 .ConfigureAwait(false);
@@ -247,7 +247,8 @@ namespace OutOfSchool.WebApi.Services
             bool provider = await providerAdminRepository.IsExistProviderWithUserIdAsync(providerId, userId)
                 .ConfigureAwait(false);
 
-            return providerAdminDeputy || provider;
+            // provider admin deputy can create only assistants
+            return (providerAdminDeputy && !isDeputy) || provider;
         }
 
         public async Task<bool> IsAllowedAsync(Guid providerId, string userId)

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
@@ -1,0 +1,266 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Newtonsoft.Json;
+
+using OutOfSchool.Common;
+using OutOfSchool.Common.Models;
+using OutOfSchool.Services.Repository;
+using OutOfSchool.WebApi.Config;
+using OutOfSchool.WebApi.Services.Communication;
+
+namespace OutOfSchool.WebApi.Services
+{
+    public class ProviderAdminService : CommunicationService, IProviderAdminService
+    {
+        private readonly IdentityServerConfig identityServerConfig;
+        private readonly ProviderAdminConfig providerAdminConfig;
+        private readonly IProviderAdminRepository providerAdminRepository;
+        private readonly ILogger<ProviderAdminService> logger;
+        private readonly ResponseDto responseDto;
+
+        public ProviderAdminService(
+            IHttpClientFactory httpClientFactory,
+            IOptions<IdentityServerConfig> identityServerConfig,
+            IOptions<ProviderAdminConfig> providerAdminConfig,
+            IOptions<CommunicationConfig> communicationConfig,
+            IProviderAdminRepository providerAdminRepository,
+            ILogger<ProviderAdminService> logger)
+            : base(httpClientFactory, communicationConfig.Value)
+        {
+            this.identityServerConfig = identityServerConfig.Value;
+            this.providerAdminConfig = providerAdminConfig.Value;
+            this.providerAdminRepository = providerAdminRepository;
+            this.logger = logger;
+            responseDto = new ResponseDto();
+        }
+
+        public async Task<ResponseDto> CreateProviderAdminAsync(string userId, CreateProviderAdminDto providerAdminDto, string token)
+        {
+            logger.LogDebug($"ProviderAdmin creating was started. User(id): {userId}");
+
+            var hasAccess = await IsAllowedCreateAsync(providerAdminDto.ProviderId, userId)
+                .ConfigureAwait(true);
+
+            if (!hasAccess)
+            {
+                logger.LogError($"User(id): {userId} doesn't have permission to create provider admin.");
+
+                responseDto.IsSuccess = false;
+                responseDto.HttpStatusCode = HttpStatusCode.Forbidden;
+
+                return responseDto;
+            }
+
+            var numberProviderAdminsLessThanMax = await providerAdminRepository
+                .GetNumberProviderAdminsAsync(providerAdminDto.ProviderId)
+                .ConfigureAwait(false);
+
+            if (numberProviderAdminsLessThanMax >= providerAdminConfig.MaxNumberAdmins)
+            {
+                logger.LogError($"Admin was not created by User(id): {userId}. " +
+                    $"Limit on the number of admins has been exceeded for the Provider(id): {providerAdminDto.ProviderId}.");
+
+                responseDto.IsSuccess = false;
+                responseDto.HttpStatusCode = HttpStatusCode.MethodNotAllowed;
+
+                return responseDto;
+            }
+
+            var request = new Request()
+            {
+                HttpMethodType = HttpMethodType.Post,
+                Url = new Uri(identityServerConfig.Authority, CommunicationConstants.CreateProviderAdmin),
+                Token = token,
+                Data = providerAdminDto,
+                RequestId = Guid.NewGuid(),
+            };
+
+            logger.LogDebug($"{request.HttpMethodType} Request(id): {request.RequestId} " +
+                $"was sent. User(id): {userId}. Url: {request.Url}");
+
+            var response = await SendRequest(request)
+                    .ConfigureAwait(false);
+
+            if (response.IsSuccess)
+            {
+                responseDto.IsSuccess = true;
+                responseDto.Result = JsonConvert
+                    .DeserializeObject<CreateProviderAdminDto>(response.Result.ToString());
+
+                return responseDto;
+            }
+
+            return response;
+        }
+
+        public async Task<ResponseDto> DeleteProviderAdminAsync(string providerAdminId, string userId, Guid providerId, string token)
+        {
+            logger.LogDebug($"ProviderAdmin(id): {providerAdminId} deleting was started. User(id): {userId}");
+
+            var hasAccess = await IsAllowedAsync(providerId, userId)
+                .ConfigureAwait(true);
+
+            if (!hasAccess)
+            {
+                logger.LogError($"User(id): {userId} doesn't have permission to delete provider admin.");
+
+                responseDto.IsSuccess = false;
+                responseDto.HttpStatusCode = HttpStatusCode.Forbidden;
+
+                return responseDto;
+            }
+
+            var provideradmin = await providerAdminRepository.GetByIdAsync(providerAdminId, providerId)
+                .ConfigureAwait(false);
+
+            if (provideradmin is null)
+            {
+                logger.LogError($"ProviderAdmin(id) {providerAdminId} not found. User(id): {userId}.");
+
+                responseDto.IsSuccess = false;
+                responseDto.HttpStatusCode = HttpStatusCode.NotFound;
+
+                return responseDto;
+            }
+
+            var request = new Request()
+            {
+                HttpMethodType = HttpMethodType.Delete,
+                Url = new Uri(identityServerConfig.Authority, CommunicationConstants.DeleteProviderAdmin),
+                Token = token,
+                Data = new DeleteProviderAdminDto()
+                {
+                    ProviderAdminId = providerAdminId,
+                },
+                RequestId = Guid.NewGuid(),
+            };
+
+            logger.LogDebug($"{request.HttpMethodType} Request(id): {request.RequestId} " +
+                $"was sent. User(id): {userId}. Url: {request.Url}");
+
+            var response = await SendRequest(request)
+                    .ConfigureAwait(false);
+
+            if (response.IsSuccess)
+            {
+                responseDto.IsSuccess = true;
+                if (!(responseDto.Result is null))
+                {
+                    responseDto.Result = JsonConvert
+                    .DeserializeObject<ActionResult>(response.Result.ToString());
+
+                    return responseDto;
+                }
+
+                return responseDto;
+            }
+
+            return response;
+        }
+
+        public async Task<ResponseDto> BlockProviderAdminAsync(string providerAdminId, string userId, Guid providerId, string token)
+        {
+            logger.LogDebug($"ProviderAdmin(id): {providerAdminId} blocking was started. User(id): {userId}");
+
+            var hasAccess = await IsAllowedAsync(providerId, userId)
+                .ConfigureAwait(true);
+
+            if (!hasAccess)
+            {
+                logger.LogError($"User(id): {userId} doesn't have permission to block provider admin.");
+
+                responseDto.IsSuccess = false;
+                responseDto.HttpStatusCode = HttpStatusCode.Forbidden;
+
+                return responseDto;
+            }
+
+            var provideradmin = await providerAdminRepository.GetByIdAsync(providerAdminId, providerId)
+                .ConfigureAwait(false);
+
+            if (provideradmin is null)
+            {
+                logger.LogError($"ProviderAdmin(id) {providerAdminId} not found. User(id): {userId}.");
+
+                responseDto.IsSuccess = false;
+                responseDto.HttpStatusCode = HttpStatusCode.NotFound;
+
+                return responseDto;
+            }
+
+            var request = new Request()
+            {
+                HttpMethodType = HttpMethodType.Put,
+                Url = new Uri(identityServerConfig.Authority, CommunicationConstants.BlockProviderAdmin),
+                Token = token,
+                Data = new BlockProviderAdminDto()
+                {
+                    ProviderAdminId = providerAdminId,
+                },
+                RequestId = Guid.NewGuid(),
+            };
+
+            logger.LogDebug($"{request.HttpMethodType} Request(id): {request.RequestId} " +
+                $"was sent. User(id): {userId}. Url: {request.Url}");
+
+            var response = await SendRequest(request)
+                    .ConfigureAwait(false);
+
+            if (response.IsSuccess)
+            {
+                responseDto.IsSuccess = true;
+                if (!(responseDto.Result is null))
+                {
+                    responseDto.Result = JsonConvert
+                    .DeserializeObject<ActionResult>(response.Result.ToString());
+
+                    return responseDto;
+                }
+
+                return responseDto;
+            }
+
+            return response;
+        }
+
+        public async Task<bool> IsAllowedCreateAsync(Guid providerId, string userId)
+        {
+            bool providerAdminDeputy = await providerAdminRepository.IsExistProviderAdminDeputyWithUserIdAsync(providerId, userId)
+                .ConfigureAwait(false);
+
+            bool provider = await providerAdminRepository.IsExistProviderWithUserIdAsync(providerId, userId)
+                .ConfigureAwait(false);
+
+            return providerAdminDeputy || provider;
+        }
+
+        public async Task<bool> IsAllowedAsync(Guid providerId, string userId)
+        {
+            bool provider = await providerAdminRepository.IsExistProviderWithUserIdAsync(providerId, userId)
+                .ConfigureAwait(false);
+
+            return provider;
+        }
+
+        public async Task<bool> CheckUserIsRelatedProviderAdmin(string userId, Guid providerId, Guid workshopId)
+        {
+           var providerAdmin = await providerAdminRepository.GetByIdAsync(userId, providerId).ConfigureAwait(false);
+
+           if (!providerAdmin.IsDeputy)
+            {
+                var relatedWorkshops = providerAdmin.ManagedWorkshops;
+                return relatedWorkshops.Where(w => w.Id == workshopId).Any();
+            }
+
+           return providerAdmin != null;
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
@@ -282,7 +282,7 @@ namespace OutOfSchool.WebApi.Services
 
                 if (!user.IsEnabled)
                 {
-                    dto.AccountStatus = Enums.AccountStatus.Blocked;
+                    dto.AccountStatus = AccountStatus.Blocked;
                 }
                 else
                 {

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -232,11 +232,10 @@ namespace OutOfSchool.WebApi
             services.AddTransient<IEntityRepository<InstitutionStatus>, EntityRepository<InstitutionStatus>>();
             services.AddTransient<IEntityRepository<Teacher>, EntityRepository<Teacher>>();
             services.AddTransient<IEntityRepository<User>, EntityRepository<User>>();
-            services.AddTransient<IEntityRepository<ProviderAdmin>, EntityRepository<ProviderAdmin>>();
-            services.AddTransient<IProviderAdminRepository, ProviderAdminRepository>();
             services.AddTransient<IEntityRepository<PermissionsForRole>, EntityRepository<PermissionsForRole>>();
             services.AddTransient<IEntityRepository<InformationAboutPortal>, EntityRepository<InformationAboutPortal>>();
 
+            services.AddTransient<IProviderAdminRepository, ProviderAdminRepository>();
             services.AddTransient<IApplicationRepository, ApplicationRepository>();
             services
                 .AddTransient<IChatRoomWorkshopModelForChatListRepository, ChatRoomWorkshopModelForChatListRepository

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -2,18 +2,21 @@
   "AppDefaults": {
     "City": "Київ"
   },
-  "Serilog": {
-    "Using": [],
-    "MinimumLevel": {
+  "Logging": {
+    "LogLevel": {
       "Default": "Information",
-      "Override": {
-        "Microsoft": "Information",
-        "System": "Warning"
-      }
-    },
-    "Enrich": [
-      "FromLogContext"
-    ]
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ProviderAdmin": {
+    "MaxNumberAdmins": 100
+  },
+
+  "Communication": {
+    "TimeoutInSeconds": 15,
+    "MaxNumberOfRetries": 3,
+    "ClientName": "WebApi"
   },
   "Identity": {
     "Authority": "http://localhost:5443"
@@ -41,23 +44,21 @@
       ]
     }
   },
+  "CommonImagesRequestLimits": {
+    "MaxCountOfAttachedFiles": 30
+  },
   "Images": {
     "Workshop": {
-      "Specs": {
-        "MinWidthPixels": 350,
-        "MaxWidthPixels": 10000,
-        "MinHeightPixels": 250,
-        "MaxHeightPixels": 8000,
-        "MaxSizeBytes": 16777216,
-        "MaxWidthHeightRatio": 2,
-        "SupportedFormats": [
-          "jpeg",
-          "png"
-        ]
-      },
-      "Limits": {
-        "MaxCountOfFiles": 10
-      }
+      "MinWidth": 350,
+      "MaxWidth": 10000,
+      "MinHeight": 250,
+      "MaxHeight": 8000,
+      "MaxWidthHeightRatio": 2,
+      "MaxSize": 16777216,
+      "SupportedFormats": [
+        "jpg",
+        "png"
+      ]
     }
   },
 
@@ -76,3 +77,5 @@
 
   "MySQLServerVersion": "8.0.27"
 }
+
+


### PR DESCRIPTION
based on PR: https://github.com/ita-social-projects/OoS-Backend/pull/437

what we currently have:
-user-provider can create two types of provider admins - deputy and assistant (workshop admin)
-user-provider-admin can create only service provider assistants (due to permissions matrix)
-provider admins can create, manage workshops and related applications (deputy - all provider's workshops, assistant - only pre-defined), but have no permission to delete workshops.

what we need
-add migration
-edit provider admin controller actions to increase security (GetRelatedProviderAdmins endpoint)
-fix code due to future comments