### PR TITLE
explicitly filter healthcheck logs

### DIFF
--- a/OutOfSchool/Directory.Packages.props
+++ b/OutOfSchool/Directory.Packages.props
@@ -64,6 +64,7 @@
         <PackageVersion Include="Serilog.Settings.Configuration" Version="3.3.0"/>
         <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0"/>
         <PackageVersion Include="Serilog.Sinks.GoogleCloudLogging" Version="5.0.0"/>
+        <PackageVersion Include="Serilog.Expressions" Version="3.4.1"/>
         <!--Automapper-->
         <PackageVersion Include="AutoMapper" Version="10.1.1"/>
         <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1"/>

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/OutOfSchool.AuthorizationServer.csproj
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/OutOfSchool.AuthorizationServer.csproj
@@ -29,6 +29,7 @@
         <PackageReference Include="Serilog.Settings.Configuration" />
         <PackageReference Include="Serilog.Sinks.File" />
         <PackageReference Include="Serilog.Sinks.GoogleCloudLogging" />
+        <PackageReference Include="Serilog.Expressions" />
         <PackageReference Include="Quartz.AspNetCore" />
         <PackageReference Include="Quartz.Extensions.DependencyInjection" />
         <PackageReference Include="Quartz.Plugins.TimeZoneConverter" />

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Google.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Google.json
@@ -19,6 +19,14 @@
           "useLogCorrelation": "true"
         }
       }
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/healthz%'"
+        }
+      }
     ]
   },
   "Identity": {

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Kubernetes.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Kubernetes.json
@@ -28,6 +28,14 @@
           "formatter": "Serilog.Formatting.Elasticsearch.ElasticsearchJsonFormatter, Serilog.Formatting.Elasticsearch"
         }
       }
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/healthz%'"
+        }
+      }
     ]
   },
   "Identity": {

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Release.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Release.json
@@ -28,6 +28,14 @@
       {
         "Name": "Console"
       }
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/healthz%'"
+        }
+      }
     ]
   },
   "Identity": {

--- a/OutOfSchool/OutOfSchool.IdentityServer/OutOfSchool.IdentityServer.csproj
+++ b/OutOfSchool/OutOfSchool.IdentityServer/OutOfSchool.IdentityServer.csproj
@@ -30,6 +30,7 @@
         <PackageReference Include="Serilog.Settings.Configuration" />
         <PackageReference Include="Serilog.Sinks.File" />
         <PackageReference Include="Serilog.Sinks.GoogleCloudLogging" />
+        <PackageReference Include="Serilog.Expressions" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
         <PackageReference Include="StyleCop.Analyzers">
             <PrivateAssets>all</PrivateAssets>

--- a/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Google.json
+++ b/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Google.json
@@ -17,6 +17,14 @@
           "useLogCorrelation": "true"
         }
       }
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/healthz%'"
+        }
+      }
     ]
   },
   "Identity": {

--- a/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Kubernetes.json
+++ b/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Kubernetes.json
@@ -28,6 +28,14 @@
           "formatter": "Serilog.Formatting.Elasticsearch.ElasticsearchJsonFormatter, Serilog.Formatting.Elasticsearch"
         }
       }
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/healthz%'"
+        }
+      }
     ]
   },
   "Identity": {

--- a/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Release.json
+++ b/OutOfSchool/OutOfSchool.IdentityServer/appsettings.Release.json
@@ -28,6 +28,14 @@
       {
         "Name": "Console"
       }
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/healthz%'"
+        }
+      }
     ]
   },
   "Identity": {

--- a/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
@@ -66,6 +66,7 @@
         <PackageReference Include="Serilog.Settings.Configuration" />
         <PackageReference Include="Serilog.Sinks.File" />
         <PackageReference Include="Serilog.Sinks.GoogleCloudLogging" />
+        <PackageReference Include="Serilog.Expressions" />
         <PackageReference Include="SkiaSharp" />
         <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies"/>
         <PackageReference Include="StyleCop.Analyzers">

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Google.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Google.json
@@ -20,6 +20,14 @@
           "useLogCorrelation": "true"
         }
       }
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/healthz%'"
+        }
+      }
     ]
   },
   "Swagger": {

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Kubernetes.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Kubernetes.json
@@ -30,6 +30,14 @@
           "formatter": "Serilog.Formatting.Elasticsearch.ElasticsearchJsonFormatter, Serilog.Formatting.Elasticsearch"
         }
       }
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/healthz%'"
+        }
+      }
     ]
   },
   "Swagger": {

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Release.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Release.json
@@ -35,6 +35,14 @@
           "formatter": "Serilog.Formatting.Elasticsearch.ElasticsearchJsonFormatter, Serilog.Formatting.Elasticsearch"
         }
       }
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/healthz%'"
+        }
+      }
     ]
   },
   "ProviderAdmin": {


### PR DESCRIPTION
As the `/healthz/*` path access is blocked from outside and is only used for internal application readiness checks we don't really need the spam in logs