### PR TITLE
rbiyovskiy/718 applicationgetbyparentid add filter by childid

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
@@ -195,7 +195,7 @@ namespace OutOfSchool.WebApi.Tests.Services
             SetupGetAllByWorkshop(existingApplications);
             var applicationFilter = new ApplicationFilter
             {
-                Status = 0,
+                Statuses = null,
                 OrderByAlphabetically = false,
                 OrderByStatus = false,
                 OrderByDateAscending = false,
@@ -215,7 +215,7 @@ namespace OutOfSchool.WebApi.Tests.Services
             SetupGetAllByWorkshopEmpty();
             var filter = new ApplicationFilter
             {
-                Status = 0,
+                Statuses = null,
                 OrderByAlphabetically = false,
                 OrderByStatus = false,
                 OrderByDateAscending = false,
@@ -246,7 +246,7 @@ namespace OutOfSchool.WebApi.Tests.Services
             SetupGetAllByProvider(existingApplications);
             var applicationFilter = new ApplicationFilter
             {
-                Status = 0,
+                Statuses = null,
                 OrderByAlphabetically = false,
                 OrderByStatus = false,
                 OrderByDateAscending = false,
@@ -266,7 +266,7 @@ namespace OutOfSchool.WebApi.Tests.Services
             SetupGetAllByProviderEmpty();
             var filter = new ApplicationFilter
             {
-                Status = 0,
+                Statuses = null,
                 OrderByAlphabetically = false,
                 OrderByStatus = false,
                 OrderByDateAscending = false,

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ApplicationFilter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ApplicationFilter.cs
@@ -6,7 +6,7 @@ namespace OutOfSchool.WebApi.Models
 {
     public class ApplicationFilter : OffsetFilter
     {
-        public ApplicationStatus Status { get; set; }
+        public IEnumerable<ApplicationStatus> Statuses { get; set; } = null;
 
         public bool OrderByDateAscending { get; set; } = true;
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ApplicationFilter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ApplicationFilter.cs
@@ -17,5 +17,7 @@ namespace OutOfSchool.WebApi.Models
         public bool ShowBlocked { get; set; } = false;
 
         public IEnumerable<Guid> Workshops { get; set; } = null;
+
+        public IEnumerable<Guid> Children { get; set; } = null;
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ApplicationService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ApplicationService.cs
@@ -60,28 +60,16 @@ namespace OutOfSchool.WebApi.Services
             IProviderAdminService providerAdminService,
             IChangesLogService changesLogService)
         {
-            this.applicationRepository = repository;
-            this.workshopRepository = workshopRepository;
-            this.logger = logger;
-            this.localizer = localizer;
-            this.childRepository = childRepository;
-            this.mapper = mapper;
-            this.notificationService = notificationService;
-            this.providerAdminService = providerAdminService;
-            this.changesLogService = changesLogService;
-            try
-            {
-                this.applicationsConstraintsConfig = applicationsConstraintsConfig.Value;
-            }
-            catch (OptionsValidationException ex)
-            {
-                foreach (var failure in ex.Failures)
-                {
-                    logger.LogError(failure);
-                }
-
-                throw;
-            }
+            applicationRepository = repository ?? throw new ArgumentNullException(nameof(repository));
+            this.workshopRepository = workshopRepository ?? throw new ArgumentNullException(nameof(workshopRepository));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
+            this.childRepository = childRepository ?? throw new ArgumentNullException(nameof(childRepository));
+            this.mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+            this.notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
+            this.providerAdminService = providerAdminService ?? throw new ArgumentNullException(nameof(providerAdminService));
+            this.changesLogService = changesLogService ?? throw new ArgumentNullException(nameof(changesLogService));
+            this.applicationsConstraintsConfig = (applicationsConstraintsConfig ?? throw new ArgumentNullException(nameof(applicationsConstraintsConfig))).Value;
         }
 
         /// <inheritdoc/>
@@ -208,8 +196,7 @@ namespace OutOfSchool.WebApi.Services
             logger.LogInformation($"Getting Applications by Parent Id started. Looking Parent Id = {id}.");
             FilterNullValidation(filter);
 
-            var predicate = PredicateBuild(filter);
-            predicate = predicate.And(a => a.ParentId == id);
+            var predicate = PredicateBuild(filter, a => a.ParentId == id);
 
             var sortPredicate = SortExpressionBuild(filter);
 
@@ -258,8 +245,7 @@ namespace OutOfSchool.WebApi.Services
 
             FilterNullValidation(filter);
 
-            var predicate = PredicateBuild(filter);
-            predicate = predicate.And(a => a.WorkshopId == id);
+            var predicate = PredicateBuild(filter, a => a.WorkshopId == id);
 
             var sortPredicate = SortExpressionBuild(filter);
 
@@ -269,7 +255,7 @@ namespace OutOfSchool.WebApi.Services
                 take: filter.Size,
                 where: predicate,
                 includeProperties: "Workshop,Child,Parent",
-                orderBy: sortPredicate).ToListAsync().ConfigureAwait(false); ;
+                orderBy: sortPredicate).ToListAsync().ConfigureAwait(false);
 
             logger.LogInformation(!applications.Any()
                 ? $"There is no applications in the Db with Workshop Id = {id}."
@@ -294,12 +280,10 @@ namespace OutOfSchool.WebApi.Services
             Expression<Func<Workshop, bool>> workshopFilter = w => w.ProviderId == id;
             var workshops = workshopRepository.Get(where: workshopFilter).Select(w => w.Id);
 
-            var predicate = PredicateBuild(filter);
-            predicate = predicate.And(a => workshops.Contains(a.WorkshopId));
+            var predicate = PredicateBuild(filter, a => workshops.Contains(a.WorkshopId));
 
             var sortPredicate = SortExpressionBuild(filter);
 
-            Expression<Func<Application, bool>> applicationFilter = a => workshops.Contains(a.WorkshopId);
             var totalAmount = await applicationRepository.Count(where: predicate).ConfigureAwait(false);
             var applications = await applicationRepository.Get(
                 skip: filter.From,
@@ -567,6 +551,18 @@ namespace OutOfSchool.WebApi.Services
                 foreach (var workshop in filter.Workshops)
                 {
                     tempPredicate = tempPredicate.Or(a => a.WorkshopId == workshop);
+                }
+
+                predicate = predicate.And(tempPredicate);
+            }
+
+            if (filter.Children != null)
+            {
+                var tempPredicate = PredicateBuilder.False<Application>();
+
+                foreach (var child in filter.Children)
+                {
+                    tempPredicate = tempPredicate.Or(a => a.ChildId == child);
                 }
 
                 predicate = predicate.And(tempPredicate);

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ApplicationService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ApplicationService.cs
@@ -539,9 +539,9 @@ namespace OutOfSchool.WebApi.Services
                 predicate = PredicateBuilder.True<Application>();
             }
 
-            if (filter.Status != 0)
+            if (filter.Statuses != null)
             {
-                predicate = predicate.And(a => a.Status == filter.Status);
+                predicate = predicate.And(a => filter.Statuses.Contains(a.Status));
             }
 
             if (filter.Workshops != null)


### PR DESCRIPTION
added filter by ChildId and tested some issues:
- null check of the parameters of the application service designer;
- added filter by ParentID, WorkshopId or ProviderId as second parameter to PredicateBuild. This filter condition will be checked first and the query should run faster.