### PR TITLE
Fix soft delete for provider

### DIFF
--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/IProviderRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/IProviderRepository.cs
@@ -1,8 +1,12 @@
 using OutOfSchool.Services.Models;
+using System.Threading.Tasks;
+using System;
 
 namespace OutOfSchool.Services.Repository;
 
 public interface IProviderRepository : ISensitiveEntityRepository<Provider>, IExistable<Provider>
 {
     bool ExistsUserId(string id);
+
+    Task<Provider> GetWithNavigations(Guid id);
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/ProviderRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/ProviderRepository.cs
@@ -71,4 +71,13 @@ public class ProviderRepository : SensitiveEntityRepository<Provider>, IProvider
 
         await db.SaveChangesAsync();
     }
+
+    public async Task<Provider> GetWithNavigations(Guid id)
+    {
+        return await db.Providers
+         .Include(x => x.LegalAddress) // TODO: Doesn't work softDelete using Include, only using loop below in Delete() method
+         .Include(x => x.Workshops)
+         .ThenInclude(w => w.Applications)
+         .SingleOrDefaultAsync(provider => provider.Id == id);
+    }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
@@ -692,7 +692,7 @@ public class ProviderServiceTests
         // Arrange
         var providerToDeleteDto = mapper.Map<ProviderDto>(fakeProviders.RandomItem());//fakeProviders.RandomItem().ToModel();
         var deleteMethodArguments = new List<Provider>();
-        providersRepositoryMock.Setup(r => r.GetById(It.IsAny<Guid>()))
+        providersRepositoryMock.Setup(r => r.GetWithNavigations(It.IsAny<Guid>()))
             .ReturnsAsync(fakeProviders.Single(p => p.Id == providerToDeleteDto.Id));
         providersRepositoryMock.Setup(r => r.Delete(Capture.In(deleteMethodArguments)));
 
@@ -716,7 +716,7 @@ public class ProviderServiceTests
             Id = fakeProviderInvalidId,
         };
         providersRepositoryMock.Setup(p => p.Delete(provider)).Returns(Task.CompletedTask);
-        providersRepositoryMock.Setup(p => p.GetById(provider.Id)).ThrowsAsync(new ArgumentNullException());
+        providersRepositoryMock.Setup(p => p.GetWithNavigations(provider.Id)).ThrowsAsync(new ArgumentNullException());
 
         // Act and Assert
         Assert.ThrowsAsync<ArgumentNullException>(

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderService.cs
@@ -609,7 +609,7 @@ public class ProviderService : IProviderService, INotificationReciever
 
         try
         {
-            var entity = await providerRepository.GetById(id).ConfigureAwait(false);
+            var entity = await providerRepository.GetWithNavigations(id).ConfigureAwait(false);
 
             if (entity is null)
             {


### PR DESCRIPTION
**Fixed soft delete process for case Provider -> Workshop -> Applications -> Provider address**

Issues for discussion:
1) Interesting behavior: in case Workshop -> Applications -> Addresses soft delete works correctly (without explicit Include), 
although override SaveChangesAsync() (where UpdateSoftDeleteStatuses is called) is used in both cases.

2) Address deleting doesn't work without a manual loop.
Maybe we should change OnDelete(DeleteBehavior.Restrict); -> .OnDelete(DeleteBehavior.Cascade); in ProviderConfiguration + new migration? But my attempt and test didn't succeed.

3) Case Provider -> Workshop -> Applications -> Workshop address doesn't work: Workshop address isn`t changed

4) Test Delete_SoftDeletes_Provider_DeletesRelatedEntities doesn't work properly, because InMemoryDatabase is used and all entities include/delete successfully

5) Should we include soft delete teachers, images, workshop descriptions, and other related entities?