### PR TITLE
Add checkin on null ManagedWorkshopIds

### DIFF
--- a/OutOfSchool/OutOfSchool.IdentityServer/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Services/ProviderAdminService.cs
@@ -243,9 +243,10 @@ public class ProviderAdminService : IProviderAdminService
             return response;
         }
 
-        if (!providerAdmin.IsDeputy && !providerAdminUpdateDto.ManagedWorkshopIds.Any())
+        if ((!providerAdmin.IsDeputy && !providerAdminUpdateDto.ManagedWorkshopIds.Any()) 
+            || providerAdminUpdateDto.ManagedWorkshopIds is null)
         {
-            logger.LogError("Cant create assistant provider admin without related workshops");
+            logger.LogError("Cant update assistant provider admin without related workshops");
             response.IsSuccess = false;
             response.HttpStatusCode = HttpStatusCode.BadRequest;
 
@@ -313,7 +314,7 @@ public class ProviderAdminService : IProviderAdminService
                     : new List<Workshop>();
 
                 await providerAdminRepository.Update(providerAdmin).ConfigureAwait(false);
-
+                
                 await providerAdminChangesLogService.SaveChangesLogAsync(providerAdmin, userId, OperationType.Update)
                     .ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.IdentityServer/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Services/ProviderAdminService.cs
@@ -243,7 +243,7 @@ public class ProviderAdminService : IProviderAdminService
             return response;
         }
 
-        if ((!providerAdmin.IsDeputy && !providerAdminUpdateDto.ManagedWorkshopIds.Any()) 
+        if ((!providerAdmin.IsDeputy && !providerAdminUpdateDto.ManagedWorkshopIds.Any())
             || providerAdminUpdateDto.ManagedWorkshopIds is null)
         {
             logger.LogError("Cant update assistant provider admin without related workshops");

--- a/OutOfSchool/OutOfSchool.IdentityServer/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Services/ProviderAdminService.cs
@@ -314,7 +314,7 @@ public class ProviderAdminService : IProviderAdminService
                     : new List<Workshop>();
 
                 await providerAdminRepository.Update(providerAdmin).ConfigureAwait(false);
-                
+
                 await providerAdminChangesLogService.SaveChangesLogAsync(providerAdmin, userId, OperationType.Update)
                     .ConfigureAwait(false);
 


### PR DESCRIPTION
I noticed when we create **ProviderAdmin** without managed workshops we can get error because in providerAdminUpdateDto.ManagedWorkshopIds.Any() because providerAdminUpdateDto.ManagedWorkshopIds is null.
I've added checking. 
But I see that we can't create provider admin without managed workshops on the front, so maybe should we just add the required attribute to **ManagedWorkshopIds** property in **CreateProviderAdminDto** model?