### PR TITLE
Add possibility to override connection string with a strongly typed options

### DIFF
--- a/OutOfSchool/OutOfSchool.Common/Config/IMySqlConnectionOptions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Config/IMySqlConnectionOptions.cs
@@ -14,6 +14,6 @@ namespace OutOfSchool.Common.Config
 
         public string Password { get; set; }
 
-        public bool IsGuidFormatBinary16 { get; set; }
+        public string GuidFormat { get; set; }
     }
 }

--- a/OutOfSchool/OutOfSchool.Common/Config/IMySqlConnectionOptions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Config/IMySqlConnectionOptions.cs
@@ -1,0 +1,19 @@
+namespace OutOfSchool.Common.Config
+{
+    public interface IMySqlConnectionOptions
+    {
+        public bool UseOverride { get; set; }
+
+        public string Server { get; set; }
+
+        public uint Port { get; set; }
+
+        public string Database { get; set; }
+
+        public string UserId { get; set; }
+
+        public string Password { get; set; }
+
+        public bool IsGuidFormatBinary16 { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.Common/Extensions/Startup/ConnectionStringExtensions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Extensions/Startup/ConnectionStringExtensions.cs
@@ -16,7 +16,7 @@ namespace OutOfSchool.Common.Extensions.Startup
         {
             var overrides = config
                 .GetSection("ConnectionStringsOverride")
-                .Get<Dictionary<string, TOptions>>();
+                .Get<Dictionary<string, TOptions>>() ?? new Dictionary<string, TOptions>();
 
             DbConnectionStringBuilder connectionStringBuilder;
 
@@ -36,6 +36,11 @@ namespace OutOfSchool.Common.Extensions.Startup
                 {
                     ConnectionString = config.GetConnectionString(connectionStringKey),
                 };
+            }
+
+            if (string.IsNullOrEmpty(connectionStringBuilder.ConnectionString))
+            {
+                throw new Exception("Provide a valid connection string or options");
             }
 
             if (!connectionStringBuilder.ContainsKey("guidformat") || connectionStringBuilder["guidformat"].ToString().ToLower() != "binary16")

--- a/OutOfSchool/OutOfSchool.Common/Extensions/Startup/ConnectionStringExtensions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Extensions/Startup/ConnectionStringExtensions.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using Microsoft.Extensions.Configuration;
+using OutOfSchool.Common.Config;
+
+namespace OutOfSchool.Common.Extensions.Startup
+{
+    public static class ConnectionStringExtensions
+    {
+        public static string GetMySqlConnectionString<TOptions>(
+            this IConfiguration config,
+            string connectionStringKey,
+            Func<TOptions, DbConnectionStringBuilder> optionsToBuilder = null)
+            where TOptions : IMySqlConnectionOptions
+        {
+            var overrides = config
+                .GetSection("ConnectionStringsOverride")
+                .Get<Dictionary<string, TOptions>>();
+
+            DbConnectionStringBuilder connectionStringBuilder;
+
+            TOptions options;
+            if (overrides.TryGetValue(connectionStringKey, out options) && options.UseOverride)
+            {
+                if (optionsToBuilder == null)
+                {
+                    throw new ArgumentException("Please provide options to builder conversion if you are using overrides");
+                }
+
+                connectionStringBuilder = optionsToBuilder(options);
+            }
+            else
+            {
+                connectionStringBuilder = new DbConnectionStringBuilder()
+                {
+                    ConnectionString = config.GetConnectionString(connectionStringKey),
+                };
+            }
+
+            if (!connectionStringBuilder.ContainsKey("guidformat") || connectionStringBuilder["guidformat"].ToString().ToLower() != "binary16")
+            {
+                throw new Exception("The connection string should have a key: 'guidformat' and a value: 'binary16'");
+            }
+
+            return connectionStringBuilder.ConnectionString;
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.Common/Extensions/Startup/ConnectionStringExtensions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Extensions/Startup/ConnectionStringExtensions.cs
@@ -20,8 +20,7 @@ namespace OutOfSchool.Common.Extensions.Startup
 
             DbConnectionStringBuilder connectionStringBuilder;
 
-            TOptions options;
-            if (overrides.TryGetValue(connectionStringKey, out options) && options.UseOverride)
+            if (overrides.TryGetValue(connectionStringKey, out var options) && options.UseOverride)
             {
                 if (optionsToBuilder == null)
                 {
@@ -43,7 +42,7 @@ namespace OutOfSchool.Common.Extensions.Startup
                 throw new Exception("Provide a valid connection string or options");
             }
 
-            if (!connectionStringBuilder.ContainsKey("guidformat") || connectionStringBuilder["guidformat"].ToString().ToLower() != "binary16")
+            if (!connectionStringBuilder.ContainsKey("guidformat") || !string.Equals(connectionStringBuilder["guidformat"].ToString(), "binary16", StringComparison.OrdinalIgnoreCase))
             {
                 throw new Exception("The connection string should have a key: 'guidformat' and a value: 'binary16'");
             }

--- a/OutOfSchool/OutOfSchool.Common/Extensions/StringExtensions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Extensions/StringExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace OutOfSchool.Common.Extensions
+{
+    public static class StringExtensions
+    {
+        public static TEnum ToEnum<TEnum>(this string value, TEnum defaultValue)
+            where TEnum : struct
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return defaultValue;
+            }
+
+            return Enum.TryParse<TEnum>(value, true, out var result) ? result : defaultValue;
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.IdentityServer/Config/IdentityConnectionOptions.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Config/IdentityConnectionOptions.cs
@@ -16,6 +16,6 @@ namespace OutOfSchool.IdentityServer.Config
 
         public string Password { get; set; }
 
-        public bool IsGuidFormatBinary16 { get; set; }
+        public string GuidFormat { get; set; }
     }
 }

--- a/OutOfSchool/OutOfSchool.IdentityServer/Config/IdentityConnectionOptions.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Config/IdentityConnectionOptions.cs
@@ -1,0 +1,21 @@
+using OutOfSchool.Common.Config;
+
+namespace OutOfSchool.IdentityServer.Config
+{
+    public class IdentityConnectionOptions : IMySqlConnectionOptions
+    {
+        public bool UseOverride { get; set; }
+
+        public string Server { get; set; }
+
+        public uint Port { get; set; }
+
+        public string Database { get; set; }
+
+        public string UserId { get; set; }
+
+        public string Password { get; set; }
+
+        public bool IsGuidFormatBinary16 { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.IdentityServer/Startup.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Startup.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -19,6 +18,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using MySqlConnector;
 using OutOfSchool.Common;
 using OutOfSchool.Common.Config;
 using OutOfSchool.Common.Extensions.Startup;
@@ -53,14 +53,7 @@ namespace OutOfSchool.IdentityServer
             services.Configure<IdentityServerConfig>(config.GetSection(IdentityServerConfig.Name));
             var migrationsAssembly = typeof(Startup).GetTypeInfo().Assembly.GetName().Name;
 
-            var connectionString = config["ConnectionStrings:DefaultConnection"];
-            var connectionStringBuilder = new DbConnectionStringBuilder();
-            connectionStringBuilder.ConnectionString = connectionString;
-            if (!connectionStringBuilder.ContainsKey("guidformat") || connectionStringBuilder["guidformat"].ToString().ToLower() != "binary16")
-            {
-                throw new Exception("The connection string should have a key: \"guidformat\" and a value: \"binary16\"");
-            }
-
+            // TODO: Move version check into an extension to reuse code across apps
             var mySQLServerVersion = config["MySQLServerVersion"];
             var serverVersion = new MySqlServerVersion(new Version(mySQLServerVersion));
             if (serverVersion.Version.Major < Constants.MySQLServerMinimalMajorVersion)
@@ -68,6 +61,17 @@ namespace OutOfSchool.IdentityServer
                 throw new Exception("MySQL Server version should be 8 or higher.");
             }
 
+            var connectionString = config.GetMySqlConnectionString<IdentityConnectionOptions>(
+                "DefaultConnection",
+                options => new MySqlConnectionStringBuilder
+                {
+                    Server = options.Server,
+                    Port = options.Port,
+                    UserID = options.UserId,
+                    Password = options.Password,
+                    Database = options.Database,
+                    GuidFormat = options.IsGuidFormatBinary16 ? MySqlGuidFormat.Binary16 : MySqlGuidFormat.Default,
+                });
             services
                 .AddDbContext<OutOfSchoolDbContext>(options => options
                     .UseMySql(

--- a/OutOfSchool/OutOfSchool.IdentityServer/Startup.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Hosting;
 using MySqlConnector;
 using OutOfSchool.Common;
 using OutOfSchool.Common.Config;
+using OutOfSchool.Common.Extensions;
 using OutOfSchool.Common.Extensions.Startup;
 using OutOfSchool.Common.PermissionsModule;
 using OutOfSchool.EmailSender;
@@ -70,7 +71,7 @@ namespace OutOfSchool.IdentityServer
                     UserID = options.UserId,
                     Password = options.Password,
                     Database = options.Database,
-                    GuidFormat = options.IsGuidFormatBinary16 ? MySqlGuidFormat.Binary16 : MySqlGuidFormat.Default,
+                    GuidFormat = options.GuidFormat.ToEnum(MySqlGuidFormat.Default),
                 });
             services
                 .AddDbContext<OutOfSchoolDbContext>(options => options

--- a/OutOfSchool/OutOfSchool.IdentityServer/appsettings.json
+++ b/OutOfSchool/OutOfSchool.IdentityServer/appsettings.json
@@ -7,7 +7,7 @@
       "Database": "",
       "UserId": "",
       "Password": "",
-      "IsGuidFormatBinary16": true
+      "GuidFormat": "Binary16"
     }
   },
   "AllowedHosts": "*",

--- a/OutOfSchool/OutOfSchool.IdentityServer/appsettings.json
+++ b/OutOfSchool/OutOfSchool.IdentityServer/appsettings.json
@@ -1,4 +1,15 @@
 {
+  "ConnectionStringsOverride": {
+    "DefaultConnection": {
+      "UseOverride": false,
+      "Server": "",
+      "Port": 3306,
+      "Database": "",
+      "UserId": "",
+      "Password": "",
+      "IsGuidFormatBinary16": true
+    }
+  },
   "AllowedHosts": "*",
   "Serilog": {
     "Using": [],

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Common/MySqlConnectionExtensionTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Common/MySqlConnectionExtensionTest.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using MySqlConnector;
+using NUnit.Framework;
+using OutOfSchool.Common.Config;
+using OutOfSchool.Common.Extensions.Startup;
+using OutOfSchool.WebApi.Config;
+
+namespace OutOfSchool.WebApi.Tests.Common
+{
+    [TestFixture]
+    public class MySqlConnectionExtensionTest
+    {
+        private readonly string connectionStringNoGuidFormat = @"{""ConnectionStrings"": {
+        ""Test"": ""server=localhost;user=root;password=rootPassword;database=out_of_school""}}";
+
+        private readonly string connectionString = @"{""ConnectionStrings"": {
+        ""Test"": ""server=localhost;user=root;password=rootPassword;database=out_of_school;guidformat=binary16""}}";
+
+        private readonly string overrides = @"{""ConnectionStringsOverride"": {
+        ""Test"": {
+            ""UseOverride"": true,
+            ""Server"": ""localhost"",
+            ""Port"": 3306,
+            ""Database"": ""test"",
+            ""UserId"": ""root"",
+            ""Password"": ""rootPassword"",
+            ""IsGuidFormatBinary16"": true
+        }
+        }}";
+
+        private readonly string overridesNoGuidFormat = @"{""ConnectionStringsOverride"": {
+        ""Test"": {
+            ""UseOverride"": true,
+            ""Server"": ""localhost"",
+            ""Port"": 3306,
+            ""Database"": ""test"",
+            ""UserId"": ""root"",
+            ""Password"": ""rootPassword"",
+            ""IsGuidFormatBinary16"": false
+        }
+        }}";
+
+        private readonly string overridesConnectionString = @"{""ConnectionStringsOverride"": {
+        ""Test"": {
+            ""UseOverride"": false,
+            ""Server"": ""localhost"",
+            ""Port"": 3306,
+            ""Database"": ""test"",
+            ""UserId"": ""root"",
+            ""Password"": ""rootPassword"",
+            ""IsGuidFormatBinary16"": true
+        }
+        },
+        ""ConnectionStrings"": {
+        ""Test"": ""server=localhost;user=root;password=rootPassword;database=out_of_school;guidformat=binary16""}}";
+
+        [Test]
+        public void IfNoOverrides_UseConnectionString()
+        {
+            // Arrange
+            var configuration = Setup(connectionString);
+
+            // Act
+            var connection = configuration.GetMySqlConnectionString<WebApiConnectionOptions>("Test");
+
+            // Assert
+            Assert.AreEqual(connection, configuration.GetConnectionString("Test"));
+        }
+
+        [Test]
+        public void IfUseOverridesFalse_UseConnectionString()
+        {
+            // Arrange
+            var configuration = Setup(overridesConnectionString);
+
+            // Act
+            var connection = configuration.GetMySqlConnectionString<WebApiConnectionOptions>("Test");
+
+            // Assert
+            Assert.AreEqual(connection, configuration.GetConnectionString("Test"));
+        }
+
+        [Test]
+        public void IfUseOverridesTrue_CheckOptionsConverter()
+        {
+            // Arrange
+            var configuration = Setup(overrides);
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() =>
+                configuration.GetMySqlConnectionString<WebApiConnectionOptions>("Test"));
+        }
+
+        [Test]
+        public void IfUseOverridesTrue_Override()
+        {
+            // Arrange
+            var configuration = Setup(overrides);
+
+            // Act
+            var connection = configuration.GetMySqlConnectionString<WebApiConnectionOptions>(
+                "Test",
+                options => new MySqlConnectionStringBuilder
+                {
+                    Server = options.Server,
+                    Port = options.Port,
+                    UserID = options.UserId,
+                    Password = options.Password,
+                    Database = options.Database,
+                    GuidFormat = options.IsGuidFormatBinary16 ? MySqlGuidFormat.Binary16 : MySqlGuidFormat.Default,
+                });
+            var builder = new DbConnectionStringBuilder()
+            {
+                ConnectionString = connection,
+            };
+
+            // Assert
+            Assert.AreEqual("test", builder["database"]);
+        }
+
+        [Test]
+        public void IfUseOverridesTrue_NoGuidFormat_Throw()
+        {
+            // Arrange
+            var configuration = Setup(overridesNoGuidFormat);
+
+            // Act & Assert
+            var ex = Assert.Throws<Exception>(() =>
+                configuration.GetMySqlConnectionString<WebApiConnectionOptions>(
+                    "Test",
+                    options => new MySqlConnectionStringBuilder
+                    {
+                        Server = options.Server,
+                        Port = options.Port,
+                        UserID = options.UserId,
+                        Password = options.Password,
+                        Database = options.Database,
+                        GuidFormat = options.IsGuidFormatBinary16 ? MySqlGuidFormat.Binary16 : MySqlGuidFormat.Default,
+                    }));
+            Assert.AreEqual(
+                ex?.Message,
+                "The connection string should have a key: 'guidformat' and a value: 'binary16'");
+        }
+
+        [Test]
+        public void IfNoOverrides_NoConnectionString_Throw()
+        {
+            // Arrange
+            var configuration = Setup(connectionString);
+
+            // Act & Assert
+            var ex = Assert.Throws<Exception>(() =>
+                configuration.GetMySqlConnectionString<WebApiConnectionOptions>("Something"));
+            Assert.AreEqual(ex?.Message, "Provide a valid connection string or options");
+        }
+
+        [Test]
+        public void IfNoOverrides_ConnectionStringHasNoGuidFormat_Throw()
+        {
+            // Arrange
+            var configuration = Setup(connectionStringNoGuidFormat);
+
+            // Act & Assert
+            var ex = Assert.Throws<Exception>(() =>
+                configuration.GetMySqlConnectionString<WebApiConnectionOptions>("Test"));
+            Assert.AreEqual(
+                ex?.Message,
+                "The connection string should have a key: 'guidformat' and a value: 'binary16'");
+        }
+
+        private IConfiguration Setup(string json)
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)));
+            return builder.Build();
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Common/MySqlConnectionExtensionTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Common/MySqlConnectionExtensionTest.cs
@@ -1,14 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Data.Common;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Text;
 using Microsoft.Extensions.Configuration;
