### PR TITLE
Tsylia / Fix workshop's provider ownership type during workshop update

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -328,8 +328,10 @@ public class WorkshopServiceTests
         var id = new Guid("ca2cc30c-419c-4b00-a344-b23f0cbf18d8");
         var changedFirstEntity = WithWorkshop(id);
         var teachers = TeachersGenerator.Generate(teachersInWorkshop).WithWorkshop(changedFirstEntity);
+        var provider = ProvidersGenerator.Generate();
         changedFirstEntity.Teachers = teachers;
         changedFirstEntity.DateTimeRanges = new List<DateTimeRange>();
+        changedFirstEntity.Provider = provider;
         SetupUpdate(changedFirstEntity);
         var expectedTeachers = teachers.Select(s => mapper.Map<TeacherDTO>(s));
 
@@ -407,10 +409,13 @@ public class WorkshopServiceTests
     public async Task Update_WhenTryUpdateStatus_ShouldReturnEntityWithOldStatus([Random(1, 100, 1)] long classId)
     {
         // Arrange
+        var provider = ProvidersGenerator.Generate();
         var inputWorkshopDto = WithWorkshop(Guid.NewGuid());
         inputWorkshopDto.Status = WorkshopStatus.Closed;
+        inputWorkshopDto.Provider = provider;
         var expectedStatus = WorkshopStatus.Open;
         var workshopDtoMock = WithWorkshop(Guid.NewGuid());
+        workshopDtoMock.Provider = provider;
 
         workshopRepository.Setup(w => w.GetWithNavigations(It.IsAny<Guid>())).ReturnsAsync(workshopDtoMock);
         workshopRepository.Setup(w => w.UnitOfWork.CompleteAsync()).ReturnsAsync(It.IsAny<int>());

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
@@ -311,8 +311,6 @@ public class WorkshopService : IWorkshopService
 
             mapper.Map(dto, currentWorkshop);
 
-            currentWorkshop.ProviderOwnership = currentWorkshop.Provider.Ownership;
-
             await UpdateWorkshop().ConfigureAwait(false);
 
             return currentWorkshop;

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Database/WorkshopService.cs
@@ -7,6 +7,7 @@ using H3Lib.Extensions;
 using Nest;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Services.Enums;
+using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Models.Images;
 using OutOfSchool.Services.Repository;
 using OutOfSchool.WebApi.Common;
@@ -309,6 +310,8 @@ public class WorkshopService : IWorkshopService
             await ChangeTeachers(currentWorkshop, dto.Teachers ?? new List<TeacherDTO>()).ConfigureAwait(false);
 
             mapper.Map(dto, currentWorkshop);
+
+            currentWorkshop.ProviderOwnership = currentWorkshop.Provider.Ownership;
 
             await UpdateWorkshop().ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
@@ -60,7 +60,8 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
             .ForMember(dest => dest.InstitutionHierarchy, opt => opt.Ignore())
             .ForMember(dest => dest.Status, opt => opt.Ignore())
-            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore());
+            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
+            .ForMember(dest => dest.ProviderOwnership, opt => opt.Ignore());
 
         CreateMap<Workshop, WorkshopDTO>()
             .ForMember(


### PR DESCRIPTION
During the workshop update, the workshop's provider ownership type has equal value to the provider's ownership type.