### PR TITLE
Baditsa/block unblock service provider 2

### DIFF
--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Newtonsoft.Json;
 using OutOfSchool.Common;
@@ -112,4 +113,6 @@ public class Workshop : IKeyedEntity<Guid>, IImageDependentEntity<Workshop>
     public virtual ICollection<ChatRoomWorkshop> ChatRooms { get; set; }
 
     public virtual List<Image<Workshop>> Images { get; set; }
+
+    public bool IsBlocked { get; set; } = false;
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/IWorkshopRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/IWorkshopRepository.cs
@@ -17,4 +17,11 @@ public interface IWorkshopRepository : IEntityRepositoryBase<Guid, Workshop>
     /// <param name="provider">Provider to be searched by.</param>
     /// <returns>List of Workshops for the specified provider.</returns>
     Task<IEnumerable<Workshop>> PartialUpdateByProvider(Provider provider);
+
+    /// <summary>
+    /// Update IsBlocked property in all workshops with specified provider.
+    /// </summary>
+    /// <param name="provider">Provider to be searched by.</param>
+    /// <returns>List of Workshops for the specified provider.</returns>
+    Task<IEnumerable<Workshop>> BlockByProvider(Provider provider);
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/WorkshopRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/WorkshopRepository.cs
@@ -58,4 +58,17 @@ public class WorkshopRepository : SensitiveEntityRepository<Workshop>, IWorkshop
 
         return await workshops.ToListAsync();
     }
+
+    public async Task<IEnumerable<Workshop>> BlockByProvider(Provider provider)
+    {
+        var workshops = db.Workshops.Where(ws => ws.ProviderId == provider.Id);
+        await workshops.ForEachAsync(ws =>
+        {
+            ws.IsBlocked = provider.IsBlocked;
+        });
+
+        await db.SaveChangesAsync();
+
+        return await workshops.ToListAsync();
+    }
 }

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/ESWorkshopProvider.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/ESWorkshopProvider.cs
@@ -141,6 +141,12 @@ public class ESWorkshopProvider : ElasticsearchProvider<WorkshopES, WorkshopFilt
             };
         }
 
+        queryContainer &= new TermQuery()
+        {
+            Field = Infer.Field<WorkshopES>(w => w.IsBlocked),
+            Value = false,
+        };
+
         if (filter.Statuses.Any())
         {
             queryContainer &= new TermsQuery()

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/Models/WorkshopES.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/Models/WorkshopES.cs
@@ -60,4 +60,5 @@ public class WorkshopES
     public List<DateTimeRangeES> DateTimeRanges { get; set; }
 
     public WorkshopStatus Status { get; set; }
+    public bool IsBlocked { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20230203165048_AddIsBlockedColumnToWorkshop.Designer.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20230203165048_AddIsBlockedColumnToWorkshop.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
@@ -10,9 +11,10 @@ using OutOfSchool.Services;
 namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230203165048_AddIsBlockedColumnToWorkshop")]
+    partial class AddIsBlockedColumnToWorkshop
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20230203165048_AddIsBlockedColumnToWorkshop.cs
+++ b/OutOfSchool/OutOfSchool.IdentityServer/Data/Migrations/OutOfSchoolMigrations/20230203165048_AddIsBlockedColumnToWorkshop.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
+{
+    public partial class AddIsBlockedColumnToWorkshop : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsBlocked",
+                table: "Workshops",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsBlocked",
+                table: "Workshops");
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Workshop/WorkshopDTO.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Workshop/WorkshopDTO.cs
@@ -133,6 +133,9 @@ public class WorkshopDTO : IValidatableObject
     [EnumDataType(typeof(ProviderLicenseStatus), ErrorMessage = Constants.EnumErrorMessage)]
     public ProviderLicenseStatus ProviderLicenseStatus { get; set; } = ProviderLicenseStatus.NotProvided;
 
+    [JsonIgnore]
+    public bool IsBlocked { get; set; }
+
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         // TODO: Validate DateTimeRanges are not empty when frontend is ready

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/IWorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/IWorkshopService.cs
@@ -132,6 +132,13 @@ public interface IWorkshopService
     Task<IEnumerable<Workshop>> PartialUpdateByProvider(Provider provider);
 
     /// <summary>
+    /// Update IsBloked property in all workshops with specified provider.
+    /// </summary>
+    /// <param name="provider">Provider to be searched by.</param>
+    /// <returns>List of Workshops for the specified provider.</returns>
+    Task<IEnumerable<Workshop>> BlockByProvider(Provider provider);
+
+    /// <summary>
     ///  Returns ProviderDto by Id of its own workshop entity.
     /// </summary>
     /// <param name="workshopId">WorkshopId for which we need to get provider owner entity.</param>

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
@@ -402,7 +402,7 @@ public class WorkshopService : IWorkshopService
         {
             logger.LogError(exception,
                 $"Partial updating {nameof(Workshop)} with ProviderId = {provider?.Id} was failed. Exception: {exception.Message}");
-            throw; // TODO Probably should not rethrow this exception to the higher level
+            throw; // TODO Probably should not rethrow this exception to the higher level. See pull request [Provicevk/unified responses #843] as future decision
         }
     }
 
@@ -420,7 +420,7 @@ public class WorkshopService : IWorkshopService
         {
             logger.LogError(exception,
                 $"Block {nameof(Workshop)} with ProviderId = {provider.Id} was failed. Exception: {exception.Message}");
-            throw; // TODO Probably should not rethrow this exception to the higher level
+            throw; // TODO Probably should not rethrow this exception to the higher level. See pull request [Provicevk/unified responses #843] as future decision
         }
     }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