-using Moq;
 using MySqlConnector;
 using NUnit.Framework;
-using OutOfSchool.Common.Config;
+using OutOfSchool.Common.Extensions;
 using OutOfSchool.Common.Extensions.Startup;
 using OutOfSchool.WebApi.Config;
 
@@ -31,7 +28,7 @@ namespace OutOfSchool.WebApi.Tests.Common
             ""Database"": ""test"",
             ""UserId"": ""root"",
             ""Password"": ""rootPassword"",
-            ""IsGuidFormatBinary16"": true
+            ""GuidFormat"": ""Binary16""
         }
         }}";
 
@@ -43,7 +40,7 @@ namespace OutOfSchool.WebApi.Tests.Common
             ""Database"": ""test"",
             ""UserId"": ""root"",
             ""Password"": ""rootPassword"",
-            ""IsGuidFormatBinary16"": false
+            ""GuidFormat"": ""Binary16""
         }
         }}";
 
@@ -55,7 +52,7 @@ namespace OutOfSchool.WebApi.Tests.Common
             ""Database"": ""test"",
             ""UserId"": ""root"",
             ""Password"": ""rootPassword"",
-            ""IsGuidFormatBinary16"": true
+            ""GuidFormat"": ""Binary16""
         }
         },
         ""ConnectionStrings"": {
@@ -114,7 +111,7 @@ namespace OutOfSchool.WebApi.Tests.Common
                     UserID = options.UserId,
                     Password = options.Password,
                     Database = options.Database,
-                    GuidFormat = options.IsGuidFormatBinary16 ? MySqlGuidFormat.Binary16 : MySqlGuidFormat.Default,
+                    GuidFormat = options.GuidFormat.ToEnum(MySqlGuidFormat.Default),
                 });
             var builder = new DbConnectionStringBuilder()
             {
@@ -142,7 +139,7 @@ namespace OutOfSchool.WebApi.Tests.Common
                         UserID = options.UserId,
                         Password = options.Password,
                         Database = options.Database,
-                        GuidFormat = options.IsGuidFormatBinary16 ? MySqlGuidFormat.Binary16 : MySqlGuidFormat.Default,
+                        GuidFormat = options.GuidFormat.ToEnum(MySqlGuidFormat.Default),
                     }));
             Assert.AreEqual(
                 ex?.Message,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Common/StringExtensionsTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Common/StringExtensionsTest.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using OutOfSchool.Common.Extensions;
+
+namespace OutOfSchool.WebApi.Tests.Common
+{
+    [TestFixture]
+    public class StringExtensionsTest
+    {
+        private readonly string enumNull = null;
+        private readonly string enumEmpty = string.Empty;
+        private readonly string enumString = "Example";
+        private readonly string notEnumString = "Hello";
+
+        [Test]
+        public void IfNull_ReturnDefault()
+        {
+            var result = enumNull.ToEnum(Test.Default);
+            Assert.AreEqual(Test.Default, result);
+        }
+
+        [Test]
+        public void IfEmpty_ReturnDefault()
+        {
+            var result = enumEmpty.ToEnum(Test.Default);
+            Assert.AreEqual(Test.Default, result);
+        }
+
+        [Test]
+        public void IfNotExistValue_ReturnDefault()
+        {
+            var result = notEnumString.ToEnum(Test.Default);
+            Assert.AreEqual(Test.Default, result);
+        }
+
+        [Test]
+        public void IfCorrectValue_ReturnParsedEnum()
+        {
+            var result = enumString.ToEnum(Test.Default);
+            Assert.AreEqual(Test.Example, result);
+        }
+
+        internal enum Test
+        {
+            Default,
+            Example,
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Config/WebApiConnectionOptions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Config/WebApiConnectionOptions.cs
@@ -1,0 +1,21 @@
+using OutOfSchool.Common.Config;
+
+namespace OutOfSchool.WebApi.Config
+{
+    public class WebApiConnectionOptions : IMySqlConnectionOptions
+    {
+        public bool UseOverride { get; set; }
+
+        public string Server { get; set; }
+
+        public uint Port { get; set; }
+
+        public string Database { get; set; }
+
+        public string UserId { get; set; }
+
+        public string Password { get; set; }
+
+        public bool IsGuidFormatBinary16 { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Config/WebApiConnectionOptions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Config/WebApiConnectionOptions.cs
@@ -16,6 +16,6 @@ namespace OutOfSchool.WebApi.Config
 
         public string Password { get; set; }
 
-        public bool IsGuidFormatBinary16 { get; set; }
+        public string GuidFormat { get; set; }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -1,10 +1,9 @@
 using System;
-using System.Data.Common;
 using System.Globalization;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 using AutoMapper;
-using Google.Cloud.Storage.V1;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -14,8 +13,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
+using MySqlConnector;
 using OutOfSchool.Common;
 using OutOfSchool.Common.Config;
 using OutOfSchool.Common.Extensions.Startup;
@@ -30,7 +29,6 @@ using OutOfSchool.Services.Extensions;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Models.ChatWorkshop;
 using OutOfSchool.Services.Repository;
-using OutOfSchool.Services.Repository.Files;
 using OutOfSchool.WebApi.Config;
 using OutOfSchool.WebApi.Config.DataAccess;
 using OutOfSchool.WebApi.Config.Images;
@@ -42,8 +40,6 @@ using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Services.Communication;
 using OutOfSchool.WebApi.Services.Images;
 using OutOfSchool.WebApi.Util;
-using OutOfSchool.WebApi.Util.FakeImplementations;
-using Quartz;
 using Serilog;
 
 namespace OutOfSchool.WebApi
@@ -149,7 +145,7 @@ namespace OutOfSchool.WebApi
                 .ConfigurePrimaryHttpMessageHandler(handler =>
                     new HttpClientHandler()
                     {
-                        AutomaticDecompression = System.Net.DecompressionMethods.GZip,
+                        AutomaticDecompression = DecompressionMethods.GZip,
                     });
 
             services.AddScoped<IProviderAdminService, ProviderAdminService>();
@@ -165,22 +161,25 @@ namespace OutOfSchool.WebApi
             services.Configure<ImageOptions<Workshop>>(Configuration.GetSection($"Images:{nameof(Workshop)}:Specs"));
             services.Configure<ImageOptions<Teacher>>(Configuration.GetSection($"Images:{nameof(Teacher)}:Specs"));
 
-            var connectionString = Configuration.GetConnectionString("DefaultConnection");
-            var connectionStringBuilder = new DbConnectionStringBuilder();
-            connectionStringBuilder.ConnectionString = connectionString;
-            if (!connectionStringBuilder.ContainsKey("guidformat") ||
-                connectionStringBuilder["guidformat"].ToString().ToLower() != "binary16")
-            {
-                throw new Exception(
-                    "The connection string should have a key: \"guidformat\" and a value: \"binary16\"");
-            }
-
+            // TODO: Move version check into an extension to reuse code across apps
             var mySQLServerVersion = Configuration["MySQLServerVersion"];
             var serverVersion = new MySqlServerVersion(new Version(mySQLServerVersion));
             if (serverVersion.Version.Major < Constants.MySQLServerMinimalMajorVersion)
             {
                 throw new Exception("MySQL Server version should be 8 or higher.");
             }
+
+            var connectionString = Configuration.GetMySqlConnectionString<WebApiConnectionOptions>(
+                "DefaultConnection",
+                options => new MySqlConnectionStringBuilder
+                {
+                    Server = options.Server,
+                    Port = options.Port,
+                    UserID = options.UserId,
+                    Password = options.Password,
+                    Database = options.Database,
+                    GuidFormat = options.IsGuidFormatBinary16 ? MySqlGuidFormat.Binary16 : MySqlGuidFormat.Default,
+                });
 
             services.AddDbContext<OutOfSchoolDbContext>(builder =>
                     builder.UseLazyLoadingProxies().UseMySql(connectionString, serverVersion, mySqlOptions =>

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -17,6 +17,7 @@ using Microsoft.FeatureManagement;
 using MySqlConnector;
 using OutOfSchool.Common;
 using OutOfSchool.Common.Config;
+using OutOfSchool.Common.Extensions;
 using OutOfSchool.Common.Extensions.Startup;
 using OutOfSchool.Common.PermissionsModule;
 using OutOfSchool.ElasticsearchData;
@@ -178,7 +179,7 @@ namespace OutOfSchool.WebApi
                     UserID = options.UserId,
                     Password = options.Password,
                     Database = options.Database,
-                    GuidFormat = options.IsGuidFormatBinary16 ? MySqlGuidFormat.Binary16 : MySqlGuidFormat.Default,
+                    GuidFormat = options.GuidFormat.ToEnum(MySqlGuidFormat.Default),
                 });
 
             services.AddDbContext<OutOfSchoolDbContext>(builder =>

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -7,7 +7,7 @@
       "Database": "",
       "UserId": "",
       "Password": "",
-      "IsGuidFormatBinary16": true
+      "GuidFormat": "Binary16"
     }
   },
   "AppDefaults": {

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -1,4 +1,15 @@
 {
+  "ConnectionStringsOverride": {
+    "DefaultConnection": {
+      "UseOverride": false,
+      "Server": "",
+      "Port": 3306,
+      "Database": "",
+      "UserId": "",
+      "Password": "",
+      "IsGuidFormatBinary16": true
+    }
+  },
   "AppDefaults": {
     "City": "Київ"
   },


### PR DESCRIPTION
- Base options needed for every service
- Possible to have different options per service
- Possible to change any database connection option by changing a single environment variable instead of generating a new connection string all the time even for a small change