### PR TITLE
fix framework version not detected by buildpacks

### DIFF
--- a/OutOfSchool/OutOfSchool.AdminInitializer/OutOfSchool.AdminInitializer.csproj
+++ b/OutOfSchool/OutOfSchool.AdminInitializer/OutOfSchool.AdminInitializer.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-      <UserSecretsId>dd058b3f-d89a-4456-a6df-2f32568b56ea</UserSecretsId>
+        <UserSecretsId>dd058b3f-d89a-4456-a6df-2f32568b56ea</UserSecretsId>
   </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" />

--- a/OutOfSchool/OutOfSchool.IdentityServer/OutOfSchool.IdentityServer.csproj
+++ b/OutOfSchool/OutOfSchool.IdentityServer/OutOfSchool.IdentityServer.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
         <UserSecretsId>23768b69-757e-4a20-894f-dcf7181971ca</UserSecretsId>
     </PropertyGroup>
     <PropertyGroup>

--- a/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>1ac220b0-4848-4d5c-b0d9-b64657bd3b04</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Buildpacks parse `*.csproj` file before running MSBuild so centralised framework version is not being set during container build