### PR TITLE
Reduce EF logs in test and prod

### DIFF
--- a/OutOfSchool/OutOfSchool.AdminInitializer/appsettings.json
+++ b/OutOfSchool/OutOfSchool.AdminInitializer/appsettings.json
@@ -1,4 +1,12 @@
 {
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Information",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+    }
+  },
   "ConnectionStringsOverride": {
     "DefaultConnection": {
       "UseOverride": true,

--- a/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Google.json
+++ b/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Google.json
@@ -5,7 +5,8 @@
       "Default": "Information",
       "Override": {
         "Microsoft": "Information",
-        "System": "Warning"
+        "System": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
       }
     },
     "WriteTo": [

--- a/OutOfSchool/OutOfSchool.IdentityServer/appsettings.GooglePreRelease.json
+++ b/OutOfSchool/OutOfSchool.IdentityServer/appsettings.GooglePreRelease.json
@@ -5,7 +5,8 @@
       "Default": "Information",
       "Override": {
         "Microsoft": "Information",
-        "System": "Warning"
+        "System": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
       }
     },
     "WriteTo": [

--- a/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Kubernetes.json
+++ b/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Kubernetes.json
@@ -2,6 +2,14 @@
   "AllowedHosts": "*",
   "Serilog": {
     "Using": ["Serilog.Sinks.Console", "Serilog.Exceptions"],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      }
+    },
     "WriteTo": [
       {
         "Name": "Console"

--- a/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Release.json
+++ b/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Release.json
@@ -16,6 +16,14 @@
   "AllowedHosts": "*",
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Exceptions" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      }
+    },
     "WriteTo": [
       {
         "Name": "Console"

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Google.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Google.json
@@ -8,7 +8,8 @@
         "System": "Warning",
         "Quartz": "Warning",
         "Quartz.Core.QuartzSchedulerThread": "Warning",
-        "Quartz.Core.JobRunShell": "Warning"
+        "Quartz.Core.JobRunShell": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
       }
     },
     "WriteTo": [

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.GooglePreRelease.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.GooglePreRelease.json
@@ -8,7 +8,8 @@
         "System": "Warning",
         "Quartz": "Warning",
         "Quartz.Core.QuartzSchedulerThread": "Warning",
-        "Quartz.Core.JobRunShell": "Warning"
+        "Quartz.Core.JobRunShell": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
       }
     },
     "WriteTo": [

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Kubernetes.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Kubernetes.json
@@ -8,7 +8,8 @@
         "System": "Warning",
         "Quartz": "Warning",
         "Quartz.Core.QuartzSchedulerThread": "Warning",
-        "Quartz.Core.JobRunShell": "Warning"
+        "Quartz.Core.JobRunShell": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
       }
     },
     "WriteTo": [

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Release.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Release.json
@@ -17,6 +17,17 @@
   },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Exceptions" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Warning",
+        "Quartz": "Warning",
+        "Quartz.Core.QuartzSchedulerThread": "Warning",
+        "Quartz.Core.JobRunShell": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      }
+    },
     "WriteTo": [
       {
         "Name": "Console",


### PR DESCRIPTION
* Do not print SQL queries in test & prod environment
* Explicitly override logging setting in test & prod so it can be modified in the default or dev config