### PR TITLE
ChangesLogRepository: Fix NRE

### DIFF
--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/ChangesLogRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/ChangesLogRepository.cs
@@ -60,15 +60,15 @@ public class ChangesLogRepository : EntityRepository<long, ChangesLog>, IChanges
     {
         var properties = entityEntry.Properties
             .Where(p => p.IsModified
-                        && trackedProperties.Contains(p.Metadata.PropertyInfo.Name))
-            .Select(x => (x.Metadata.PropertyInfo.Name,
+                        && trackedProperties.Contains(p.Metadata.Name))
+            .Select(x => (x.Metadata.Name,
                 valueProjector(x.Metadata.ClrType, x.OriginalValue),
                 valueProjector(x.Metadata.ClrType, x.CurrentValue)));
 
         var references = entityEntry.References
-            .Where(x => trackedProperties.Contains(x.Metadata.PropertyInfo.Name)
+            .Where(x => trackedProperties.Contains(x.Metadata.Name)
                         && x.TargetEntry?.State == EntityState.Modified)
-            .Select(x => (x.Metadata.PropertyInfo.Name,
+            .Select(x => (x.Metadata.Name,
                 valueProjector(x.TargetEntry.Metadata.ClrType, x.TargetEntry.OriginalValues.ToObject()),
                 valueProjector(x.TargetEntry.Metadata.ClrType, x.TargetEntry.CurrentValues.ToObject())));
 


### PR DESCRIPTION
After implementing soft delete, a NRE exception appeared in `ChangesLogRepository`. This is because a new `IsDeleted` column was added to the entities without a corresponding field in the C# classes. An attempt to access a missing `PropertyInfo` property in the `IsDeleted` property entry causes a NRE. To fix this `Metadata.Name` is used instead of `Metadata.PropertyInfo.Name`.