### PR TITLE
Provicevko/gcp synchronization

### DIFF
--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/Files/GcpFilesStorageBase.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/Files/GcpFilesStorageBase.cs
@@ -1,14 +1,21 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Google.Api.Gax;
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Storage.v1.Data;
 using Google.Cloud.Storage.V1;
 using OutOfSchool.Services.Common.Exceptions;
 using OutOfSchool.Services.Contexts;
 using OutOfSchool.Services.Contexts.Configuration;
 using OutOfSchool.Services.Extensions;
 using OutOfSchool.Services.Models;
+using Object = System.Object;
 
 namespace OutOfSchool.Services.Repository.Files
 {
@@ -24,6 +31,12 @@ namespace OutOfSchool.Services.Repository.Files
         private protected StorageClient StorageClient { get; }
 
         private protected string BucketName { get; }
+
+        public async Task<IAsyncEnumerable<Objects>> GetBulkListsOfObjectsAsync(string prefix = null, ListObjectsOptions options = null)
+        {
+            var objects = await Task.Run(() => StorageClient.ListObjectsAsync(BucketName, prefix: prefix, options: options));
+            return objects.AsRawResponses();
+        }
 
         /// <inheritdoc/>
         public virtual async Task<TFile> GetByIdAsync(string fileId, CancellationToken cancellationToken = default)

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/Files/GcpImagesSyncDataRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/Files/GcpImagesSyncDataRepository.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Services.Models.Images;
+
+namespace OutOfSchool.Services.Repository.Files
+{
+    public class GcpImagesSyncDataRepository : IGcpImagesSyncDataRepository
+    {
+        private readonly OutOfSchoolDbContext dbContext;
+        private readonly DbSet<Workshop> workshopSet;
+        private readonly DbSet<Teacher> teacherSet;
+        private readonly DbSet<Provider> providerSet;
+        private readonly DbSet<Image<Workshop>> workshopImagesSet;
+        private readonly DbSet<Image<Provider>> providerImagesSet;
+
+        public GcpImagesSyncDataRepository(OutOfSchoolDbContext dbContext)
+        {
+            this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+
+            workshopSet = dbContext.Set<Workshop>();
+            teacherSet = dbContext.Set<Teacher>();
+            providerSet = dbContext.Set<Provider>();
+            workshopImagesSet = dbContext.Set<Image<Workshop>>();
+            providerImagesSet = dbContext.Set<Image<Provider>>();
+        }
+
+        #region EntityCoverImages
+
+        public async Task<List<string>> GetIntersectWorkshopCoverImagesIds(IEnumerable<string> searchIds)
+            => await GetIntersectEntityCoverImagesIds(workshopSet, searchIds).ConfigureAwait(false);
+
+        public async Task<List<string>> GetIntersectTeacherCoverImagesIds(IEnumerable<string> searchIds)
+            => await GetIntersectEntityCoverImagesIds(teacherSet, searchIds).ConfigureAwait(false);
+
+        public async Task<List<string>> GetIntersectProviderCoverImagesIds(IEnumerable<string> searchIds)
+            => await GetIntersectEntityCoverImagesIds(providerSet, searchIds).ConfigureAwait(false);
+
+        #endregion
+
+        #region EntityImages
+
+        public async Task<List<string>> GetIntersectWorkshopImagesIds(IEnumerable<string> searchIds)
+            => await GetIntersectEntityImagesIds(workshopImagesSet, searchIds).ConfigureAwait(false);
+
+        public async Task<List<string>> GetIntersectProviderImagesIds(IEnumerable<string> searchIds)
+            => await GetIntersectEntityImagesIds(providerImagesSet, searchIds).ConfigureAwait(false);
+
+        #endregion
+
+        private async Task<List<string>> GetIntersectEntityCoverImagesIds<TEntity>(
+            IQueryable<TEntity> dbSet,
+            IEnumerable<string> searchIds)
+            where TEntity : class, IKeyedEntity, IImageDependentEntity<TEntity>, new()
+        {
+            _ = searchIds ?? throw new ArgumentNullException(nameof(searchIds));
+
+            return await dbSet
+                .Where(x => searchIds.Contains(x.CoverImageId))
+                .Select(x => x.CoverImageId)
+                .ToListAsync().ConfigureAwait(false);
+        }
+
+        private async Task<List<string>> GetIntersectEntityImagesIds<TEntity>(
+            IQueryable<Image<TEntity>> dbSet,
+            IEnumerable<string> searchIds)
+            where TEntity : class, IKeyedEntity, IImageDependentEntity<TEntity>, new()
+        {
+            _ = searchIds ?? throw new ArgumentNullException(nameof(searchIds));
+
+            return await dbSet
+                .Select(x => x.ExternalStorageId)
+                .Where(x => searchIds.Contains(x))
+                .ToListAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/Files/IFilesStorage.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/Files/IFilesStorage.cs
@@ -1,5 +1,10 @@
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Google.Api.Gax;
+using Google.Apis.Storage.v1.Data;
+using Google.Cloud.Storage.V1;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Models.Images;
 
@@ -8,6 +13,8 @@ namespace OutOfSchool.Services.Repository.Files
     public interface IFilesStorage<TFile, TIdentifier>
         where TFile : FileModel
     {
+        Task<IAsyncEnumerable<Objects>> GetBulkListsOfObjectsAsync(string prefix = null, ListObjectsOptions options = null);
+
         /// <summary>
         /// Asynchronously gets a file by its id.
         /// </summary>

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/Files/IGcpImagesSyncDataRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/Files/IGcpImagesSyncDataRepository.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace OutOfSchool.Services.Repository.Files
+{
+    public interface IGcpImagesSyncDataRepository
+    {
+        Task<List<string>> GetIntersectWorkshopCoverImagesIds(IEnumerable<string> searchIds);
+
+        Task<List<string>> GetIntersectTeacherCoverImagesIds(IEnumerable<string> searchIds);
+
+        Task<List<string>> GetIntersectProviderCoverImagesIds(IEnumerable<string> searchIds);
+
+        Task<List<string>> GetIntersectWorkshopImagesIds(IEnumerable<string> searchIds);
+
+        Task<List<string>> GetIntersectProviderImagesIds(IEnumerable<string> searchIds);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/FileStorageExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/FileStorageExtensions.cs
@@ -61,7 +61,7 @@ namespace OutOfSchool.WebApi.Extensions.Startup
                 .WithIdentity("gcpImagesJobTrigger", "gcp")
                 .ForJob(gcpImagesJobKey)
                 .StartNow()
-                .WithSimpleSchedule(x => x.WithIntervalInSeconds(30).RepeatForever()));
+                .WithCronSchedule("0 0 0 * * ?"));
 
             return services;
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/FileStorageExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/FileStorageExtensions.cs
@@ -51,6 +51,7 @@ namespace OutOfSchool.WebApi.Extensions.Startup
         {
             _ = services ?? throw new ArgumentNullException(nameof(services));
 
+            services.AddScoped<IGcpImagesSyncDataRepository, GcpImagesSyncDataRepository>();
             services.AddScoped<IGcpStorageSynchronizationService, GcpImagesStorageSynchronizationService>();
 
             var gcpImagesJobKey = new JobKey("gcpImagesJob", "gcp");

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/QuartzExtension.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/QuartzExtension.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MySqlConnector;
+using OutOfSchool.Common.Extensions.Startup;
+using OutOfSchool.WebApi.Config;
+using OutOfSchool.WebApi.Services.Elasticsearch;
+using OutOfSchool.WebApi.Util;
+using Quartz;
+
+namespace OutOfSchool.WebApi.Extensions.Startup
+{
+    public static class QuartzExtension
+    {
+        public static IServiceCollection AddDefaultQuartz(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            _ = services ?? throw new ArgumentNullException(nameof(services));
+
+            services.AddQuartz(q =>
+            {
+                q.SchedulerId = "DefaultAppQuartz";
+                q.SchedulerName = "DefaultAppQuartz";
+                q.SetProperty("quartz.serializer.type", "json");
+                q.SetProperty("quartz.jobStore.type", "Quartz.Impl.AdoJobStore.JobStoreTX, Quartz");
+                q.SetProperty("quartz.jobStore.dataSource", "default");
+                q.SetProperty("quartz.dataSource.default.provider", "MySql");
+                q.SetProperty(
+                    "quartz.dataSource.default.connectionString",
+                    configuration.GetMySqlConnectionString<QuartzConnectionOptions>(
+                        "QuartzConnection",
+                        options => new MySqlConnectionStringBuilder
+                        {
+                            Server = options.Server,
+                            Port = options.Port,
+                            UserID = options.UserId,
+                            Password = options.Password,
+                            Database = options.Database,
+                        }));
+                q.SetProperty("quartz.jobStore.clustered", "true");
+                q.SetProperty("quartz.jobStore.driverDelegateType", "Quartz.Impl.AdoJobStore.StdAdoDelegate, Quartz");
+                q.SetProperty("quartz.jobStore.useProperties", "true");
+                q.UseMicrosoftDependencyInjectionJobFactory();
+
+                foreach (var quartzAction in QuartzPool.GetQuartzConfigActions)
+                {
+                    quartzAction?.Invoke(q);
+                }
+            });
+
+            services.AddQuartzServer(options => { options.WaitForJobsToComplete = true; });
+
+            QuartzPool.Done();
+
+            return services;
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/GcpImagesStorageSynchronizationService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/GcpImagesStorageSynchronizationService.cs
@@ -21,7 +21,9 @@ namespace OutOfSchool.WebApi.Services.Gcp
     public class GcpImagesStorageSynchronizationService : IGcpStorageSynchronizationService
     {
         private const string ListObjectOptionsFields = "items(name,timeCreated),nextPageToken";
-        private const int ListObjectOptionsPageSize = 5;
+
+        // TODO: must be changed to approximately 10000 after testing
+        private const int ListObjectOptionsPageSize = 25;
 
         private readonly ILogger<GcpImagesStorageSynchronizationService> logger;
         private readonly IImageFilesStorage imagesStorage;
@@ -42,8 +44,9 @@ namespace OutOfSchool.WebApi.Services.Gcp
             try
             {
                 logger.LogDebug("Gcp storage synchronization was started at utc time: {Time}", DateTime.UtcNow);
-                var dateTimeNowUtc = DateTime.Now;
-                var jokeData = dateTimeNowUtc;
+
+                // gcp returns data by local time
+                var dateTime = DateTime.Now.AddMinutes(-1);
 
                 var listsOfObjects = await GetListsOfObjects(cancellationToken).ConfigureAwait(false);
                 var tasks = new List<Task>();
@@ -57,7 +60,7 @@ namespace OutOfSchool.WebApi.Services.Gcp
 
                     Console.WriteLine(objects.NextPageToken);
                     var mappedObjects = objects.Items
-                        .Where(x => x.TimeCreated <= jokeData)
+                        .Where(x => x.TimeCreated < dateTime)
                         .Select(x => x.Name)
                         .ToHashSet();
 

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/GcpImagesStorageSynchronizationService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/GcpImagesStorageSynchronizationService.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Apis.Storage.v1.Data;
+using Google.Cloud.Storage.V1;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Services.Models.Images;
+using OutOfSchool.Services.Repository;
+using OutOfSchool.Services.Repository.Files;
+using OutOfSchool.WebApi.Models;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace OutOfSchool.WebApi.Services.Gcp
+{
+    public class GcpImagesStorageSynchronizationService : IGcpStorageSynchronizationService
+    {
+        private readonly ILogger<GcpImagesStorageSynchronizationService> logger;
+        private readonly IImageFilesStorage imagesStorage;
+        private readonly IWorkshopRepository workshopRepository;
+        private readonly ISensitiveEntityRepository<Teacher> teacherRepository;
+        private readonly IProviderRepository providerRepository;
+
+        public GcpImagesStorageSynchronizationService(
+            ILogger<GcpImagesStorageSynchronizationService> logger,
+            IWorkshopRepository workshopRepository,
+            ISensitiveEntityRepository<Teacher> teacherRepository,
+            IProviderRepository providerRepository,
+            IImageFilesStorage imagesStorage)
+        {
+            this.logger = logger;
+            this.imagesStorage = imagesStorage;
+            this.workshopRepository = workshopRepository;
+            this.teacherRepository = teacherRepository;
+            this.providerRepository = providerRepository;
+        }
+
+        // TODO: add try/catch
+        public async Task SynchronizeAsync(CancellationToken cancellationToken = default)
+        {
+            var dateTimeNowUtc = DateTime.Now;
+            var jokeData = dateTimeNowUtc.AddDays(-1);
+
+            var listsOfObjects = await GetListsOfObjects(cancellationToken).ConfigureAwait(false);
+
+            var deleteIds = new List<string>();
+
+            // TODO: add TPL usage for every pack of objects
+            await foreach (var objects in listsOfObjects.WithCancellation(cancellationToken))
+            {
+                Debug.WriteLine(objects.NextPageToken);
+                var mappedObjects = objects.Items
+                    .Where(x => x.TimeCreated <= jokeData)
+                    .Select(x => x.Name)
+                    .ToHashSet();
+
+                var notAttachedIds = await SynchronizeAll(mappedObjects, cancellationToken).ConfigureAwait(false);
+
+                // TODO: uncomment this
+                // await RemoveNotAttachedIds(notAttachedIds).ConfigureAwait(false);
+
+                Console.WriteLine($"{objects.Items.Count} : {mappedObjects.Count()}");
+            }
+        }
+
+        private static async Task<List<string>> SynchronizeEntityCoverImages<TRepository, TEntity, TKey>(TRepository repository, IEnumerable<string> searchIds)
+            where TRepository : IEntityRepositoryBase<TKey, TEntity>
+            where TEntity : class, IKeyedEntity<TKey>, IImageDependentEntity<TEntity>, new()
+        {
+            return await repository
+                .GetByFilterNoTracking(x => searchIds.Contains(x.CoverImageId))
+                .Select(x => x.CoverImageId)
+                .ToListAsync().ConfigureAwait(false);
+        }
+
+        private static async Task<List<string>> SynchronizeEntityImages<TRepository, TEntity, TKey>(TRepository repository, IEnumerable<string> searchIds)
+            where TRepository : IEntityRepositoryBase<TKey, TEntity>
+            where TEntity : class, IKeyedEntity<TKey>, IImageDependentEntity<TEntity>, new()
+        {
+            return await repository
+                .GetByFilterNoTracking(x => !x.Images
+                    .Select(i => i.ExternalStorageId)
+                    .Intersect(searchIds).Any())
+                .SelectMany(x => x.Images.Select(i => i.ExternalStorageId))
+                .ToListAsync().ConfigureAwait(false);
+        }
+
+        private List<Func<IEnumerable<string>, Task<List<string>>>> GetAllSyncFunctions()
+        {
+            return new List<Func<IEnumerable<string>, Task<List<string>>>>
+            {
+                SynchronizeWorkshopImages,
+                SynchronizeProviderImages,
+                SynchronizeWorkshopCoverImages,
+                SynchronizeTeacherCoverImages,
+                SynchronizeProviderCoverImages,
+            };
+        }
+
+        private async Task<HashSet<string>> SynchronizeAll(HashSet<string> searchIds, CancellationToken cancellationToken = default)
+        {
+            var allSyncFunctions = GetAllSyncFunctions();
+
+            foreach (var syncFunction in allSyncFunctions)
+            {
+                var syncResult = await syncFunction(searchIds).ConfigureAwait(false);
+                if (syncResult != null)
+                {
+                    searchIds.ExceptWith(syncResult);
+                }
+            }
+
+            return searchIds;
+        }
+
+        private async Task<List<string>> SynchronizeWorkshopCoverImages(IEnumerable<string> searchIds)
+            => await SynchronizeEntityCoverImages<IWorkshopRepository, Workshop, Guid>(workshopRepository, searchIds).ConfigureAwait(false);
+
+        private async Task<List<string>> SynchronizeTeacherCoverImages(IEnumerable<string> searchIds)
+            => await SynchronizeEntityCoverImages<ISensitiveEntityRepository<Teacher>, Teacher, Guid>(teacherRepository, searchIds).ConfigureAwait(false);
+
+        private async Task<List<string>> SynchronizeProviderCoverImages(IEnumerable<string> searchIds)
+            => await SynchronizeEntityCoverImages<IProviderRepository, Provider, Guid>(providerRepository, searchIds).ConfigureAwait(false);
+
+        private async Task<List<string>> SynchronizeWorkshopImages(IEnumerable<string> searchIds)
+            => await SynchronizeEntityImages<IWorkshopRepository, Workshop, Guid>(workshopRepository, searchIds)
+                .ConfigureAwait(false);
+
+        private async Task<List<string>> SynchronizeProviderImages(IEnumerable<string> searchIds)
+            => await SynchronizeEntityImages<ISensitiveEntityRepository<Teacher>, Teacher, Guid>(teacherRepository, searchIds)
+                .ConfigureAwait(false);
+
+        private async Task<IAsyncEnumerable<Objects>> GetListsOfObjects(CancellationToken cancellationToken = default)
+        {
+            var options = new ListObjectsOptions
+            {
+                Fields = "items(name,timeCreated),nextPageToken",
+                PageSize = 50,
+            };
+
+            return await imagesStorage.GetBulkListsOfObjectsAsync(options: options).ConfigureAwait(false);
+        }
+
+        private async Task RemoveNotAttachedIds(IEnumerable<string> idsToRemove)
+        {
+            foreach (var id in idsToRemove)
+            {
+                try
+                {
+                    await imagesStorage.DeleteAsync(id).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e, "Image was not deleted because the storage had thrown exception");
+                }
+            }
+        }
+
+        // private HashSet<string> SynchronizeEntityImages(IEnumerable<string> searchIds)
+        // {
+        //     return workshopRepository
+        //         .GetByFilterNoTracking(x => x.Images.Select(r => r.ExternalStorageId).Intersect(searchIds))
+        //         .Select(x => x.CoverImageId)
+        //         .ToHashSet();
+        // }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/GcpImagesStorageSynchronizationService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/GcpImagesStorageSynchronizationService.cs
@@ -24,6 +24,7 @@ namespace OutOfSchool.WebApi.Services.Gcp
 
         // TODO: must be changed to approximately 10000 after testing
         private const int ListObjectOptionsPageSize = 25;
+        private const byte CountOfTasksAtOneTime = 10;
 
         private readonly ILogger<GcpImagesStorageSynchronizationService> logger;
         private readonly IImageFilesStorage imagesStorage;
@@ -58,7 +59,6 @@ namespace OutOfSchool.WebApi.Services.Gcp
                         break;
                     }
 
-                    Console.WriteLine(objects.NextPageToken);
                     var mappedObjects = objects.Items
                         .Where(x => x.TimeCreated < dateTime)
                         .Select(x => x.Name)
@@ -71,9 +71,9 @@ namespace OutOfSchool.WebApi.Services.Gcp
                             await RemoveNotAttachedIds(notAttachedIds).ConfigureAwait(false);
                         }, cancellationToken));
 
-                    if (tasks.Count % 10 == 0)
+                    if (tasks.Count % CountOfTasksAtOneTime == 0)
                     {
-                        await Task.WhenAll(tasks).ConfigureAwait(false); // in order to decrease CPU and memory using, works by parts count of 10 tasks
+                        await Task.WhenAll(tasks.GetRange(tasks.Count - CountOfTasksAtOneTime, CountOfTasksAtOneTime)).ConfigureAwait(false); // in order to decrease CPU and memory using, works by parts count of 10 tasks
                     }
                 }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/GcpStorageSynchronizationQuartzJob.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/GcpStorageSynchronizationQuartzJob.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using OutOfSchool.WebApi.Services.Gcp;
 using Quartz;
 
-namespace OutOfSchool.WebApi.Services.Images
+namespace OutOfSchool.WebApi.Services.Gcp
 {
     public class GcpStorageSynchronizationQuartzJob : IJob
     {

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/GcpStorageSynchronizationQuartzJob.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/GcpStorageSynchronizationQuartzJob.cs
@@ -19,11 +19,11 @@ namespace OutOfSchool.WebApi.Services.Gcp
 
         public async Task Execute(IJobExecutionContext context)
         {
-            logger.LogDebug("Gcp storage synchronization was started");
+            logger.LogDebug("Gcp storage synchronization job was started");
 
             await gcpStorageSynchronizationService.SynchronizeAsync().ConfigureAwait(false);
 
-            logger.LogDebug("Gcp storage synchronization was finished");
+            logger.LogDebug("Gcp storage synchronization job was finished");
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/IGcpStorageSynchronizationService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Gcp/IGcpStorageSynchronizationService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OutOfSchool.WebApi.Services.Gcp
+{
+    public interface IGcpStorageSynchronizationService
+    {
+        Task SynchronizeAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Images/GcpStorageSynchronizationQuartzJob.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Images/GcpStorageSynchronizationQuartzJob.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OutOfSchool.WebApi.Services.Gcp;
+using Quartz;
+
+namespace OutOfSchool.WebApi.Services.Images
+{
+    public class GcpStorageSynchronizationQuartzJob : IJob
+    {
+        private readonly IGcpStorageSynchronizationService gcpStorageSynchronizationService;
+        private readonly ILogger<GcpStorageSynchronizationQuartzJob> logger;
+
+        public GcpStorageSynchronizationQuartzJob(
+            IGcpStorageSynchronizationService gcpStorageSynchronizationService,
+            ILogger<GcpStorageSynchronizationQuartzJob> logger)
+        {
+            this.gcpStorageSynchronizationService = gcpStorageSynchronizationService;
+            this.logger = logger;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            logger.LogDebug("Gcp storage synchronization was started");
+
+            await gcpStorageSynchronizationService.SynchronizeAsync().ConfigureAwait(false);
+
+            logger.LogDebug("Gcp storage synchronization was finished");
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -31,6 +31,7 @@ using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Models.ChatWorkshop;
 using OutOfSchool.Services.Models.SubordinationStructure;
 using OutOfSchool.Services.Repository;
+using OutOfSchool.Services.Repository.Files;
 using OutOfSchool.WebApi.Config;
 using OutOfSchool.WebApi.Config.DataAccess;
 using OutOfSchool.WebApi.Config.Images;
@@ -40,6 +41,7 @@ using OutOfSchool.WebApi.Hubs;
 using OutOfSchool.WebApi.Middlewares;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Services.Communication;
+using OutOfSchool.WebApi.Services.Gcp;
 using OutOfSchool.WebApi.Services.Images;
 using OutOfSchool.WebApi.Services.SubordinationStructure;
 using OutOfSchool.WebApi.Util;
@@ -161,7 +163,7 @@ namespace OutOfSchool.WebApi
             // Image options
             services.Configure<GcpStorageImagesSourceConfig>(Configuration.GetSection(GcpStorageConfigConstants.GcpStorageImagesConfig));
             services.Configure<ExternalImageSourceConfig>(Configuration.GetSection(ExternalImageSourceConfig.Name));
-            services.AddSingleton<MongoDb>();
+            //services.AddSingleton<MongoDb>();
             services.Configure<ImageOptions<Workshop>>(Configuration.GetSection($"Images:{nameof(Workshop)}:Specs"));
             services.Configure<ImageOptions<Teacher>>(Configuration.GetSection($"Images:{nameof(Teacher)}:Specs"));
             services.Configure<ImageOptions<Provider>>(Configuration.GetSection($"Images:{nameof(Provider)}:Specs"));
@@ -277,6 +279,7 @@ namespace OutOfSchool.WebApi
             services.AddTransient<IWorkshopRepository, WorkshopRepository>();
             //services.AddTransient<IExternalImageStorage, ExternalImageStorage>();
             services.AddImagesStorage(turnOnFakeStorage: Configuration.GetValue<bool>("TurnOnFakeImagesStorage"));
+            services.AddGcpSynchronization();
 
             services.AddTransient<IElasticsearchSyncRecordRepository, ElasticsearchSyncRecordRepository>();
             services.AddTransient<INotificationRepository, NotificationRepository>();
@@ -324,6 +327,7 @@ namespace OutOfSchool.WebApi
             services.AddAutoMapper(typeof(MappingProfile));
 
             services.AddSignalR();
+            services.AddDefaultQuartz(Configuration);
 
             services.AddStackExchangeRedisCache(options =>
             {

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -279,7 +279,7 @@ namespace OutOfSchool.WebApi
             services.AddTransient<IWorkshopRepository, WorkshopRepository>();
             //services.AddTransient<IExternalImageStorage, ExternalImageStorage>();
             services.AddImagesStorage(turnOnFakeStorage: Configuration.GetValue<bool>("TurnOnFakeImagesStorage"));
-            services.AddGcpSynchronization();
+            services.AddGcpSynchronization(Configuration);
 
             services.AddTransient<IElasticsearchSyncRecordRepository, ElasticsearchSyncRecordRepository>();
             services.AddTransient<INotificationRepository, NotificationRepository>();

--- a/OutOfSchool/OutOfSchool.WebApi/Util/FakeImplementations/FakeImagesStorage.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/FakeImplementations/FakeImagesStorage.cs
@@ -1,13 +1,23 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Google.Api.Gax;
+using Google.Apis.Storage.v1.Data;
+using Google.Cloud.Storage.V1;
 using OutOfSchool.Services.Models.Images;
 using OutOfSchool.Services.Repository.Files;
+using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace OutOfSchool.WebApi.Util.FakeImplementations
 {
     public class FakeImagesStorage : IImageFilesStorage
     {
+        public Task<IAsyncEnumerable<Objects>> GetBulkListsOfObjectsAsync(string prefix = null, ListObjectsOptions options = null)
+        {
+            throw new NotSupportedException();
+        }
+
         public Task<ImageFileModel> GetByIdAsync(string fileId, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new ImageFileModel());

--- a/OutOfSchool/OutOfSchool.WebApi/Util/QuartzPool.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/QuartzPool.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using Quartz;
+
+namespace OutOfSchool.WebApi.Util
+{
+    public static class QuartzPool
+    {
+        private static List<Action<IServiceCollectionQuartzConfigurator>> quartzConfigActions
+            = new List<Action<IServiceCollectionQuartzConfigurator>>();
+
+        public static IReadOnlyList<Action<IServiceCollectionQuartzConfigurator>> GetQuartzConfigActions
+            => quartzConfigActions.AsReadOnly();
+
+        public static void AddJob<T>(Action<IJobConfigurator> configure = null)
+            where T : IJob
+        {
+            quartzConfigActions.Add(q => q.AddJob<T>(configure));
+        }
+
+        public static void AddTrigger(Action<ITriggerConfigurator> configure = null)
+        {
+            quartzConfigActions.Add(t => t.AddTrigger(configure));
+        }
+
+        public static void Done() => quartzConfigActions = new List<Action<IServiceCollectionQuartzConfigurator>>();
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -174,6 +174,11 @@
       "OperationsPerTask": 10,
       "DelayBetweenTasksInMilliseconds": 60000
     }
+  },
+  "Quartz": {
+    "CronSchedules":{
+      "GcpImagesSyncCronScheduleString": "0 0 0 * * ?"
+    }
   }
 }
 


### PR DESCRIPTION
**Supposedly must cover operations with many files (up to some millions)**

**Changes:**
- moved default quartz config to separate extension method
- added custom quartz task pool that is used to add initial jobs with one default quartz
- created gcp sync data repository in order to make explict queries and avoid unwanted inner joins we have if wanna get images from entity with EntityRepositoryBase methods
- created quartz job for synchronize gcp storage images with main db OutOfSchool
- created relevant service for completing sync operation

**The default values for testing period:**
- sync every day at 00:00
- 25 objects per page from gcp

**Estimated values those must be after testing:**
 - sync every 3-6 months at 00:00
 - 10000+ objects per page (should be tested in related tests)

**Pay attention to:**
- `GcpImagesStorageSynchronizationService.SynchronizeAsync()` method.
- performance

I try to limit 10 tasks at time and wait until they are completed to save memory usage but I'm not sure absolutely that there will be any ability to release memory by GC if it needs because of stack references.
Theoretically:
- in `SynchronizeAsync() await foreach(){}` `mappedObjects` will be detached from execution context in next iteration but there is still a reference to it in `SynchronizeAll(mappedObjects, cancellationToken)`
- after completing a task with `SynchronizeAll(mappedObjects, cancellationToken)` in another thread, `mappedObjects` must be without any reference so it can be released by GC.

**Future: Tests will be written after we agree the final version.**