### PR TITLE
add multiple description

### DIFF
--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/WorkshopConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/WorkshopConfiguration.cs
@@ -28,6 +28,9 @@ namespace OutOfSchool.Services.Models.Configurations
             builder.HasMany(x => x.Teachers)
                 .WithOne(x => x.Workshop)
                 .HasForeignKey(x => x.WorkshopId);
+            builder.HasMany(x => x.WorkshopDescriptionItems)
+                .WithOne(x => x.Workshop)
+                .HasForeignKey(x => x.WorkshopId);
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -60,9 +60,7 @@ namespace OutOfSchool.Services.Models
         [Range(0, 10000, ErrorMessage = "Field value should be in a range from 1 to 10 000")]
         public decimal Price { get; set; } = default;
 
-        [Required(ErrorMessage = "Description is required")]
-        [MaxLength(500)]
-        public string Description { get; set; } = string.Empty;
+        public virtual ICollection<WorkshopDescriptionItem> WorkshopDescriptionItems { get; set; }
 
         public bool WithDisabilityOptions { get; set; } = default;
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDescriptionItem.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDescriptionItem.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace OutOfSchool.Services.Models
+{
+    public class WorkshopDescriptionItem : IKeyedEntity<Guid>
+    {
+        public Guid Id { get; set; }
+
+        [Required(ErrorMessage = "Description heading is required")]
+        [MaxLength(200)]
+        public string SectionName { get; set; }
+
+        [Required(ErrorMessage = "Description text is required")]
+        [MaxLength(2000)]
+        public string Description { get; set; }
+
+        public Guid WorkshopId { get; set; }
+
+        public virtual Workshop Workshop { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/OutOfSchoolDbContext.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/OutOfSchoolDbContext.cs
@@ -86,6 +86,8 @@ namespace OutOfSchool.Services
 
         public DbSet<ProviderSectionItem> ProviderSectionItems { get; set; }
 
+        public DbSet<WorkshopDescriptionItem> WorkshopDescriptionItems { get; set; }
+
         public DbSet<ChangesLog> ChangesLog { get; set; }
 
         public DbSet<ProviderAdminChangesLog> ProviderAdminChangesLog { get; set; }

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/Models/WorkshopES.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/Models/WorkshopES.cs
@@ -26,7 +26,7 @@ namespace OutOfSchool.ElasticsearchData.Models
 
         public OwnershipType ProviderOwnership { get; set; }
 
-        public string Description { get; set; }
+        public string Description { get; set; } // Sum of all WorkshopDescriptionItems (SectionName + Description)
 
         public int MinAge { get; set; }
 

--- a/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20220620185326_AddressH3Add.Designer.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20220620185326_AddressH3Add.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
 namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220620185326_AddressH3Add")]
+    partial class AddressH3Add
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20220620185326_AddressH3Add.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20220620185326_AddressH3Add.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
+{
+    public partial class AddressH3Add : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Workshops");
+
+            migrationBuilder.CreateTable(
+                name: "WorkshopDescriptionItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "binary(16)", nullable: false),
+                    SectionName = table.Column<string>(type: "varchar(200)", maxLength: 200, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Description = table.Column<string>(type: "varchar(2000)", maxLength: 2000, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    WorkshopId = table.Column<Guid>(type: "binary(16)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkshopDescriptionItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WorkshopDescriptionItems_Workshops_WorkshopId",
+                        column: x => x.WorkshopId,
+                        principalTable: "Workshops",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkshopDescriptionItems_WorkshopId",
+                table: "WorkshopDescriptionItems",
+                column: "WorkshopId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WorkshopDescriptionItems");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Workshops",
+                type: "varchar(500)",
+                maxLength: 500,
+                nullable: false,
+                defaultValue: "")
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ApplicationControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ApplicationControllerTests.cs
@@ -758,7 +758,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             return eSlist;
         }
 
-        private WorkshopDescriptionItemDto FakeWorkshopDescriptionItem ()
+        private WorkshopDescriptionItemDto FakeWorkshopDescriptionItem()
         {
             var id = Guid.NewGuid();
             return new WorkshopDescriptionItemDto

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ApplicationControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ApplicationControllerTests.cs
@@ -14,6 +14,7 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Controllers.V1;
 using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
+using OutOfSchool.WebApi.Models.Workshop;
 using OutOfSchool.WebApi.Services;
 
 
@@ -536,7 +537,12 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                 Id = Guid.NewGuid(),
                 Title = "Title6",
                 Phone = "1111111111",
-                Description = "Desc6",
+                WorkshopDescriptionItems = new[]
+                {
+                    FakeWorkshopDescriptionItem(),
+                    FakeWorkshopDescriptionItem(),
+                    FakeWorkshopDescriptionItem(),
+                },
                 Price = 6000,
                 WithDisabilityOptions = true,
                 ProviderTitle = "ProviderTitle",
@@ -601,7 +607,11 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     Id = Guid.NewGuid(),
                     Title = "Title1",
                     Phone = "1111111111",
-                    Description = "Desc1",
+                    WorkshopDescriptionItems = new[]
+                    {
+                        FakeWorkshopDescriptionItem(),
+                        FakeWorkshopDescriptionItem(),
+                    },
                     Price = 1000,
                     WithDisabilityOptions = true,
                     ProviderId = Guid.NewGuid(),
@@ -627,7 +637,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     Id = Guid.NewGuid(),
                     Title = "Title2",
                     Phone = "1111111111",
-                    Description = "Desc2",
+                    WorkshopDescriptionItems = new[]
+                    {
+                        FakeWorkshopDescriptionItem(),
+                    },
                     Price = 2000,
                     WithDisabilityOptions = true,
                     ProviderId = Guid.NewGuid(),
@@ -653,7 +666,12 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     Id = Guid.NewGuid(),
                     Title = "Title3",
                     Phone = "1111111111",
-                    Description = "Desc3",
+                    WorkshopDescriptionItems = new[]
+                    {
+                        FakeWorkshopDescriptionItem(),
+                        FakeWorkshopDescriptionItem(),
+                        FakeWorkshopDescriptionItem(),
+                    },
                     Price = 3000,
                     WithDisabilityOptions = true,
                     ProviderId = Guid.NewGuid(),
@@ -675,7 +693,11 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     Id = Guid.NewGuid(),
                     Title = "Title4",
                     Phone = "1111111111",
-                    Description = "Desc4",
+                    WorkshopDescriptionItems = new[]
+                    {
+                        FakeWorkshopDescriptionItem(),
+                        FakeWorkshopDescriptionItem(),
+                    },
                     Price = 4000,
                     WithDisabilityOptions = true,
                     ProviderId = Guid.NewGuid(),
@@ -697,7 +719,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     Id = Guid.NewGuid(),
                     Title = "Title5",
                     Phone = "1111111111",
-                    Description = "Desc5",
+                    WorkshopDescriptionItems = new[]
+                    {
+                        FakeWorkshopDescriptionItem(),
+                    },
                     Price = 5000,
                     WithDisabilityOptions = true,
                     ProviderId = Guid.NewGuid(),
@@ -731,6 +756,17 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             }
 
             return eSlist;
+        }
+
+        private WorkshopDescriptionItemDto FakeWorkshopDescriptionItem ()
+        {
+            var id = Guid.NewGuid();
+            return new WorkshopDescriptionItemDto
+            {
+                Id = id,
+                SectionName = "test heading",
+                Description = $"test description text sentence for id: {id.ToString()}",
+            };
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -636,7 +636,7 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             return eSlist;
         }
 
-        private WorkshopDescriptionItemDto FakeWorkshopDescriptionItem ()
+        private WorkshopDescriptionItemDto FakeWorkshopDescriptionItem()
         {
             var id = Guid.NewGuid();
             return new WorkshopDescriptionItemDto

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -406,7 +406,11 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                 Id = Guid.NewGuid(),
                 Title = "Title6",
                 Phone = "1111111111",
-                Description = "Desc6",
+                WorkshopDescriptionItems = new[]
+                {
+                    FakeWorkshopDescriptionItem(),
+                    FakeWorkshopDescriptionItem(),
+                },
                 Price = 6000,
                 WithDisabilityOptions = true,
                 ProviderTitle = "ProviderTitle",
@@ -471,7 +475,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     Id = Guid.NewGuid(),
                     Title = "Title1",
                     Phone = "1111111111",
-                    Description = "Desc1",
+                    WorkshopDescriptionItems = new[]
+                    {
+                        FakeWorkshopDescriptionItem(),
+                    },
                     Price = 1000,
                     WithDisabilityOptions = true,
                     ProviderId = Guid.NewGuid(),
@@ -497,7 +504,12 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     Id = Guid.NewGuid(),
                     Title = "Title2",
                     Phone = "1111111111",
-                    Description = "Desc2",
+                    WorkshopDescriptionItems = new[]
+                    {
+                        FakeWorkshopDescriptionItem(),
+                        FakeWorkshopDescriptionItem(),
+                        FakeWorkshopDescriptionItem(),
+                    },
                     Price = 2000,
                     WithDisabilityOptions = true,
                     ProviderId = Guid.NewGuid(),
@@ -523,7 +535,12 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     Id = Guid.NewGuid(),
                     Title = "Title3",
                     Phone = "1111111111",
-                    Description = "Desc3",
+                    WorkshopDescriptionItems = new[]
+                    {
+                        FakeWorkshopDescriptionItem(),
+                        FakeWorkshopDescriptionItem(),
+                        FakeWorkshopDescriptionItem(),
+                    },
                     Price = 3000,
                     WithDisabilityOptions = true,
                     ProviderId = Guid.NewGuid(),
@@ -545,7 +562,11 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     Id = Guid.NewGuid(),
                     Title = "Title4",
                     Phone = "1111111111",
-                    Description = "Desc4",
+                    WorkshopDescriptionItems = new[]
+                    {
+                        FakeWorkshopDescriptionItem(),
+                        FakeWorkshopDescriptionItem(),
+                    },
                     Price = 4000,
                     WithDisabilityOptions = true,
                     ProviderId = Guid.NewGuid(),
@@ -567,7 +588,10 @@ namespace OutOfSchool.WebApi.Tests.Controllers
                     Id = Guid.NewGuid(),
                     Title = "Title5",
                     Phone = "1111111111",
-                    Description = "Desc5",
+                    WorkshopDescriptionItems = new[]
+                    {
+                        FakeWorkshopDescriptionItem(),
+                    },
                     Price = 5000,
                     WithDisabilityOptions = true,
                     ProviderId = Guid.NewGuid(),
@@ -610,6 +634,17 @@ namespace OutOfSchool.WebApi.Tests.Controllers
             }
 
             return eSlist;
+        }
+
+        private WorkshopDescriptionItemDto FakeWorkshopDescriptionItem ()
+        {
+            var id = Guid.NewGuid();
+            return new WorkshopDescriptionItemDto
+            {
+                Id = id,
+                SectionName = "test heading",
+                Description = $"test description text sentence for id: {id.ToString()}",
+            };
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Extensions/MappingExtensionsTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Extensions/MappingExtensionsTests.cs
@@ -14,6 +14,7 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.ChatWorkshop;
+using OutOfSchool.WebApi.Models.Workshop;
 using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Extensions
@@ -244,7 +245,15 @@ namespace OutOfSchool.WebApi.Tests.Extensions
                 Id = Guid.NewGuid(),
                 Title = "Title5",
                 Phone = "1111111111",
-                Description = "Desc5",
+                WorkshopDescriptionItems = new[]
+                {
+                    new WorkshopDescriptionItemDto
+                    {
+                        Id = Guid.NewGuid(),
+                        SectionName = "test heading1",
+                        Description = "test sentence of description1",
+                    },
+                },
                 Price = 5000,
                 IsPerMonth = true,
                 WithDisabilityOptions = true,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -460,7 +460,6 @@ namespace OutOfSchool.WebApi.Tests.Services
                 Id = id,
                 Title = "ChangedTitle",
                 Phone = "1111111111",
-                //Description = "Desc1",
                 Price = 1000,
                 WithDisabilityOptions = true,
                 ProviderTitle = "ProviderTitle",

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -460,7 +460,7 @@ namespace OutOfSchool.WebApi.Tests.Services
                 Id = id,
                 Title = "ChangedTitle",
                 Phone = "1111111111",
-                Description = "Desc1",
+                //Description = "Desc1",
                 Price = 1000,
                 WithDisabilityOptions = true,
                 ProviderTitle = "ProviderTitle",
@@ -487,6 +487,15 @@ namespace OutOfSchool.WebApi.Tests.Services
                     BuildingNumber = "BuildingNumber55",
                     Latitude = 10,
                     Longitude = 10,
+                },
+                WorkshopDescriptionItems = new[]
+                {
+                    new WorkshopDescriptionItem()
+                    {
+                        Id = Guid.NewGuid(),
+                        SectionName = "Workshop description heading 1",
+                        Description = "Workshop description text 1",
+                    },
                 },
             };
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/ElasticsearchMappingExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/ElasticsearchMappingExtensions.cs
@@ -11,7 +11,7 @@ namespace OutOfSchool.WebApi.Extensions
     // TODO: create a mapping profile instead of extensions
     public static class ElasticsearchMappingExtensions
     {
-        const char SEPARATOR = '¤';
+        private const char SEPARATOR = '¤';
 
         // From DTO to ES models
         public static WorkshopES ToESModel(this WorkshopDTO workshopDto)

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/ElasticsearchMappingExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/ElasticsearchMappingExtensions.cs
@@ -11,6 +11,8 @@ namespace OutOfSchool.WebApi.Extensions
     // TODO: create a mapping profile instead of extensions
     public static class ElasticsearchMappingExtensions
     {
+        const char SEPARATOR = '¤';
+
         // From DTO to ES models
         public static WorkshopES ToESModel(this WorkshopDTO workshopDto)
         {
@@ -21,8 +23,15 @@ namespace OutOfSchool.WebApi.Extensions
                         dest => dest.Keywords,
                         opt =>
                             opt.MapFrom(src =>
-                                string.Join('¤', src.Keywords.Distinct())))
-                    .ForMember(dest => dest.Directions, opt => opt.MapFrom(src => src.Directions));
+                                string.Join(SEPARATOR, src.Keywords.Distinct())))
+                    .ForMember(dest => dest.Directions, opt => opt.MapFrom(src => src.Directions))
+                    .ForMember(
+                        dest => dest.Description,
+                        opt =>
+                            opt.MapFrom(src =>
+                                src.WorkshopDescriptionItems
+                                    .Aggregate(string.Empty, (accumulator, wdi) =>
+                                        $"{accumulator}{wdi.SectionName}{SEPARATOR}{wdi.Description}{SEPARATOR}")));
 
                 cfg.CreateMap<AddressDto, AddressES>()
                     .ForMember(

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/MappingExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/MappingExtensions.cs
@@ -7,6 +7,7 @@ using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Models.ChatWorkshop;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.ChatWorkshop;
+using OutOfSchool.WebApi.Models.Workshop;
 
 namespace OutOfSchool.WebApi.Extensions
 {
@@ -152,6 +153,7 @@ namespace OutOfSchool.WebApi.Extensions
                 cfg.CreateMap<Address, AddressDto>();
                 cfg.CreateMap<Provider, ProviderDto>();
                 cfg.CreateMap<Teacher, TeacherDTO>();
+                cfg.CreateMap<WorkshopDescriptionItem, WorkshopDescriptionItemDto>();
             });
         }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Workshop/WorkshopDTO.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Workshop/WorkshopDTO.cs
@@ -13,6 +13,7 @@ using OutOfSchool.Common.Enums;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Models;
 using OutOfSchool.WebApi.Models.Workshop;
+using OutOfSchool.WebApi.Util.CustomValidation;
 using OutOfSchool.WebApi.Util.JsonTools;
 
 namespace OutOfSchool.WebApi.Models
@@ -64,9 +65,9 @@ namespace OutOfSchool.WebApi.Models
         [Range(0, 10000, ErrorMessage = "Field value should be in a range from 1 to 10 000")]
         public decimal Price { get; set; } = default;
 
-        [Required(ErrorMessage = "Description is required")]
-        [MaxLength(500)]
-        public string Description { get; set; } = string.Empty;
+        [ModelBinder(BinderType = typeof(JsonModelBinder))]
+        [CollectionNotEmpty(ErrorMessage = "At least one description is required")]
+        public IEnumerable<WorkshopDescriptionItemDto> WorkshopDescriptionItems { get; set; }
 
         public bool WithDisabilityOptions { get; set; } = default;
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Workshop/WorkshopDescriptionItemDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Workshop/WorkshopDescriptionItemDto.cs
@@ -1,18 +1,20 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace OutOfSchool.WebApi.Models
+namespace OutOfSchool.WebApi.Models.Workshop
 {
-    public class ProviderSectionItemDto
+    public class WorkshopDescriptionItemDto
     {
         public Guid Id { get; set; }
 
+        [Required]
         [MaxLength(200)]
         public string SectionName { get; set; }
 
+        [Required]
         [MaxLength(2000)]
         public string Description { get; set; }
 
-        public Guid ProviderId { get; set; }
+        public Guid WorkshopId { get; set; }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Util/CustomValidation/CollectionNotEmptyAttribute.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/CustomValidation/CollectionNotEmptyAttribute.cs
@@ -4,7 +4,7 @@ using System.Collections;
 namespace OutOfSchool.WebApi.Util.CustomValidation
 {
     [AttributeUsage(AttributeTargets.Property)]
-    public class CollectionNotEmpty : System.ComponentModel.DataAnnotations.ValidationAttribute
+    public class CollectionNotEmptyAttribute : System.ComponentModel.DataAnnotations.ValidationAttribute
     {
         public override bool IsValid(object value)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Util/CustomValidation/CollectionValidator.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/CustomValidation/CollectionValidator.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections;
+
+namespace OutOfSchool.WebApi.Util.CustomValidation
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class CollectionNotEmpty : System.ComponentModel.DataAnnotations.ValidationAttribute
+    {
+        public override bool IsValid(object value)
+        {
+            return value switch
+            {
+                ICollection collection => collection.Count > 0,
+                IEnumerable enumerable => enumerable.GetEnumerator().MoveNext(),
+                _ => false
+            };
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
@@ -59,12 +59,18 @@ namespace OutOfSchool.WebApi.Util
                 .ForMember(dest => dest.InstitutionHierarchy, opt => opt.MapFrom(src => src.InstitutionHierarchy.Title))
                 .ForMember(dest => dest.Directions, opt => opt.MapFrom(src => src.InstitutionHierarchy.Directions));
 
+            CreateMap<WorkshopDescriptionItem, WorkshopDescriptionItemDto>().ReverseMap();
+
             CreateMap<Address, AddressDto>().ReverseMap();
 
             CreateMap<BlockedProviderParentBlockDto, BlockedProviderParent>();
             CreateMap<BlockedProviderParent, BlockedProviderParentDto>().ReverseMap();
 
-            CreateMap<ProviderSectionItem, ProviderSectionItemDto>().ReverseMap();
+            CreateMap<ProviderSectionItem, ProviderSectionItemDto>().ReverseMap()
+                .ForMember(
+                    dest =>
+                    dest.Name, opt =>
+                    opt.MapFrom(psi => psi.SectionName));
 
             CreateMap<Provider, ProviderDto>()
                  .ForMember(dest => dest.ActualAddress, opt => opt.MapFrom(src => src.ActualAddress))
@@ -142,7 +148,14 @@ namespace OutOfSchool.WebApi.Util
                 .ForMember(dest => dest.Rating, opt => opt.Ignore())
                 .ForMember(dest => dest.Direction, opt => opt.Ignore())
                 .ForMember(dest => dest.InstitutionHierarchy, opt => opt.MapFrom(src => src.InstitutionHierarchy.Title))
-                .ForMember(dest => dest.Directions, opt => opt.MapFrom(src => src.InstitutionHierarchy.Directions));
+                .ForMember(dest => dest.Directions, opt => opt.MapFrom(src => src.InstitutionHierarchy.Directions))
+                .ForMember(
+                    dest => dest.Description,
+                    opt =>
+                        opt.MapFrom(src =>
+                            src.WorkshopDescriptionItems
+                                .Aggregate(string.Empty, (accumulator, wdi) =>
+                                    $"{accumulator}{wdi.SectionName}{SEPARATOR}{wdi.Description}{SEPARATOR}")));
 
 #warning The next mapping is here to test UI Admin features. Will be removed or refactored
             CreateMap<ShortUserDto, AdminDto>();

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/WorkshopGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/WorkshopGenerator.cs
@@ -21,7 +21,13 @@ namespace OutOfSchool.Tests.Common.TestDataGenerators
             .RuleFor(x => x.MinAge, f => f.Random.Number(1, 18))
             //            .RuleFor(x => x.MaxAge, f => f.)
             .RuleFor(x => x.Price, f => f.Random.Decimal())
-            .RuleFor(x => x.Description, f => f.Lorem.Paragraph())
+            .RuleFor(x => x.WorkshopDescriptionItems, f => f.Make(new Random().Next(1, 4), () =>
+                new WorkshopDescriptionItem()
+                {
+                    Id = Guid.NewGuid(),
+                    SectionName = f.Lorem.Sentence(),
+                    Description = f.Lorem.Paragraph(),
+                }))
             .RuleFor(x => x.WithDisabilityOptions, f => f.Random.Bool())
             .RuleFor(x => x.DisabilityOptionsDesc, f => f.Lorem.Sentence())
             .RuleFor(x => x.CoverImageId, f => f.Image.LoremFlickrUrl())


### PR DESCRIPTION
https://github.com/ita-social-projects/OoS-Backend/issues/651

Created another one because dat GitHub is a hard nut to crack :)

Multiple Description Added which includes:
* New Entity and Dto models
* Elastic search aggregation mapping
* Custom validation on WorkshopDto added (but I would like to use Fluent Validation instead of Data Annotations)
* Mapping fixed
* Few unit tests fixed

Also in the scope of this task
* Fixed Naming of Property ProviderSectionItemDto. @litvinets please take a look on Dtos
* Added SEPARATOR constant ElasticsearchMappingExtensions