@@ -402,7 +402,25 @@ public class WorkshopService : IWorkshopService
         {
             logger.LogError(exception,
                 $"Partial updating {nameof(Workshop)} with ProviderId = {provider?.Id} was failed. Exception: {exception.Message}");
-            throw;
+            throw; // TODO Probably should not rethrow this exception to the higher level
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <exception cref="DbUpdateConcurrencyException">If a concurrency violation is encountered while saving to database.</exception>
+    public async Task<IEnumerable<Workshop>> BlockByProvider(Provider provider)
+    {
+        logger.LogInformation($"Block {nameof(Workshop)} with ProviderId = {provider.Id} was started.");
+
+        try
+        {
+            return await workshopRepository.BlockByProvider(provider).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException exception)
+        {
+            logger.LogError(exception,
+                $"Block {nameof(Workshop)} with ProviderId = {provider.Id} was failed. Exception: {exception.Message}");
+            throw; // TODO Probably should not rethrow this exception to the higher level
         }
     }
 
@@ -587,6 +605,7 @@ public class WorkshopService : IWorkshopService
         else
         {
             predicate = predicate.And(x => x.Provider.Status == ProviderStatus.Approved);
+            predicate = predicate.And(x => !x.IsBlocked);
         }
 
         if (filter.Ids.Any())

--- a/OutOfSchool/OutOfSchool.WebApi/Services/IWorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/IWorkshopServicesCombiner.cs
@@ -100,6 +100,12 @@ public interface IWorkshopServicesCombiner
     /// <returns><see cref="IEnumerable{T}"/> of Workshops for the specified provider.</returns>
     Task<IEnumerable<Workshop>> PartialUpdateByProvider(Provider provider);
 
+    /// <summary>
+    /// Update IsBlocked property in all workshops with specified provider.
+    /// </summary>
+    /// <param name="provider">Provider to be searched by.</param>
+    /// <returns><see cref="IEnumerable{T}"/> of Workshops for the specified provider.</returns>
+    Task<IEnumerable<Workshop>> BlockByProvider(Provider provider);
 
     /// <summary>
     /// Get id of provider, who owns Workshop with specefied id

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderService.cs
@@ -284,6 +284,7 @@ public class ProviderService : IProviderService, INotificationReciever
         return dto;
     }
 
