### PR TITLE
#859 socialgroup multiselection

### DIFF
--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Child.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Child.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using System.Collections.Generic;
 using OutOfSchool.Services.Enums;
 
 namespace OutOfSchool.Services.Models
@@ -25,8 +25,8 @@ namespace OutOfSchool.Services.Models
 
         public virtual Parent Parent { get; set; }
 
-        public long? SocialGroupId { get; set; }
+        public virtual ICollection<SocialGroup> SocialGroups { get; set; }
 
-        public virtual SocialGroup SocialGroup { get; set; }
+        public virtual List<ChildSocialGroup> ChildSocialGroups { get; set; }
     }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ChildSocialGroup.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ChildSocialGroup.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace OutOfSchool.Services.Models
+{
+    public class ChildSocialGroup
+    {
+        public Guid ChildId { get; set; }
+
+        public virtual Child Child { get; set; }
+
+        public long SocialGroupId { get; set; }
+
+        public virtual SocialGroup SocialGroup { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/ChildConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/ChildConfiguration.cs
@@ -34,6 +34,19 @@ namespace OutOfSchool.Services.Models.Configurations
 
             builder.Property(x => x.PlaceOfStudy)
                 .HasMaxLength(500);
+
+            builder
+                .HasMany(x => x.SocialGroups)
+                .WithMany(x => x.Children)
+                .UsingEntity<ChildSocialGroup>(
+                    j => j
+                        .HasOne(pt => pt.SocialGroup)
+                        .WithMany(t => t.ChildSocialGroups)
+                        .HasForeignKey(pt => pt.SocialGroupId),
+                    j => j
+                        .HasOne(pt => pt.Child)
+                        .WithMany(t => t.ChildSocialGroups)
+                        .HasForeignKey(pt => pt.ChildId));
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/SocialGroup.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/SocialGroup.cs
@@ -6,16 +6,13 @@ namespace OutOfSchool.Services.Models
 {
     public class SocialGroup : IKeyedEntity<long>
     {
-        public SocialGroup()
-        {
-            Children = new List<Child>();
-        }
-
         public long Id { get; set; }
 
         [MaxLength(100)]
         public string Name { get; set; } = string.Empty;
 
         public virtual IReadOnlyCollection<Child> Children { get; set; }
+
+        public virtual List<ChildSocialGroup> ChildSocialGroups { get; set; }
     }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/OutOfSchoolDbContext.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/OutOfSchoolDbContext.cs
@@ -32,6 +32,8 @@ namespace OutOfSchool.Services
 
         public DbSet<Child> Children { get; set; }
 
+        public DbSet<ChildSocialGroup> ChildrenSocialGroups { get; set; }
+
         public DbSet<Workshop> Workshops { get; set; }
 
         public DbSet<Teacher> Teachers { get; set; }

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/ChildRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/ChildRepository.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using OutOfSchool.Services.Models;
+
+namespace OutOfSchool.Services.Repository
+{
+    public class ChildRepository : EntityRepository<Child>, IEntityRepository<Child>
+    {
+        private readonly OutOfSchoolDbContext db;
+
+        public ChildRepository(OutOfSchoolDbContext dbContext)
+         : base(dbContext)
+        {
+            db = dbContext;
+        }
+
+        public override Task<Child> Create(Child child)
+        {
+            db.SocialGroups.AttachRange(child.SocialGroups);
+            return base.Create(child);
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20220610100800_AddChildSocialGroups.Designer.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20220610100800_AddChildSocialGroups.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
 namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220610100800_AddChildSocialGroups")]
+    partial class AddChildSocialGroups
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20220610100800_AddChildSocialGroups.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20220610100800_AddChildSocialGroups.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
+{
+    public partial class AddChildSocialGroups : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Children_SocialGroups_SocialGroupId",
+                table: "Children");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Children_SocialGroupId",
+                table: "Children");
+
+            migrationBuilder.DropColumn(
+                name: "SocialGroupId",
+                table: "Children");
+
+            migrationBuilder.CreateTable(
+                name: "ChildrenSocialGroups",
+                columns: table => new
+                {
+                    ChildId = table.Column<Guid>(type: "binary(16)", nullable: false),
+                    SocialGroupId = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChildrenSocialGroups", x => new { x.ChildId, x.SocialGroupId });
+                    table.ForeignKey(
+                        name: "FK_ChildrenSocialGroups_Children_ChildId",
+                        column: x => x.ChildId,
+                        principalTable: "Children",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ChildrenSocialGroups_SocialGroups_SocialGroupId",
+                        column: x => x.SocialGroupId,
+                        principalTable: "SocialGroups",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChildrenSocialGroups_SocialGroupId",
+                table: "ChildrenSocialGroups",
+                column: "SocialGroupId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChildrenSocialGroups");
+
+            migrationBuilder.AddColumn<long>(
+                name: "SocialGroupId",
+                table: "Children",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Children_SocialGroupId",
+                table: "Children",
+                column: "SocialGroupId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Children_SocialGroups_SocialGroupId",
+                table: "Children",
+                column: "SocialGroupId",
+                principalTable: "SocialGroups",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ParentControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ParentControllerTests.cs
@@ -87,7 +87,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     MiddleName = "MiddleName",
                     DateOfBirth = new DateTime(2005, 2, 23),
                     Gender = Gender.Male,
-                    SocialGroupId = 1,
+                    SocialGroups = new List<SocialGroupDto>
+                    {
+                        new SocialGroupDto{ Id = 1, Name = "FakeSocialGroup" },
+                    },
                     ParentId = Guid.NewGuid(),
                 },
                 new ChildDto()
@@ -98,7 +101,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     MiddleName = "MiddleName",
                     DateOfBirth = new DateTime(2005, 2, 23),
                     Gender = Gender.Female,
-                    SocialGroupId = 1,
+                    SocialGroups = new List<SocialGroupDto>
+                    {
+                        new SocialGroupDto{ Id = 1, Name = "FakeSocialGroup" },
+                    },
                     ParentId = Guid.NewGuid(),
                 },
             };

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
@@ -710,11 +710,22 @@ namespace OutOfSchool.WebApi.Tests.Services
 
         private IEnumerable<Child> WithChildList()
         {
+            var fakeSocialGroups = new List<SocialGroup>() {
+                new SocialGroup() { Id = 1, Name = "FakeSocialGroup1" },
+                new SocialGroup() { Id = 2, Name = "FakeSocialGroup2" },
+            };
+
+            var fakeChildSocialGroups = new List<ChildSocialGroup>()
+            {
+                new ChildSocialGroup() { ChildId = new Guid("64988abc-776a-4ff8-961c-ba73c7db1986"), SocialGroupId = 1 },
+                new ChildSocialGroup() { ChildId = new Guid("f29d0e07-e4f2-440b-b0fe-eaa11e31ddae"), SocialGroupId = 2 },
+            };
+
             return new List<Child>()
                 {
-                    new Child { Id = new Guid("64988abc-776a-4ff8-961c-ba73c7db1986"), FirstName = "fn1", LastName = "ln1", MiddleName = "mn1", DateOfBirth = new DateTime(2003, 11, 9), Gender = Gender.Male, ParentId = new Guid("cce7dcbf-991b-4c8e-ba30-4e3cc9e952f3"), SocialGroupId = 2 },
-                    new Child { Id = new Guid("f29d0e07-e4f2-440b-b0fe-eaa11e31ddae"), FirstName = "fn2", LastName = "ln2", MiddleName = "mn2", DateOfBirth = new DateTime(2004, 11, 8), Gender = Gender.Female, ParentId = new Guid("cce7dcbf-991b-4c8e-ba30-4e3cc9e952f3"), SocialGroupId = 1 },
-                    new Child { Id = new Guid("6ddd21d0-2f2e-48a0-beec-fefcb44cd3f0"), FirstName = "fn3", LastName = "ln3", MiddleName = "mn3", DateOfBirth = new DateTime(2006, 11, 2), Gender = Gender.Male, ParentId = new Guid("cce7dcbf-991b-4c8e-ba30-4e3cc9e952f3"), SocialGroupId = 1 },
+                    new Child { Id = new Guid("64988abc-776a-4ff8-961c-ba73c7db1986"), FirstName = "fn1", LastName = "ln1", MiddleName = "mn1", DateOfBirth = new DateTime(2003, 11, 9), Gender = Gender.Male, ParentId = new Guid("cce7dcbf-991b-4c8e-ba30-4e3cc9e952f3"), SocialGroups = fakeSocialGroups, ChildSocialGroups = fakeChildSocialGroups },
+                    new Child { Id = new Guid("f29d0e07-e4f2-440b-b0fe-eaa11e31ddae"), FirstName = "fn2", LastName = "ln2", MiddleName = "mn2", DateOfBirth = new DateTime(2004, 11, 8), Gender = Gender.Female, ParentId = new Guid("cce7dcbf-991b-4c8e-ba30-4e3cc9e952f3"), SocialGroups = fakeSocialGroups, ChildSocialGroups = fakeChildSocialGroups },
+                    new Child { Id = new Guid("6ddd21d0-2f2e-48a0-beec-fefcb44cd3f0"), FirstName = "fn3", LastName = "ln3", MiddleName = "mn3", DateOfBirth = new DateTime(2006, 11, 2), Gender = Gender.Male, ParentId = new Guid("cce7dcbf-991b-4c8e-ba30-4e3cc9e952f3"), SocialGroups = fakeSocialGroups, ChildSocialGroups = fakeChildSocialGroups },
                 };
         }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/MappingExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/MappingExtensions.cs
@@ -58,6 +58,7 @@ namespace OutOfSchool.WebApi.Extensions
             {
                 cfg.CreateMap<Child, ChildDto>();
                 cfg.CreateMap<Parent, ParentDtoWithContactInfo>();
+                cfg.CreateMap<SocialGroup, SocialGroupDto>();
             });
         }
 
@@ -173,6 +174,7 @@ namespace OutOfSchool.WebApi.Extensions
             return Mapper<ChildDto, Child>(childDto, cfg =>
             {
                 cfg.CreateMap<ChildDto, Child>();
+                cfg.CreateMap<SocialGroupDto, SocialGroup>();
                 cfg.CreateMap<ParentDTO, Parent>();
             });
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ChildDTO.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ChildDTO.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using OutOfSchool.Services.Enums;
@@ -36,7 +37,7 @@ namespace OutOfSchool.WebApi.Models
 
         public Guid ParentId { get; set; } = default;
 
-        public long? SocialGroupId { get; set; } = default;
+        public List<SocialGroupDto> SocialGroups { get; set; }
 
         public ParentDtoWithContactInfo Parent{ get; set; }
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Models/SocialGroupDTO.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/SocialGroupDTO.cs
@@ -9,7 +9,5 @@ namespace OutOfSchool.WebApi.Models
 
         [MaxLength(100)]
         public string Name { get; set; } = string.Empty;
-
-        public ICollection<long> ChildrenIds { get; }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ChildService.cs
@@ -68,7 +68,7 @@ namespace OutOfSchool.WebApi.Services
 
             var totalAmount = await childRepository.Count().ConfigureAwait(false);
 
-            var children = await childRepository.Get(offsetFilter.From, offsetFilter.Size, $"{nameof(Child.SocialGroup)}", null, x => x.Id, true)
+            var children = await childRepository.Get(offsetFilter.From, offsetFilter.Size, $"{nameof(Child.SocialGroups)}", null, x => x.Id, true)
                 .ToListAsync()
                 .ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -251,7 +251,7 @@ namespace OutOfSchool.WebApi
             services.AddTransient<IEntityRepository<Application>, EntityRepository<Application>>();
             services.AddTransient<IEntityRepository<ChatMessageWorkshop>, EntityRepository<ChatMessageWorkshop>>();
             services.AddTransient<IEntityRepository<ChatRoomWorkshop>, EntityRepository<ChatRoomWorkshop>>();
-            services.AddTransient<IEntityRepository<Child>, EntityRepository<Child>>();
+            services.AddTransient<IEntityRepository<Child>, ChildRepository>();
             services.AddTransient<IEntityRepository<City>, EntityRepository<City>>();
             services.AddTransient<IEntityRepository<Favorite>, EntityRepository<Favorite>>();
             services.AddTransient<IEntityRepository<SocialGroup>, EntityRepository<SocialGroup>>();

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/ChildDtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/ChildDtoGenerator.cs
@@ -60,7 +60,7 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
         {
             _ = child ?? throw new ArgumentNullException(nameof(child));
 
-            child.SocialGroupId = socialGroup?.Id ?? default;
+            child.SocialGroups?.Add(socialGroup);
 
             return child;
         }

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/ChildGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/ChildGenerator.cs
@@ -58,8 +58,7 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
         {
             _ = child ?? throw new ArgumentNullException(nameof(child));
 
-            child.SocialGroup = socialGroup;
-            child.SocialGroupId = socialGroup?.Id ?? default;
+            child.SocialGroups?.Add(socialGroup);
 
             return child;
         }


### PR DESCRIPTION
* added ChildRepository
* added ChildrenSocialGroups
* removed ChildrensId from SocialGroupDTO

**Comments from previous pull request:**

@provicevko 
![image](https://user-images.githubusercontent.com/3643368/173052536-a687b185-c946-42ee-95ba-b213a3dce504.png)


In other repositories, such as ParentRepository ProviderRepository, there are no null checks in Create method. In which cases a child can be null?

@h4wk13 
![image](https://user-images.githubusercontent.com/3643368/173052692-295dcdbf-7c42-4aaf-baac-b7f22e6516f4.png)
![image](https://user-images.githubusercontent.com/3643368/173052750-42b2533b-e6cb-4fa8-86b6-0557b5416469.png)

Agree, initializers are removed.
