### PR TITLE
updated endpoints to use SearchResult models

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
@@ -15,6 +15,7 @@ using OutOfSchool.WebApi.Controllers.V1;
 using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -32,7 +33,7 @@ public class InstitutionStatusControllerTests
     {
         // setup controller
         service = new Mock<IStatusService>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
         controller = new InstitutionStatusController(service.Object, localizer.Object);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/MinistryAdminControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/MinistryAdminControllerTests.cs
@@ -11,6 +11,7 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Controllers;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -26,7 +27,7 @@ public class MinistryAdminControllerTests
     [SetUp]
     public void Setup()
     {
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         ministryAdminServiceMock = new Mock<IMinistryAdminService>();
         ministryAdminController =
             new MinistryAdminController(ministryAdminServiceMock.Object, new Mock<ILogger<MinistryAdminController>>().Object);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ParentControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ParentControllerTests.cs
@@ -16,6 +16,7 @@ using OutOfSchool.WebApi.Controllers.V1;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Workshop;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -44,7 +45,7 @@ public class ParentControllerTests
         serviceChild = new Mock<IChildService>();
 
         localizer = new Mock<IStringLocalizer<SharedResource>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
 
         httpContextMoq = new Mock<HttpContext>();
         httpContextMoq.Setup(x => x.User.FindFirst("sub"))

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
@@ -17,6 +17,7 @@ using OutOfSchool.WebApi.Controllers.V1;
 using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -34,7 +35,7 @@ public class PermissionsForRoleControllerTests
     public void Setup()
     {
         service = new Mock<IPermissionsForRoleService>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         controller = new PermissionsForRoleController(service.Object);
 
         permissionsForAllRoles = PermissionsForRolesGenerator.GenerateForExistingRoles();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllerTests.cs
@@ -23,6 +23,7 @@ using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Providers;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -39,7 +40,7 @@ public class ProviderControllerTests
     [SetUp]
     public void Setup()
     {
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         userId = Guid.NewGuid().ToString();
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
         var user = new ClaimsPrincipal

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -126,8 +126,10 @@ public class WorkshopControllerTests
     public async Task GetByProviderId_WhenThereAreWorkshops_ShouldReturnOkResultObject()
     {
         // Arrange
-        var filter = new OffsetFilter() { From = 0, Size = int.MaxValue };
-        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopBaseCard>(It.IsAny<Guid>(), It.IsAny<OffsetFilter>(), It.IsAny<Guid?>())).ReturnsAsync(workshopBaseCards);
+        var filter = new ExcludeIdFilter() { From = 0, Size = int.MaxValue };
+        var searchResult = new SearchResult<WorkshopBaseCard>() { TotalAmount = 5, Entities = workshopBaseCards };
+        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopBaseCard>(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(searchResult);
 
         // Act
         var result = await controller.GetByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as OkObjectResult;
@@ -136,16 +138,17 @@ public class WorkshopControllerTests
         workshopServiceMoq.VerifyAll();
         Assert.That(result, Is.Not.Null);
         Assert.AreEqual(Ok, result.StatusCode);
-        Assert.AreEqual(workshops.Count, (result.Value as List<WorkshopBaseCard>).Count);
+        Assert.AreEqual(workshops.Count, (result.Value as SearchResult<WorkshopBaseCard>).TotalAmount);
     }
 
     [Test]
     public async Task GetByProviderId_WhenThereIsNoWorkshops_ShouldReturnNoContentResult([Random(uint.MinValue, uint.MaxValue, 1)] long randomNumber)
     {
         // Arrange
-        var filter = new OffsetFilter() { From = 0, Size = int.MaxValue };
-        var emptyList = new List<WorkshopBaseCard>();
-        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopBaseCard>(It.IsAny<Guid>(), It.IsAny<OffsetFilter>(), It.IsAny<Guid?>())).ReturnsAsync(emptyList);
+        var filter = new ExcludeIdFilter() { From = 0, Size = int.MaxValue };
+        var emptySearchResult = new SearchResult<WorkshopBaseCard>() { TotalAmount = 0, Entities = new List<WorkshopBaseCard>() };
+        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopBaseCard>(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(emptySearchResult);
 
         // Act
         var result = await controller.GetByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as NoContentResult;
@@ -167,6 +170,27 @@ public class WorkshopControllerTests
         Assert.AreEqual("Provider id is empty.", (result as BadRequestObjectResult).Value);
     }
 
+    [Test]
+    public async Task GetByProviderId_WhenThereIsExcludedId_ShouldReturnOkResultObject()
+    {
+        // Arrange
+        var expectedWorkshopCount = workshopBaseCards.Count - 1;
+        var excludedId = workshopBaseCards.FirstOrDefault().WorkshopId;
+        var filter = new ExcludeIdFilter() { From = 0, Size = int.MaxValue, ExcludedId = excludedId };
+        var searchResult = new SearchResult<WorkshopBaseCard>() { TotalAmount = 4, Entities = workshopBaseCards.Skip(1).ToList() };
+        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopBaseCard>(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(searchResult);
+
+        // Act
+        var result = await controller.GetByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as OkObjectResult;
+
+        // Assert
+        workshopServiceMoq.VerifyAll();
+        Assert.That(result, Is.Not.Null);
+        Assert.AreEqual(Ok, result.StatusCode);
+        Assert.AreEqual(expectedWorkshopCount, (result.Value as SearchResult<WorkshopBaseCard>).TotalAmount);
+    }
+
     #endregion
 
     #region GetWorkshopListByProviderId
@@ -174,9 +198,10 @@ public class WorkshopControllerTests
     public async Task GetWorkshopListByProviderId_WhenThereAreWorkshops_ShouldReturnOkResultObject()
     {
         // Arrange
-        var filter = new OffsetFilter() { From = 0, Size = int.MaxValue };
-        workshopServiceMoq.Setup(x => x.GetWorkshopListByProviderId(It.IsAny<Guid>(), It.IsAny<OffsetFilter>()))
-            .ReturnsAsync(workshopShortEntitiesList);
+        var filter = new ExcludeIdFilter() { From = 0, Size = int.MaxValue };
+        var searchResult = new SearchResult<ShortEntityDto>() { TotalAmount = 10, Entities = workshopShortEntitiesList };
+        workshopServiceMoq.Setup(x => x.GetWorkshopListByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(searchResult);
 
         // Act
         var result = await controller.GetWorkshopListByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as OkObjectResult;
@@ -185,17 +210,17 @@ public class WorkshopControllerTests
         workshopServiceMoq.VerifyAll();
         Assert.That(result, Is.Not.Null);
         Assert.AreEqual(Ok, result.StatusCode);
-        Assert.AreEqual(workshopShortEntitiesList.Count, (result.Value as List<ShortEntityDto>).Count);
+        Assert.AreEqual(workshopShortEntitiesList.Count, (result.Value as SearchResult<ShortEntityDto>).TotalAmount);
     }
 
     [Test]
     public async Task GetWorkshopListByProviderId_WhenThereIsNoWorkshops_ShouldReturnNoContentResult()
     {
         // Arrange
-        var filter = new OffsetFilter() { From = 0, Size = int.MaxValue };
-        var emptyList = new List<ShortEntityDto>();
-        workshopServiceMoq.Setup(x => x.GetWorkshopListByProviderId(It.IsAny<Guid>(), It.IsAny<OffsetFilter>()))
-            .ReturnsAsync(emptyList);
+        var filter = new ExcludeIdFilter() { From = 0, Size = int.MaxValue };
+        var emptySearchResult = new SearchResult<ShortEntityDto>() { TotalAmount = 0, Entities = new List<ShortEntityDto>() };
+        workshopServiceMoq.Setup(x => x.GetWorkshopListByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(emptySearchResult);
 
         // Act
         var result = await controller.GetWorkshopListByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as NoContentResult;
@@ -211,9 +236,11 @@ public class WorkshopControllerTests
     {
         // Arrange
         var expectedCount = 1;
-        var filter = new OffsetFilter() { From = 0, Size = expectedCount };
-        workshopServiceMoq.Setup(x => x.GetWorkshopListByProviderId(It.IsAny<Guid>(), It.IsAny<OffsetFilter>()))
-            .ReturnsAsync(workshopShortEntitiesList.Take(expectedCount).ToList());
+        var expectedTotalCount = 10;
+        var filter = new ExcludeIdFilter() { From = 0, Size = expectedCount };
+        var searchResult = new SearchResult<ShortEntityDto>() { TotalAmount = expectedTotalCount, Entities = workshopShortEntitiesList.Take(expectedCount).ToList() };
+        workshopServiceMoq.Setup(x => x.GetWorkshopListByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(searchResult);
 
         // Act
         var result = await controller.GetWorkshopListByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as OkObjectResult;
@@ -222,7 +249,8 @@ public class WorkshopControllerTests
         workshopServiceMoq.VerifyAll();
         Assert.That(result, Is.Not.Null);
         Assert.AreEqual(Ok, result.StatusCode);
-        Assert.AreEqual(expectedCount, (result.Value as List<ShortEntityDto>).Count);
+        Assert.AreEqual(expectedTotalCount, (result.Value as SearchResult<ShortEntityDto>).TotalAmount);
+        Assert.AreEqual(expectedCount, (result.Value as SearchResult<ShortEntityDto>).Entities.Count);
     }
 
     [Test]
@@ -231,10 +259,12 @@ public class WorkshopControllerTests
         // Arrange
         var skipCount = 1;
         var expectedCount = 2;
+        var expectedTotalCount = 10;
         var expectedResult = workshopShortEntitiesList.Skip(skipCount).Take(expectedCount).ToList();
-        var filter = new OffsetFilter() { From = skipCount, Size = expectedCount };
-        workshopServiceMoq.Setup(x => x.GetWorkshopListByProviderId(It.IsAny<Guid>(), It.IsAny<OffsetFilter>()))
-            .ReturnsAsync(expectedResult);
+        var filter = new ExcludeIdFilter() { From = skipCount, Size = expectedCount };
+        var searchResult = new SearchResult<ShortEntityDto>() { TotalAmount = expectedTotalCount, Entities = expectedResult };
+        workshopServiceMoq.Setup(x => x.GetWorkshopListByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(searchResult);
 
         // Act
         var result = await controller.GetWorkshopListByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as OkObjectResult;
@@ -243,8 +273,8 @@ public class WorkshopControllerTests
         workshopServiceMoq.VerifyAll();
         Assert.That(result, Is.Not.Null);
         Assert.AreEqual(Ok, result.StatusCode);
-        Assert.AreEqual(expectedCount, (result.Value as List<ShortEntityDto>).Count);
-        Assert.AreSame(expectedResult, result.Value as List<ShortEntityDto>);
+        Assert.AreEqual(expectedTotalCount, (result.Value as SearchResult<ShortEntityDto>).TotalAmount);
+        Assert.AreSame(expectedResult, (result.Value as SearchResult<ShortEntityDto>).Entities);
     }
 
     [Test]
@@ -297,9 +327,10 @@ public class WorkshopControllerTests
     public async Task GetWorkshopProviderViewCardsByProviderId_WhenThereAreWorkshops_ShouldReturnOkResultObject()
     {
         // Arrange
-        var filter = new OffsetFilter() { From = 0, Size = int.MaxValue };
-        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopProviderViewCard>(It.IsAny<Guid>(), It.IsAny<OffsetFilter>(), It.IsAny<Guid?>()))
-            .ReturnsAsync(workshopProviderViewCardList);
+        var filter = new ExcludeIdFilter() { From = 0, Size = int.MaxValue };
+        var searchResult = new SearchResult<WorkshopProviderViewCard>() { TotalAmount = 5, Entities = workshopProviderViewCardList };
+        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopProviderViewCard>(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(searchResult);
 
         // Act
         var result = await controller.GetWorkshopProviderViewCardsByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as OkObjectResult;
@@ -308,17 +339,17 @@ public class WorkshopControllerTests
         workshopServiceMoq.VerifyAll();
         Assert.That(result, Is.Not.Null);
         Assert.AreEqual(Ok, result.StatusCode);
-        Assert.AreEqual(workshopProviderViewCardList.Count, (result.Value as List<WorkshopProviderViewCard>).Count);
+        Assert.AreEqual(workshopProviderViewCardList.Count, (result.Value as SearchResult<WorkshopProviderViewCard>).TotalAmount);
     }
 
     [Test]
     public async Task GetWorkshopProviderViewCardsByProviderId_WhenThereIsNoWorkshops_ShouldReturnNoContentResult()
     {
         // Arrange
-        var filter = new OffsetFilter() { From = 0, Size = int.MaxValue };
-        var emptyList = new List<WorkshopProviderViewCard>();
-        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopProviderViewCard>(It.IsAny<Guid>(), It.IsAny<OffsetFilter>(), It.IsAny<Guid?>()))
-            .ReturnsAsync(emptyList);
+        var filter = new ExcludeIdFilter() { From = 0, Size = int.MaxValue };
+        var emptySearchResult = new SearchResult<WorkshopProviderViewCard>() { TotalAmount = 0, Entities = new List<WorkshopProviderViewCard>() };
+        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopProviderViewCard>(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(emptySearchResult);
 
         // Act
         var result = await controller.GetWorkshopProviderViewCardsByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as NoContentResult;
@@ -334,9 +365,11 @@ public class WorkshopControllerTests
     {
         // Arrange
         var expectedCount = 1;
-        var filter = new OffsetFilter() { From = 0, Size = expectedCount };
-        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopProviderViewCard>(It.IsAny<Guid>(), It.IsAny<OffsetFilter>(), It.IsAny<Guid?>()))
-            .ReturnsAsync(workshopProviderViewCardList.Take(expectedCount).ToList());
+        var filter = new ExcludeIdFilter() { From = 0, Size = expectedCount };
+        var expectedTotalAmount = 5;
+        var searchResult = new SearchResult<WorkshopProviderViewCard>() { TotalAmount = expectedTotalAmount, Entities = workshopProviderViewCardList.Take(expectedCount).ToList() };
+        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopProviderViewCard>(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(searchResult);
 
         // Act
         var result = await controller.GetWorkshopProviderViewCardsByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as OkObjectResult;
@@ -345,7 +378,8 @@ public class WorkshopControllerTests
         workshopServiceMoq.VerifyAll();
         Assert.That(result, Is.Not.Null);
         Assert.AreEqual(Ok, result.StatusCode);
-        Assert.AreEqual(expectedCount, (result.Value as List<WorkshopProviderViewCard>).Count);
+        Assert.AreEqual(expectedCount, (result.Value as SearchResult<WorkshopProviderViewCard>).Entities.Count);
+        Assert.AreEqual(expectedTotalAmount, (result.Value as SearchResult<WorkshopProviderViewCard>).TotalAmount);
     }
 
     [Test]
@@ -354,10 +388,12 @@ public class WorkshopControllerTests
         // Arrange
         var skipCount = 1;
         var expectedCount = 2;
+        var expectedTotalAmount = 5;
         var expectedResult = workshopProviderViewCardList.Skip(skipCount).Take(expectedCount).ToList();
-        var filter = new OffsetFilter() { From = skipCount, Size = expectedCount };
-        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopProviderViewCard>(It.IsAny<Guid>(), It.IsAny<OffsetFilter>(), It.IsAny<Guid?>()))
-            .ReturnsAsync(expectedResult);
+        var filter = new ExcludeIdFilter() { From = skipCount, Size = expectedCount };
+        var searchResult = new SearchResult<WorkshopProviderViewCard>() { TotalAmount = expectedTotalAmount, Entities = expectedResult };
+        workshopServiceMoq.Setup(x => x.GetByProviderId<WorkshopProviderViewCard>(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+            .ReturnsAsync(searchResult);
 
         // Act
         var result = await controller.GetWorkshopProviderViewCardsByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false) as OkObjectResult;
@@ -366,8 +402,8 @@ public class WorkshopControllerTests
         workshopServiceMoq.VerifyAll();
         Assert.That(result, Is.Not.Null);
         Assert.AreEqual(Ok, result.StatusCode);
-        Assert.AreEqual(expectedCount, (result.Value as List<WorkshopProviderViewCard>).Count);
-        Assert.AreSame(expectedResult, result.Value as List<WorkshopProviderViewCard>);
+        Assert.AreEqual(expectedTotalAmount, (result.Value as SearchResult<WorkshopProviderViewCard>).TotalAmount);
+        Assert.AreSame(expectedResult, (result.Value as SearchResult<WorkshopProviderViewCard>).Entities);
     }
 
     [Test]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/AchievementServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/AchievementServiceTest.cs
@@ -16,6 +16,7 @@ using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Achievement;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -45,7 +46,7 @@ public class AchievementServiceTest
         achievementRepository = new AchievementRepository(context);
         logger = new Mock<ILogger<AchievementService>>();
         localizer = new Mock<IStringLocalizer<SharedResource>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         service = new AchievementService(achievementRepository, logger.Object, localizer.Object, mapper);
 
         SeedDatabase();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/AddressServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/AddressServiceTests.cs
@@ -15,6 +15,7 @@ using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -41,7 +42,7 @@ public class AddressServiceTests
         localizer = new Mock<IStringLocalizer<SharedResource>>();
         repo = new EntityRepository<long, Address>(context);
         logger = new Mock<ILogger<AddressService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
 
         service = new AddressService(repo, logger.Object, localizer.Object, mapper);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatMessageWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatMessageWorkshopServiceTests.cs
@@ -16,6 +16,7 @@ using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.ChatWorkshop;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -56,7 +57,7 @@ public class ChatMessageWorkshopServiceTests
         messageRepository = new EntityRepository<Guid, ChatMessageWorkshop>(dbContext);
         roomServiceMock = new Mock<IChatRoomWorkshopService>();
         loggerMock = new Mock<ILogger<ChatMessageWorkshopService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
 
         messageService = new ChatMessageWorkshopService(
             messageRepository,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -17,6 +17,7 @@ using OutOfSchool.Tests.Common;
 using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Models.ChatWorkshop;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -86,7 +87,7 @@ public class ChatRoomWorkshopServiceTests
         roomRepository = new EntityRepository<Guid, ChatRoomWorkshop>(dbContext);
         roomWithSpecialModelRepositoryMock = new Mock<IChatRoomWorkshopModelForChatListRepository>();
         loggerMock = new Mock<ILogger<ChatRoomWorkshopService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
 
         roomService = new ChatRoomWorkshopService(
             roomRepository,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CodeficatorServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CodeficatorServiceTests.cs
@@ -13,6 +13,7 @@ using OutOfSchool.Services.Repository;
 using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Models.Codeficator;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -35,7 +36,7 @@ public class CodeficatorServiceTests
         options = builder.Options;
         context = new OutOfSchoolDbContext(options);
 
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         repository = new CodeficatorRepository(context);
         service = new CodeficatorService(repository, mapper);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -236,8 +236,6 @@ public class WorkshopServiceTests
         (result as SearchResult<WorkshopBaseCard>).TotalAmount.Should().Be(workshops.Count);
         (result as SearchResult<WorkshopBaseCard>).Entities.Should().BeEquivalentTo(expectedWorkshopBaseCards);
     }
-
-
     #endregion
 
     #region GetWorkshopListByProviderId
@@ -673,7 +671,6 @@ public class WorkshopServiceTests
            .Setup(repo => repo.Count(It.IsAny<Expression<Func<Workshop, bool>>>()))
             .Returns(Task.FromResult(count));
     }
-
 
     private void SetupUpdate(Workshop workshop)
     {

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -44,7 +44,7 @@ public class WorkshopServiceTests
         logger = new Mock<ILogger<WorkshopService>>();
         mapperMock = new Mock<IMapper>();
         workshopImagesMediator = new Mock<IImageDependentEntityImagesInteractionService<Workshop>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         workshopService =
             new WorkshopService(
                 workshopRepository.Object,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/MinistryAdminServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/MinistryAdminServiceTests.cs
@@ -19,6 +19,7 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Config;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -61,7 +62,7 @@ public class MinistryAdminServiceTests
 
         institutionAdminRepositoryMock = new Mock<IInstitutionAdminRepository>();
         var logger = new Mock<ILogger<MinistryAdminService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         userRepositoryMock = new Mock<IEntityRepository<string, User>>();
 
         ministryAdminService = new MinistryAdminService(

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/PermissionsForRoleServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/PermissionsForRoleServiceTests.cs
@@ -16,6 +16,7 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -38,7 +39,7 @@ public class PermissionsForRoleServiceTests
         var context = new OutOfSchoolDbContext(options);
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
         repository = new EntityRepository<long, PermissionsForRole>(context);
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         var logger = new Mock<ILogger<PermissionsForRoleService>>();
         service = new PermissionsForRoleService(repository, logger.Object, localizer.Object, mapper);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
@@ -17,6 +17,7 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Models.Providers;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Services.Images;
+using OutOfSchool.WebApi.Util;
 using Quartz.Impl.AdoJobStore.Common;
 
 namespace OutOfSchool.WebApi.Tests.Services;
@@ -58,7 +59,7 @@ public class ProviderServiceTests
         notificationService = new Mock<INotificationService>(MockBehavior.Strict);
         providerAdminService = new Mock<IProviderAdminService>();
 
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
 
         providerService = new ProviderService(
             providersRepositoryMock.Object,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SocialGroupServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SocialGroupServiceTests.cs
@@ -14,6 +14,7 @@ using OutOfSchool.Services.Repository;
 using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -40,7 +41,7 @@ public class SocialGroupServiceTests
         localizer = new Mock<IStringLocalizer<SharedResource>>();
         repository = new EntityRepository<long, SocialGroup>(context);
         logger = new Mock<ILogger<SocialGroupService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         service = new SocialGroupService(repository, logger.Object, localizer.Object, mapper);
 
         SeedDatabase();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
@@ -16,6 +16,7 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -37,7 +38,7 @@ public class StatusServiceTests
         options = builder.Options;
         context = new OutOfSchoolDbContext(options);
         repository = new EntityRepository<long, InstitutionStatus>(context);
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         var logger = new Mock<ILogger<StatusService>>();
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
         service = new StatusService(repository, logger.Object, localizer.Object, mapper);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/UserServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/UserServiceTest.cs
@@ -16,6 +16,7 @@ using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Extensions;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
+using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -42,7 +43,7 @@ public class UserServiceTest
         localizer = new Mock<IStringLocalizer<SharedResource>>();
         repo = new EntityRepository<string, User>(context);
         logger = new Mock<ILogger<UserService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<Util.MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         service = new UserService(repo, logger.Object, localizer.Object, mapper);
 
         SeedDatabase();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/ModelValidationHelperTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/ModelValidationHelperTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using NUnit.Framework;
+using OutOfSchool.WebApi.Models;
+using OutOfSchool.WebApi.Util;
+
+namespace OutOfSchool.WebApi.Tests.Util;
+
+[TestFixture]
+public class ModelValidationHelperTests
+{
+    [Test]
+    public void ValidateExcludedIdFilter_WhenNull_Should_ThrowException()
+    {
+        // Act and Assert
+        Assert.Throws<ArgumentNullException>(() => ModelValidationHelper.ValidateExcludedIdFilter(null));
+    }
+
+    [Test]
+    public void ValidateExcludedIdFilter_WhenGuidIsEMpty_Should_ThrowException()
+    {
+        // Arrange
+        var filter = new ExcludeIdFilter() { ExcludedId = Guid.Empty };
+
+        // Act and Assert
+        Assert.Throws<ArgumentException>(() => ModelValidationHelper.ValidateExcludedIdFilter(filter));
+    }
+
+    [Test]
+    public void ValidateExcludedIdFilter_WhenOffsetFilterIsIncorrect_Should_ThrowException()
+    {
+        // Arrange
+        var filter = new ExcludeIdFilter() { From = -1 };
+
+        // Act and Assert
+        Assert.Throws<ArgumentException>(() => ModelValidationHelper.ValidateExcludedIdFilter(filter));
+    }
+
+
+    [Test]
+    public void ValidateExcludedIdFilter_WhenValidFilter_Should_Not_ThrowException()
+    {
+        // Arrange
+        var filter = new ExcludeIdFilter() { From = 1, ExcludedId = Guid.NewGuid() };
+
+        // Act and Assert
+        Assert.DoesNotThrow(() => ModelValidationHelper.ValidateExcludedIdFilter(filter));
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/ModelValidationHelperTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/ModelValidationHelperTests.cs
@@ -35,7 +35,6 @@ public class ModelValidationHelperTests
         Assert.Throws<ArgumentException>(() => ModelValidationHelper.ValidateExcludedIdFilter(filter));
     }
 
-
     [Test]
     public void ValidateExcludedIdFilter_WhenValidFilter_Should_Not_ThrowException()
     {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
@@ -242,7 +242,7 @@ public class ProviderAdminController : Controller
     /// Method to Get data about managed Workshops.
     /// </summary>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<WorkshopProviderViewCard>))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SearchResult<WorkshopProviderViewCard>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -258,7 +258,7 @@ public class ProviderAdminController : Controller
 
         var relatedWorkshops = await providerAdminService.GetWorkshopsThatProviderAdminCanManage(userId, userSubrole == Subrole.ProviderDeputy).ConfigureAwait(false);
 
-        if (!relatedWorkshops.Any())
+        if (relatedWorkshops.TotalAmount == 0)
         {
             return NoContent();
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -74,9 +74,9 @@ public class WorkshopController : ControllerBase
     /// </summary>
     /// <param name="providerId">Id of the provider.</param>
     /// <param name="offsetFilter">Filter to get specified portion of workshop view cards for specified provider.</param>
-    /// <returns>The result is a <see cref="List{ShortEntityDto}"/> that contains a sorted by Title list of workshops that were received.</returns>
+    /// <returns>The result is a <see cref="SearchResult{ShortEntityDto}"/> that contains a sorted by Title list of workshops that were received.</returns>
     [AllowAnonymous]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<ShortEntityDto>))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SearchResult<ShortEntityDto>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -92,7 +92,7 @@ public class WorkshopController : ControllerBase
 
         var workshops = await combinedWorkshopService.GetWorkshopListByProviderId(providerId, offsetFilter).ConfigureAwait(false);
 
-        if (!workshops.Any())
+        if (workshops.TotalAmount == 0)
         {
             return NoContent();
         }
@@ -104,30 +104,30 @@ public class WorkshopController : ControllerBase
     /// Get workshop cards by Provider's Id.
     /// </summary>
     /// <param name="id">Provider's id.</param>
-    /// <param name="offsetFilter">Filter to get specified portion of workshop view cards for specified provider.</param>
-    /// <param name="excludedWorkshopId">Id of the excluded workshop.</param>
-    /// <returns><see cref="IEnumerable{WorkshopBaseCard}"/>, or no content.</returns>
+    /// <param name="filter">Filter to get specified portion of workshop view cards for specified provider.
+    /// Id of the excluded workshop could be specified.</param>
+    /// <returns><see cref="SearchResult{WorkshopBaseCard}"/>, or no content.</returns>
     /// <response code="200">The list of found entities by given Id.</response>
     /// <response code="204">No entity with given Id was found.</response>
     /// <response code="400">Provider id is empty.</response>
     /// <response code="500">If any server error occures. For example: Id was less than one.</response>
     [AllowAnonymous]
     [HttpGet("{id}")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<WorkshopBaseCard>))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SearchResult<WorkshopBaseCard>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> GetByProviderId(Guid id, [FromQuery] OffsetFilter offsetFilter, [FromQuery] Guid? excludedWorkshopId = null)
+    public async Task<IActionResult> GetByProviderId(Guid id, [FromQuery] ExcludeIdFilter filter)
     {
         if (id == Guid.Empty)
         {
             return BadRequest("Provider id is empty.");
         }
 
-        var workshopCards = await combinedWorkshopService.GetByProviderId<WorkshopBaseCard>(id, offsetFilter, excludedWorkshopId)
+        var workshopCards = await combinedWorkshopService.GetByProviderId<WorkshopBaseCard>(id, filter)
             .ConfigureAwait(false);
 
-        if (!workshopCards.Any())
+        if (workshopCards.TotalAmount == 0)
         {
             return NoContent();
         }
@@ -139,24 +139,24 @@ public class WorkshopController : ControllerBase
     /// Get a portion of workshop view cards for specified provider.
     /// </summary>
     /// <param name="id">Provider's Id.</param>
-    /// <param name="offsetFilter">Filter to get specified portion of workshop view cards for specified provider.</param>
-    /// <returns>Workshop view cards that were found.</returns>
+    /// <param name="filter">Filter to get specified portion of workshop view cards for specified provider, Id of the excluded workshop could be specified..</param>
+    /// <returns><see cref="SearchResult{WorkshopProviderViewCard}"/>, or no content.</returns>
     [AllowAnonymous]
     [HttpGet("{id}")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<WorkshopProviderViewCard>))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SearchResult<WorkshopProviderViewCard>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> GetWorkshopProviderViewCardsByProviderId(Guid id, [FromQuery] OffsetFilter offsetFilter)
+    public async Task<IActionResult> GetWorkshopProviderViewCardsByProviderId(Guid id, [FromQuery] ExcludeIdFilter filter)
     {
         if (id == Guid.Empty)
         {
             return BadRequest("Provider id is empty.");
         }
 
-        var workshopProviderViewCards = await combinedWorkshopService.GetByProviderId<WorkshopProviderViewCard>(id, offsetFilter).ConfigureAwait(false);
+        var workshopProviderViewCards = await combinedWorkshopService.GetByProviderId<WorkshopProviderViewCard>(id, filter).ConfigureAwait(false);
 
-        if (!workshopProviderViewCards.Any())
+        if (workshopProviderViewCards.TotalAmount == 0)
         {
             return NoContent();
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
@@ -86,21 +86,21 @@ public class WorkshopController : ControllerBase
     /// Get workshop cards by Provider's Id.
     /// </summary>
     /// <param name="id">Provider's id.</param>
-    /// <returns><see cref="IEnumerable{WorkshopCard}"/>, or no content.</returns>
+    /// <param name="filter">Filter to get specified portion of workshops for specified provider. Ids of the excluded workshops could be specified.</param>
+    /// <returns><see cref="SearchResult{WorkshopCard}"/>, or no content.</returns>
     /// <response code="200">The list of found entities by given Id.</response>
     /// <response code="204">No entity with given Id was found.</response>
     /// <response code="500">If any server error occures. For example: Id was less than one.</response>
     [AllowAnonymous]
     [HttpGet("{id}")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<WorkshopCard>))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SearchResult<WorkshopCard>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> GetByProviderId(Guid id)
+    public async Task<IActionResult> GetByProviderId(Guid id, [FromQuery] ExcludeIdFilter filter)
     {
-        var offsetFilter = new OffsetFilter() { From = 0, Size = int.MaxValue };
-        var workshopCards = await combinedWorkshopService.GetByProviderId<WorkshopBaseCard>(id, offsetFilter).ConfigureAwait(false);
+        var workshopCards = await combinedWorkshopService.GetByProviderId<WorkshopBaseCard>(id, filter).ConfigureAwait(false);
 
-        if (!workshopCards.Any())
+        if (workshopCards.TotalAmount == 0)
         {
             return NoContent();
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ExcludeIdFilter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ExcludeIdFilter.cs
@@ -1,0 +1,10 @@
+﻿namespace OutOfSchool.WebApi.Models;
+
+/// <inheritdoc/>>
+public class ExcludeIdFilter : OffsetFilter
+{
+    /// <summary>
+    /// Gets or sets filter to exclude entity by excluded id.
+    /// </summary>
+    public Guid? ExcludedId { get; set; }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/IWorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/IWorkshopService.cs
@@ -76,7 +76,7 @@ public interface IWorkshopService
     /// </summary>
     /// <param name="offsetFilter">Filter to get a certain portion of all entities.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.
-    /// The task result contains the <see cref="IEnumerable{TEntity}"/> that contains found elements.</returns>
+    /// The task result contains the <see cref="SearchResult{TEntity}"/> that contains found elements.</returns>
     Task<SearchResult<WorkshopDTO>> GetAll(OffsetFilter offsetFilter);
 
     /// <summary>
@@ -85,18 +85,18 @@ public interface IWorkshopService
     /// <param name="providerId">Provider's key.</param>
     /// <param name="offsetFilter">Filter to get a certain portion of all entities.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.
-    /// The task result contains a <see cref="List{ShortEntityDto}"/> that contains elements from the input sequence.</returns>
-    Task<List<ShortEntityDto>> GetWorkshopListByProviderId(Guid providerId, OffsetFilter offsetFilter);
+    /// The task result contains a <see cref="SearchResult{ShortEntityDto}"/> that contains elements from the input sequence.</returns>
+    Task<SearchResult<ShortEntityDto>> GetWorkshopListByProviderId(Guid providerId, OffsetFilter offsetFilter);
 
     /// <summary>
     /// Get all workshops by provider Id.
     /// </summary>
     /// <param name="id">Provider's key.</param>
-    /// <param name="offsetFilter">Filter to get a certain portion of all entities.</param>
+    /// <param name="filter">Filter to get a certain portion of all entities Or/And exclude by Workshop id.</param>
     /// <typeparam name="T">Type of entity that must be return.</typeparam>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.
-    /// The task result contains a <see cref="IEnumerable{WorkshopCard}"/> that contains elements from the input sequence.</returns>
-    Task<IEnumerable<T>> GetByProviderId<T>(Guid id, OffsetFilter offsetFilter)
+    /// The task result contains a <see cref="SearchResult{WorkshopCard}"/> that contains elements from the input sequence.</returns>
+    Task<SearchResult<T>> GetByProviderId<T>(Guid id, ExcludeIdFilter filter)
         where T : WorkshopBaseCard;
 
     /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
@@ -556,6 +556,8 @@ public class WorkshopService : IWorkshopService
             .ConfigureAwait(false)).ProviderId;
     }
 
+    private static void ValidateExcludedIdFilter(ExcludeIdFilter filter) => ModelValidationHelper.ValidateExcludedIdFilter(filter);
+
     private Expression<Func<Workshop, bool>> PredicateBuild(WorkshopFilter filter)
     {
         var predicate = PredicateBuilder.True<Workshop>();
@@ -633,7 +635,7 @@ public class WorkshopService : IWorkshopService
             predicate = filter.IsAppropriateHours
                 ? predicate.And(x => x.DateTimeRanges.Any(tr =>
                     tr.StartTime >= filter.MinStartTime && tr.EndTime.Hours <= filter.MaxStartTime.Hours))
-                : predicate = predicate.And(x => x.DateTimeRanges.Any(tr =>
+                : predicate.And(x => x.DateTimeRanges.Any(tr =>
                     tr.StartTime >= filter.MinStartTime && tr.StartTime.Hours <= filter.MaxStartTime.Hours));
         }
 
@@ -751,6 +753,4 @@ public class WorkshopService : IWorkshopService
     }
 
     private void ValidateOffsetFilter(OffsetFilter offsetFilter) => ModelValidationHelper.ValidateOffsetFilter(offsetFilter);
-
-    private void ValidateExcludedIdFilter(ExcludeIdFilter filter) => ModelValidationHelper.ValidateExcludedIdFilter(filter);
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
@@ -231,7 +231,9 @@ public class WorkshopService : IWorkshopService
         filter ??= new ExcludeIdFilter();
         ValidateExcludedIdFilter(filter);
 
-        var workshopBaseCardsCount = await workshopRepository.Count(where: x => x.ProviderId == id).ConfigureAwait(false);
+        var workshopBaseCardsCount = await workshopRepository.Count(where: x =>
+                                                filter.ExcludedId == null ? (x.ProviderId == id)
+                                                : (x.ProviderId == id && x.Id != filter.ExcludedId)).ConfigureAwait(false);
         var workshops = await workshopRepository.Get(
             skip: filter.From,
             take: filter.Size,

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
@@ -753,5 +753,4 @@ public class WorkshopService : IWorkshopService
     private void ValidateOffsetFilter(OffsetFilter offsetFilter) => ModelValidationHelper.ValidateOffsetFilter(offsetFilter);
 
     private void ValidateExcludedIdFilter(ExcludeIdFilter filter) => ModelValidationHelper.ValidateExcludedIdFilter(filter);
-
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
@@ -197,13 +197,14 @@ public class WorkshopService : IWorkshopService
     }
 
     /// <inheritdoc/>
-    public async Task<List<ShortEntityDto>> GetWorkshopListByProviderId(Guid providerId, OffsetFilter offsetFilter)
+    public async Task<SearchResult<ShortEntityDto>> GetWorkshopListByProviderId(Guid providerId, OffsetFilter offsetFilter)
     {
         logger.LogDebug($"Getting Workshop (Id, Title) by organization started. Looking ProviderId = {providerId}.");
 
         offsetFilter ??= new OffsetFilter();
         ValidateOffsetFilter(offsetFilter);
 
+        var workshopsCount = await workshopRepository.Count(where: x => x.ProviderId == providerId).ConfigureAwait(false);
         var workshops = await workshopRepository.Get(
             skip: offsetFilter.From,
             take: offsetFilter.Size,
@@ -211,25 +212,32 @@ public class WorkshopService : IWorkshopService
             .ToListAsync()
             .ConfigureAwait(false);
 
-        var result = mapper.Map<List<ShortEntityDto>>(workshops).OrderBy(entity => entity.Title).ToList();
+        var workshopDTOs = mapper.Map<List<ShortEntityDto>>(workshops).OrderBy(entity => entity.Title).ToList();
+        var result = new SearchResult<ShortEntityDto>()
+        {
+            TotalAmount = workshopsCount,
+            Entities = workshopDTOs,
+        };
 
         return result;
     }
 
     /// <inheritdoc/>
-    public async Task<IEnumerable<T>> GetByProviderId<T>(Guid id, OffsetFilter offsetFilter)
+    public async Task<SearchResult<T>> GetByProviderId<T>(Guid id, ExcludeIdFilter filter)
         where T : WorkshopBaseCard
     {
         logger.LogInformation($"Getting Workshop by organization started. Looking ProviderId = {id}.");
 
-        offsetFilter ??= new OffsetFilter();
-        ValidateOffsetFilter(offsetFilter);
+        filter ??= new ExcludeIdFilter();
+        ValidateExcludedIdFilter(filter);
 
+        var workshopBaseCardsCount = await workshopRepository.Count(where: x => x.ProviderId == id).ConfigureAwait(false);
         var workshops = await workshopRepository.Get(
-            skip: offsetFilter.From,
-            take: offsetFilter.Size,
+            skip: filter.From,
+            take: filter.Size,
             includeProperties: includingPropertiesForMappingDtoModel,
-            where: x => x.ProviderId == id)
+            where: x => filter.ExcludedId == null ? (x.ProviderId == id)
+                                  : (x.ProviderId == id && x.Id != filter.ExcludedId))
             .ToListAsync()
             .ConfigureAwait(false);
 
@@ -237,9 +245,14 @@ public class WorkshopService : IWorkshopService
             ? $"There aren't Workshops for Provider with Id = {id}."
             : $"From Workshop table were successfully received {workshops.Count} records.");
 
-        var workshopBaseCards = mapper.Map<List<T>>(workshops);
+        var workshopBaseCards = mapper.Map<List<T>>(workshops).ToList();
+        var result = new SearchResult<T>()
+        {
+            TotalAmount = workshopBaseCardsCount,
+            Entities = await GetWorkshopsWithAverageRating(workshopBaseCards).ConfigureAwait(false),
+        };
 
-        return await GetWorkshopsWithAverageRating(workshopBaseCards);
+        return result;
     }
 
     /// <inheritdoc/>
@@ -736,4 +749,7 @@ public class WorkshopService : IWorkshopService
     }
 
     private void ValidateOffsetFilter(OffsetFilter offsetFilter) => ModelValidationHelper.ValidateOffsetFilter(offsetFilter);
+
+    private void ValidateExcludedIdFilter(ExcludeIdFilter filter) => ModelValidationHelper.ValidateExcludedIdFilter(filter);
+
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Services/IProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/IProviderAdminService.cs
@@ -48,7 +48,7 @@ public interface IProviderAdminService
     /// <param name="userId">Key in the table.</param>
     /// <param name="isProviderDeputy">Is providerAdmin deputy or no.</param>
     /// <returns>List of the workshops that providerAdmin can manage.</returns>
-    Task<IEnumerable<WorkshopProviderViewCard>> GetWorkshopsThatProviderAdminCanManage(string userId, bool isProviderDeputy);
+    Task<SearchResult<WorkshopProviderViewCard>> GetWorkshopsThatProviderAdminCanManage(string userId, bool isProviderDeputy);
 
     /// <summary>
     /// Get entity by it's key.

--- a/OutOfSchool/OutOfSchool.WebApi/Services/IWorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/IWorkshopServicesCombiner.cs
@@ -28,7 +28,7 @@ public interface IWorkshopServicesCombiner
     /// <param name="offsetFilter">Filter to get a certain portion of all entities.</param>
     /// <returns>A <see cref="Task{ShortEntityDto}"/> representing the result of the asynchronous operation.
     /// The task result contains a <see cref="List{ShortEntityDto}"/> that contains elements from the input sequence.</returns>
-    Task<List<ShortEntityDto>> GetWorkshopListByProviderId(Guid providerId, OffsetFilter offsetFilter);
+    Task<SearchResult<ShortEntityDto>> GetWorkshopListByProviderId(Guid providerId, OffsetFilter offsetFilter);
 
     /// <summary>
     /// Get entity by it's key.
@@ -71,12 +71,11 @@ public interface IWorkshopServicesCombiner
     /// Get all workshop cards with the specified provider's Id.
     /// </summary>
     /// <param name="id">Provider's key.</param>
-    /// <param name="offsetFilter">Filter to get a certain portion of all entities.</param>
-    /// <param name="excludedWorkshopId">Id of the excluded workshop.</param>
+    /// <param name="filter">Filter to get a certain portion of all entities or exclude some entities by excluded ids.</param>
     /// <typeparam name="T">Type of entity that must be return.</typeparam>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.
     /// The task result contains a <see cref="List{WorkshopBaseCard}"/> that contains elements from the input sequence.</returns>
-    Task<List<T>> GetByProviderId<T>(Guid id, OffsetFilter offsetFilter, Guid? excludedWorkshopId = null)
+    Task<SearchResult<T>> GetByProviderId<T>(Guid id, ExcludeIdFilter filter)
         where T : WorkshopBaseCard;
 
     /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
@@ -327,9 +327,9 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
         string userId,
         bool isProviderDeputy)
     {
-        var providersAdmins = await providerAdminRepository
-            .GetByFilter(p => p.UserId == userId && p.IsDeputy == isProviderDeputy, includingPropertiesForMaping)
-            .ConfigureAwait(false);
+        var providersAdmins = (await providerAdminRepository
+            .GetByFilter(p => p.UserId == userId && p.IsDeputy == isProviderDeputy, includingPropertiesForMaping))
+            .ToList();
 
         if (!providersAdmins.Any())
         {
@@ -356,8 +356,11 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
             return await workshopService.GetByProviderId<WorkshopProviderViewCard>(providerAdmin.ProviderId, filter).ConfigureAwait(false);
         }
 
-        var workshops = providersAdmins.SingleOrDefault()
-                        .ManagedWorkshops.Select(workshop => mapper.Map<WorkshopProviderViewCard>(workshop)).ToList();
+        var pa = providersAdmins.SingleOrDefault();
+
+        var workshops = pa is not null
+            ? pa.ManagedWorkshops.Select(workshop => mapper.Map<WorkshopProviderViewCard>(workshop)).ToList()
+            : new List<WorkshopProviderViewCard>();
 
         return new SearchResult<WorkshopProviderViewCard>()
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
@@ -333,7 +333,8 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
 
         if (!providersAdmins.Any())
         {
-            return new SearchResult<WorkshopProviderViewCard>() {
+            return new SearchResult<WorkshopProviderViewCard>()
+            {
                 Entities = new List<WorkshopProviderViewCard>(),
                 TotalAmount = 0,
             };
@@ -360,7 +361,7 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
         return new SearchResult<WorkshopProviderViewCard>()
         {
             Entities = workshops,
-            TotalAmount = workshops.Count(),
+            TotalAmount = workshops.Count,
         };
     }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
@@ -343,7 +343,8 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
         if (isProviderDeputy)
         {
             var providerAdmin = providersAdmins.SingleOrDefault(x => x.IsDeputy);
-            if (providerAdmin == null) {
+            if (providerAdmin == null)
+            {
                 return new SearchResult<WorkshopProviderViewCard>()
                 {
                     Entities = new List<WorkshopProviderViewCard>(),

--- a/OutOfSchool/OutOfSchool.WebApi/Services/WorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/WorkshopServicesCombiner.cs
@@ -153,23 +153,18 @@ public class WorkshopServicesCombiner : IWorkshopServicesCombiner, INotification
     }
 
     /// <inheritdoc/>
-    public async Task<List<ShortEntityDto>> GetWorkshopListByProviderId(Guid providerId, OffsetFilter offsetFilter)
+    public async Task<SearchResult<ShortEntityDto>> GetWorkshopListByProviderId(Guid providerId, OffsetFilter offsetFilter)
     {
         return await workshopService.GetWorkshopListByProviderId(providerId, offsetFilter).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task<List<T>> GetByProviderId<T>(Guid id, OffsetFilter offsetFilter, Guid? excludedWorkshopId = null)
+    public async Task<SearchResult<T>> GetByProviderId<T>(Guid id, ExcludeIdFilter filter)
         where T : WorkshopBaseCard
     {
-        var workshopBaseCards = await workshopService.GetByProviderId<T>(id, offsetFilter).ConfigureAwait(false);
+        var workshopBaseCards = await workshopService.GetByProviderId<T>(id, filter).ConfigureAwait(false);
 
-        if (excludedWorkshopId is not null && excludedWorkshopId != Guid.Empty)
-        {
-            workshopBaseCards = workshopBaseCards.Where(x => x.WorkshopId != excludedWorkshopId);
-        }
-
-        return workshopBaseCards.ToList();
+        return workshopBaseCards;
     }
 
     /// <inheritdoc/>

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelValidationHelper.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelValidationHelper.cs
@@ -16,7 +16,7 @@ public static class ModelValidationHelper
         var isValid = true;
 
         var stringBuilder = new StringBuilder();
-        stringBuilder.AppendLine($"Validation of {nameof(OffsetFilter)} faild.");
+        stringBuilder.AppendLine($"Validation of {nameof(OffsetFilter)} failed.");
 
         if (offsetFilter.Size < 0)
         {
@@ -33,6 +33,30 @@ public static class ModelValidationHelper
         if (!isValid)
         {
             throw new ArgumentException(stringBuilder.ToString(), nameof(offsetFilter));
+        }
+    }
+
+    public static void ValidateExcludedIdFilter(ExcludeIdFilter filter)
+    {
+        if (filter == null)
+        {
+            throw new ArgumentNullException(nameof(filter));
+        }
+
+        ValidateOffsetFilter(filter);
+
+        var isValid = true;
+        var stringBuilder = new StringBuilder();
+        stringBuilder.AppendLine($"Validation of {nameof(ExcludeIdFilter)} failed.");
+
+        if (filter.ExcludedId != null && filter.ExcludedId == Guid.Empty) {
+            isValid = false;
+            stringBuilder.AppendLine($"{nameof(ExcludeIdFilter.ExcludedId)}: ExcludedId cannot be Empty Guid.");
+        }
+
+        if (!isValid)
+        {
+            throw new ArgumentException(stringBuilder.ToString(), nameof(filter));
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelValidationHelper.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelValidationHelper.cs
@@ -49,7 +49,8 @@ public static class ModelValidationHelper
         var stringBuilder = new StringBuilder();
         stringBuilder.AppendLine($"Validation of {nameof(ExcludeIdFilter)} failed.");
 
-        if (filter.ExcludedId != null && filter.ExcludedId == Guid.Empty) {
+        if (filter.ExcludedId != null && filter.ExcludedId == Guid.Empty)
+        {
             isValid = false;
             stringBuilder.AppendLine($"{nameof(ExcludeIdFilter.ExcludedId)}: ExcludedId cannot be Empty Guid.");
         }


### PR DESCRIPTION
updated endpoints to use SearchResult models:
GET v1/GetWorkshopProviderViewCardsByProviderId
GET v1/GetWorkshopListByProviderId
GET v1/GetByProviderId
GET v2/GetByProviderId
GET v1/ManagedWorkshops

