### PR TITLE
fixed a degrees/radians mismatch issue

### DIFF
--- a/OutOfSchool/OutOfSchool.Common/GeoMathHelper.cs
+++ b/OutOfSchool/OutOfSchool.Common/GeoMathHelper.cs
@@ -15,18 +15,18 @@ namespace OutOfSchool.Common
         public static decimal GetDistanceFromLatLonInKm(double lat1, double lon1, double lat2, double lon2)
         {
             var r = 6371e3; // Radius of the earth in m
-            var dLat = Deg2rad(lat2 - lat1);  // Deg2rad below
-            var dLon = Deg2rad(lon2 - lon1);
+            var dLat = Deg2Rad(lat2 - lat1); // Deg2rad below
+            var dLon = Deg2Rad(lon2 - lon1);
             var a =
-                    (Math.Sin(dLat / 2) * Math.Sin(dLat / 2)) +
-                    (Math.Cos(Deg2rad(lat1)) * Math.Cos(Deg2rad(lat2)) *
-                    Math.Sin(dLon / 2) * Math.Sin(dLon / 2));
+                (Math.Sin(dLat / 2) * Math.Sin(dLat / 2)) +
+                (Math.Cos(Deg2Rad(lat1)) * Math.Cos(Deg2Rad(lat2)) *
+                 Math.Sin(dLon / 2) * Math.Sin(dLon / 2));
             var c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
             var d = r * c; // Distance in km
             return (decimal)d;
         }
 
-        public static double Deg2rad(double deg)
+        public static double Deg2Rad(double deg)
         {
             return deg * (Math.PI / 180);
         }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Address.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Address.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using H3Lib;
+using H3Lib.Extensions;
 using OutOfSchool.Common;
 
 namespace OutOfSchool.Services.Models
@@ -33,7 +34,7 @@ namespace OutOfSchool.Services.Models
         public double Longitude { get; set; }
 
         // parameter r means size (resolution) of hexagon
-        public ulong GeoHash => H3Lib.Api.GeoToH3(new GeoCoord((decimal)Latitude, (decimal)Longitude), GeoMathHelper.Resolution);
+        public ulong GeoHash => Api.GeoToH3(default(GeoCoord).SetDegrees((decimal)Latitude, (decimal)Longitude), GeoMathHelper.Resolution);
 
         public override bool Equals(object obj)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/GeoMathHelperExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/GeoMathHelperExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using H3Lib;
+using H3Lib.Extensions;
 using OutOfSchool.Common;
 using OutOfSchool.Services.Models;
 
@@ -10,7 +11,7 @@ namespace OutOfSchool.WebApi.Extensions
         {
             if (!(city is null))
             {
-                city.GeoHash = Api.GeoToH3(new GeoCoord((decimal)city.Latitude, (decimal)city.Longitude), GeoMathHelper.ResolutionForCity);
+                city.GeoHash = Api.GeoToH3(default(GeoCoord).SetDegrees((decimal)city.Latitude, (decimal)city.Longitude), GeoMathHelper.ResolutionForCity);
             }
 
             return city;

--- a/OutOfSchool/OutOfSchool.WebApi/Services/CityService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/CityService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using H3Lib;
+using H3Lib.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -92,7 +93,8 @@ namespace OutOfSchool.WebApi.Services
                 filter = new CityFilter();
             }
 
-            var geo = new GeoCoord(filter.Latitude, filter.Longitude);
+            var geo = default(GeoCoord).SetDegrees(filter.Latitude, filter.Longitude);
+
             var h3Location = Api.GeoToH3(geo, GeoMathHelper.ResolutionForCity);
             Api.KRing(h3Location, GeoMathHelper.KRingForResolution, out var neighbours);
 
@@ -109,8 +111,8 @@ namespace OutOfSchool.WebApi.Services
                         .GetDistanceFromLatLonInKm(
                             (double)city.Latitude,
                             (double)city.Longitude,
-                            (double)geo.Latitude,
-                            (double)geo.Longitude),
+                            (double)filter.Latitude,
+                            (double)filter.Longitude),
                 })
                 .OrderBy(p => p.Distance)
                 .Select(c => c.city)

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using AutoMapper;
 using H3Lib;
+using H3Lib.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -401,8 +402,8 @@ namespace OutOfSchool.WebApi.Services
                 filter = new WorkshopFilter();
             }
 
-            var geo = new GeoCoord(filter.Latitude, filter.Longitude);
-            var h3Location = H3Lib.Api.GeoToH3(geo, GeoMathHelper.Resolution);
+            var geo = default(GeoCoord).SetDegrees(filter.Latitude, filter.Longitude);
+            var h3Location = Api.GeoToH3(geo, GeoMathHelper.Resolution);
             Api.KRing(h3Location, GeoMathHelper.KRingForResolution, out var neighbours);
 
             var filterPredicate = PredicateBuild(filter);
@@ -430,8 +431,8 @@ namespace OutOfSchool.WebApi.Services
                         .GetDistanceFromLatLonInKm(
                             w.Address.Latitude,
                             w.Address.Longitude,
-                            (double)geo.Latitude,
-                            (double)geo.Longitude),
+                            (double)filter.Latitude,
+                            (double)filter.Longitude),
                 })
                 .OrderBy(p => p.Distance).Take(filter.Size).Select(a => a.w);
 


### PR DESCRIPTION
`GeoCoord` requires radians as constructor input.
Changed the creation of new `GeoCoord`s to invoking an extension method that returns a new `GeoCoord` from a set of lat/lon in degrees.