### PR TITLE
#657 workshop create with teachers

### DIFF
--- a/OutOfSchool/OutOfSchool.IdentityServer.Tests/Controllers/AccountControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer.Tests/Controllers/AccountControllerTests.cs
@@ -46,8 +46,8 @@ namespace OutOfSchool.IdentityServer.Tests.Controllers
                 fakeUserManager.Object,
                 fakeEmailSender.Object,
                 fakeLogger.Object,
-                fakeLocalizer.Object,
-                fakeRazorViewToStringRenderer.Object
+                fakeRazorViewToStringRenderer.Object,
+                fakeLocalizer.Object
                 );
         }
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -70,6 +70,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
         {
             workshopServiceMoq = new Mock<IWorkshopServicesCombiner>();
             providerServiceMoq = new Mock<IProviderService>();
+            providerAdminService = new Mock<IProviderAdminService>();
             localizer = new Mock<IStringLocalizer<SharedResource>>();
 
             controller = new WorkshopController(workshopServiceMoq.Object, providerServiceMoq.Object, providerAdminService.Object, localizer.Object, options.Object)

--- a/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
@@ -46,7 +46,6 @@ namespace OutOfSchool.WebApi.Util
 
                     return dateTimeRanges;
                 }))
-                .ForMember(dest => dest.Teachers, opt => opt.Ignore())
                 .ForMember(dest => dest.Images, opt => opt.Ignore())
                 .ForMember(dest => dest.CoverImageId, opt => opt.Ignore());
 


### PR DESCRIPTION
Changes:
* Teachers create/update with workshop create/update methods. 
If the teacher model is removed from workshop model then teacher will be removed from DB

Fixed:

* AccountControllerTests incorrect objects sequence
* WorkshopControllerTests  providerAdminService was null

All tests in  WorkshopControllerTests and AccountControllerTests  are passed