### PR TITLE
Checking on null for user.MiddleName was added

### DIFF
--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/ParentRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/ParentRepository.cs
@@ -37,7 +37,7 @@ public class ParentRepository : EntityRepositoryBase<Guid, Parent>, IParentRepos
             Id = Guid.Empty,
             IsParent = true,
             FirstName = user.FirstName,
-            MiddleName = user.MiddleName,
+            MiddleName = user.MiddleName ?? string.Empty,
             LastName = user.LastName,
             Gender = user.Gender,
             ParentId = entity.Id,


### PR DESCRIPTION
When a user is registered child is created. But for user field middleName is not required, instead middleName for Child is required (in DB not null)