+    /// <inheritdoc/>
     public async Task<ProviderBlockDto> Block(ProviderBlockDto providerBlockDto)
     {
         logger.LogInformation($"Block/Unblock Provider by Id started.");
@@ -303,6 +304,17 @@ public class ProviderService : IProviderService, INotificationReciever
         provider.IsBlocked = providerBlockDto.IsBlocked;
         provider.BlockReason = providerBlockDto.IsBlocked ? providerBlockDto.BlockReason : null;
         await providerRepository.UnitOfWork.CompleteAsync().ConfigureAwait(false);
+
+        // TODO What's happen if previous action will not successfull?
+        var workshops = await workshopServiceCombiner
+                           .BlockByProvider(provider)
+                           .ConfigureAwait(false);
+
+        foreach (var workshop in workshops)
+        {
+            logger.LogInformation($"IsBlocked property with povider Id = {provider.Id} " +
+                                  $"in workshops with Id = {workshop.Id} updated successfully.");
+        }
 
         logger.LogInformation($"Provider(id) {providerBlockDto.Id} IsBlocked was changed to {provider.IsBlocked}");
 

--- a/OutOfSchool/OutOfSchool.WebApi/Services/WorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/WorkshopServicesCombiner.cs
@@ -127,6 +127,23 @@ public class WorkshopServicesCombiner : IWorkshopServicesCombiner, INotification
     }
 
     /// <inheritdoc/>
+    public async Task<IEnumerable<Workshop>> BlockByProvider(Provider provider)
+    {
+        var workshops = await workshopService.BlockByProvider(provider).ConfigureAwait(false);
+
+        foreach (var workshop in workshops)
+        {
+            await elasticsearchSynchronizationService.AddNewRecordToElasticsearchSynchronizationTable(
+                    ElasticsearchSyncEntity.Workshop,
+                    workshop.Id,
+                    ElasticsearchSyncOperation.Update)
+                .ConfigureAwait(false);
+        }
+
+        return workshops;
+    }
+
+    /// <inheritdoc/>
     public async Task Delete(Guid id)
     {
         await workshopService.Delete(id).ConfigureAwait(false);

--- a/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
@@ -60,7 +60,8 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.Images, opt => opt.Ignore())
             .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
             .ForMember(dest => dest.InstitutionHierarchy, opt => opt.Ignore())
-            .ForMember(dest => dest.Status, opt => opt.Ignore());
+            .ForMember(dest => dest.Status, opt => opt.Ignore())
+            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore());
 
         CreateMap<Workshop, WorkshopDTO>()
             .ForMember(
@@ -73,6 +74,8 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.InstitutionId, opt => opt.MapFrom(src => src.InstitutionHierarchy.InstitutionId))
             .ForMember(dest => dest.Institution, opt => opt.MapFrom(src => src.InstitutionHierarchy.Institution.Title))
             .ForMember(dest => dest.CoverImage, opt => opt.Ignore())
+            .ForMember(dest => dest.IsBlocked, opt => opt.MapFrom(src => src.Provider.IsBlocked))
+
             .ForMember(dest => dest.Rating, opt => opt.Ignore())
             .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore())
             .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())


### PR DESCRIPTION
1. Recreated branch instead [baditsa/block-unblock_service_provider](https://github.com/ita-social-projects/OoS-Backend/pull/982)
- when the service provider is blocked - the provider's workshops block too (isBlocked field has been added to Workshop table)
- If the workshop is blocked this workshop isn't visible for search (condition has been added to workshop.GetByFilter() in database query)
2. Fix issues (partial) regarding review comments in  [baditsa/block-unblock_service_provider](https://github.com/ita-social-projects/OoS-Backend/pull/982)
3. IsBlocked field is added to ES for the workshop 
