### PR TITLE
Remove custom request id and use header propagation

### DIFF
--- a/OutOfSchool/Directory.Packages.props
+++ b/OutOfSchool/Directory.Packages.props
@@ -22,6 +22,7 @@
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5"/>
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.6"/>
         <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.6"/>
+        <PackageVersion Include="Microsoft.AspNetCore.HeaderPropagation" Version="6.0.21" />
         <!--Entity Framework-->
         <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)"/>
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(EFCoreVersion)"/>

--- a/OutOfSchool/OutOfSchool.AuthCommon/Controllers/AccountController.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Controllers/AccountController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using OutOfSchool.AuthCommon.Config;
+using OutOfSchool.AuthCommon.Extensions;
 using OutOfSchool.AuthCommon.ViewModels;
 using OutOfSchool.RazorTemplatesData.Models.Emails;
 
@@ -153,7 +154,7 @@ public class AccountController : Controller
                 "{Path} Changing email was failed for User(id): {UserId}. {Errors}",
                 path,
                 user.Id,
-                string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                result.ErrorMessages());
 
             return BadRequest();
         }
@@ -165,7 +166,7 @@ public class AccountController : Controller
                 "{Path} Setting username was failed for User(id): {UserId}. {Errors}",
                 path,
                 userId,
-                string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                result.ErrorMessages());
 
             return BadRequest();
         }
@@ -229,7 +230,7 @@ public class AccountController : Controller
                 "{Path} Email сonfirmation was failed for User(id): {UserId}. {Errors}",
                 path,
                 user.Id,
-                string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                result.ErrorMessages());
 
             return BadRequest();
         }
@@ -380,7 +381,7 @@ public class AccountController : Controller
             "{Path} Reset password was failed. User(id): {UserId}. {Errors}",
             path,
             userId,
-            string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+            result.ErrorMessages());
 
         return View("Password/ResetPasswordFailed", localizer["Change password failed"]);
     }
@@ -420,7 +421,7 @@ public class AccountController : Controller
             "{Path} Changing password was failed for User(id): {UserId}. {Errors}",
             path,
             userId,
-            string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+            result.ErrorMessages());
 
         ModelState.AddModelError(string.Empty, localizer["Change password failed"]);
         return View("Password/ChangePassword");

--- a/OutOfSchool/OutOfSchool.AuthCommon/Controllers/AreaAdminController.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Controllers/AreaAdminController.cs
@@ -12,7 +12,6 @@ public class AreaAdminController : Controller
     private readonly ILogger<AreaAdminController> logger;
     private readonly ICommonMinistryAdminService<AreaAdminBaseDto> areaAdminService;
 
-    private string path;
     private string currentUserId;
 
     public AreaAdminController(
@@ -26,8 +25,6 @@ public class AreaAdminController : Controller
     public override void OnActionExecuting(ActionExecutingContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-
-        path = $"{context.HttpContext.Request.Path.Value}[{context.HttpContext.Request.Method}]";
         currentUserId = User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub);
     }
 
@@ -36,14 +33,12 @@ public class AreaAdminController : Controller
     public async Task<ResponseDto> Create(AreaAdminBaseDto areaAdminBaseDto)
     {
         logger.LogDebug(
-            "Received request {RequestHeader}. {Path} started. User(id): {UserId}",
-            Request.Headers["X-Request-ID"],
-            path,
+            "Operation initiated by User(id): {UserId}",
             currentUserId);
 
         if (!ModelState.IsValid)
         {
-            logger.LogError($"Input data was not valid for User(id): {currentUserId}");
+            logger.LogError("Input data was not valid for User(id): {CurrentUserId}", currentUserId);
 
             return new ResponseDto()
             {
@@ -53,7 +48,7 @@ public class AreaAdminController : Controller
         }
 
         return await areaAdminService
-            .CreateMinistryAdminAsync(areaAdminBaseDto, Role.AreaAdmin, Url, currentUserId, Request.Headers["X-Request-ID"]);
+            .CreateMinistryAdminAsync(areaAdminBaseDto, Role.AreaAdmin, Url, currentUserId);
     }
 
     [HttpPut("{areaAdminId}")]
@@ -61,13 +56,11 @@ public class AreaAdminController : Controller
     public async Task<ResponseDto> Update(string areaAdminId, AreaAdminBaseDto updateAreaAdminDto)
     {
         logger.LogDebug(
-            "Received request {Headers}. {path} started. User(id): {userId}",
-            Request.Headers["X-Request-ID"],
-            path,
+            "Operation initiated by User(id): {UserId}",
             currentUserId);
 
         return await areaAdminService
-            .UpdateMinistryAdminAsync(updateAreaAdminDto, currentUserId, Request.Headers["X-Request-ID"]);
+            .UpdateMinistryAdminAsync(updateAreaAdminDto, currentUserId);
     }
 
     [HttpDelete("{areaAdminId}")]
@@ -77,13 +70,11 @@ public class AreaAdminController : Controller
         _ = areaAdminId ?? throw new ArgumentNullException(nameof(areaAdminId));
 
         logger.LogDebug(
-            "Received request {RequestHeader}. {Path} started. User(id): {UserId}",
-            Request.Headers["X-Request-ID"],
-            path,
+            "Operation initiated by User(id): {UserId}",
             currentUserId);
 
         return await areaAdminService
-            .DeleteMinistryAdminAsync(areaAdminId, currentUserId, Request.Headers["X-Request-ID"]);
+            .DeleteMinistryAdminAsync(areaAdminId, currentUserId);
     }
 
     [HttpPut("{areaAdminId}/{isBlocked}")]
@@ -91,22 +82,19 @@ public class AreaAdminController : Controller
     public async Task<ResponseDto> Block(string areaAdminId, bool isBlocked)
     {
         logger.LogDebug(
-            "Received request {RequestHeader}. {Path} started. User(id): {UserId}",
-            Request.Headers["X-Request-ID"],
-            path,
+            "Operation initiated by User(id): {UserId}",
             currentUserId);
 
         return await areaAdminService
-            .BlockMinistryAdminAsync(areaAdminId, currentUserId, Request.Headers["X-Request-ID"], isBlocked);
+            .BlockMinistryAdminAsync(areaAdminId, currentUserId, isBlocked);
     }
 
     [HttpPut("{areaAdminId}")]
     [HasPermission(Permissions.AreaAdminEdit)]
     public async Task<ResponseDto> Reinvite(string areaAdminId)
     {
-        logger.LogDebug($"Received request " +
-                        $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {currentUserId}");
+        logger.LogDebug("Operation initiated by User(id): {CurrentUserId}",  currentUserId);
         return await areaAdminService
-            .ReinviteMinistryAdminAsync(areaAdminId, currentUserId, Url, Request.Headers["X-Request-ID"]);
+            .ReinviteMinistryAdminAsync(areaAdminId, currentUserId, Url);
     }
 }

--- a/OutOfSchool/OutOfSchool.AuthCommon/Controllers/MinistryAdminController.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Controllers/MinistryAdminController.cs
@@ -13,7 +13,6 @@ public class MinistryAdminController : Controller
     private readonly ILogger<MinistryAdminController> logger;
     private readonly ICommonMinistryAdminService<MinistryAdminBaseDto> ministryAdminService;
 
-    private string path;
     private string userId;
 
     public MinistryAdminController(
@@ -28,7 +27,6 @@ public class MinistryAdminController : Controller
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        path = $"{context.HttpContext.Request.Path.Value}[{context.HttpContext.Request.Method}]";
         userId = User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub);
     }
 
@@ -37,8 +35,7 @@ public class MinistryAdminController : Controller
     public async Task<ResponseDto> Create(MinistryAdminBaseDto ministryAdminBaseDto)
     {
         logger.LogDebug(
-            "Received request {RequestHeader}. {Path} started. User(id): {UserId}",
-            Request.Headers["X-Request-ID"], path, userId);
+            "Operation initiated by User(id): {UserId}", userId);
 
         if (!ModelState.IsValid)
         {
@@ -52,22 +49,17 @@ public class MinistryAdminController : Controller
         }
 
         return await ministryAdminService
-            .CreateMinistryAdminAsync(ministryAdminBaseDto, Role.MinistryAdmin, Url, userId, Request.Headers["X-Request-ID"]);
+            .CreateMinistryAdminAsync(ministryAdminBaseDto, Role.MinistryAdmin, Url, userId);
     }
 
     [HttpPut("{ministryAdminId}")]
     [HasPermission(Permissions.MinistryAdminEdit)]
     public async Task<ResponseDto> Update(string ministryAdminId, MinistryAdminBaseDto updateMinistryAdminDto)
     {
-        logger.LogDebug(
-            "Received request " +
-            "{Headers}. {path} started. User(id): {userId}",
-            Request.Headers["X-Request-ID"],
-            path,
-            userId);
+        logger.LogDebug("Operation initiated by User(id): {UserId}", userId);
 
         return await ministryAdminService
-            .UpdateMinistryAdminAsync(updateMinistryAdminDto, userId, Request.Headers["X-Request-ID"]);
+            .UpdateMinistryAdminAsync(updateMinistryAdminDto, userId);
     }
 
     [HttpDelete("{ministryAdminId}")]
@@ -76,34 +68,29 @@ public class MinistryAdminController : Controller
     {
         ArgumentNullException.ThrowIfNull(ministryAdminId);
 
-        logger.LogDebug(
-            "Received request {RequestHeader}. {Path} started. User(id): {UserId}",
-            Request.Headers["X-Request-ID"], path, userId);
+        logger.LogDebug("Operation initiated by User(id): {UserId}", userId);
 
         return await ministryAdminService
-            .DeleteMinistryAdminAsync(ministryAdminId, userId, Request.Headers["X-Request-ID"]);
+            .DeleteMinistryAdminAsync(ministryAdminId, userId);
     }
 
     [HttpPut("{ministryAdminId}/{isBlocked}")]
     [HasPermission(Permissions.MinistryAdminEdit)]
     public async Task<ResponseDto> Block(string ministryAdminId, bool isBlocked)
     {
-        logger.LogDebug(
-            "Received request {RequestHeader}. {Path} started. User(id): {UserId}",
-            Request.Headers["X-Request-ID"], path, userId);
+        logger.LogDebug("Operation initiated by User(id): {UserId}", userId);
 
         return await ministryAdminService
-            .BlockMinistryAdminAsync(ministryAdminId, userId, Request.Headers["X-Request-ID"], isBlocked);
+            .BlockMinistryAdminAsync(ministryAdminId, userId, isBlocked);
     }
 
     [HttpPut("{ministryAdminId}")]
     [HasPermission(Permissions.MinistryAdminEdit)]
     public async Task<ResponseDto> Reinvite(string ministryAdminId)
     {
-        logger.LogDebug($"Received request " +
-                        $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {userId}");
+        logger.LogDebug("Operation initiated by User(id): {UserId}", userId);
 
         return await ministryAdminService
-            .ReinviteMinistryAdminAsync(ministryAdminId, userId, Url, Request.Headers["X-Request-ID"]);
+            .ReinviteMinistryAdminAsync(ministryAdminId, userId, Url);
     }
 }

--- a/OutOfSchool/OutOfSchool.AuthCommon/Controllers/ProviderAdminController.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Controllers/ProviderAdminController.cs
@@ -12,7 +12,6 @@ public class ProviderAdminController : Controller
     private readonly ILogger<ProviderAdminController> logger;
     private readonly IProviderAdminService providerAdminService;
 
-    private string path;
     private string userId;
 
     public ProviderAdminController(
@@ -25,7 +24,6 @@ public class ProviderAdminController : Controller
 
     public override void OnActionExecuting(ActionExecutingContext context)
     {
-        path = $"{context.HttpContext.Request.Path.Value}[{context.HttpContext.Request.Method}]";
         userId = User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub);
     }
 
@@ -33,11 +31,10 @@ public class ProviderAdminController : Controller
     [HasPermission(Permissions.ProviderAdmins)]
     public async Task<ResponseDto> Create(CreateProviderAdminDto providerAdminDto)
     {
-        logger.LogDebug($"Received request " +
-                        $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {userId}");
+        logger.LogDebug("Operation initiated by User(id): {UserId}", userId);
 
         return await providerAdminService
-            .CreateProviderAdminAsync(providerAdminDto, Url, userId, Request.Headers["X-Request-ID"]);
+            .CreateProviderAdminAsync(providerAdminDto, Url, userId);
     }
 
     [HttpPut("{providerAdminId}")]
@@ -45,14 +42,11 @@ public class ProviderAdminController : Controller
     public async Task<ResponseDto> Update(string providerAdminId, UpdateProviderAdminDto providerAdminUpdateDto)
     {
         logger.LogDebug(
-            "Received request " +
-            "{Headers}. {path} started. User(id): {userId}",
-            Request.Headers["X-Request-ID"],
-            path,
+            "Operation initiated by User(id): {UserId}",
             userId);
 
         return await providerAdminService
-            .UpdateProviderAdminAsync(providerAdminUpdateDto, userId, Request.Headers["X-Request-ID"]);
+            .UpdateProviderAdminAsync(providerAdminUpdateDto, userId);
     }
 
     [HttpDelete("{providerAdminId}")]
@@ -64,43 +58,39 @@ public class ProviderAdminController : Controller
             throw new ArgumentNullException(nameof(providerAdminId));
         }
 
-        logger.LogDebug($"Received request " +
-                        $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {userId}");
+        logger.LogDebug("Operation initiated by User(id): {UserId}", userId);
 
         return await providerAdminService
-            .DeleteProviderAdminAsync(providerAdminId, userId, Request.Headers["X-Request-ID"]);
+            .DeleteProviderAdminAsync(providerAdminId, userId);
     }
 
     [HttpPut("{providerAdminId}/{isBlocked}")]
     [HasPermission(Permissions.ProviderRemove)]
     public async Task<ResponseDto> Block(string providerAdminId, bool isBlocked)
     {
-        logger.LogDebug($"Received request " +
-                        $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {userId}");
+        logger.LogDebug("Operation initiated by User(id): {UserId}", userId);
 
         return await providerAdminService
-            .BlockProviderAdminAsync(providerAdminId, userId, Request.Headers["X-Request-ID"], isBlocked);
+            .BlockProviderAdminAsync(providerAdminId, userId, isBlocked);
     }
 
     [HttpPut("{providerId}/{isBlocked}")]
     [HasPermission(Permissions.ProviderBlock)]
     public async Task<ResponseDto> BlockByProvider(Guid providerId, bool isBlocked)
     {
-        logger.LogDebug($"Received request " +
-                        $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {userId}");
+        logger.LogDebug("Operation initiated by User(id): {UserId}", userId);
 
         return await providerAdminService
-            .BlockProviderAdminsAndDeputiesByProviderAsync(providerId, userId, Request.Headers["X-Request-ID"], isBlocked);
+            .BlockProviderAdminsAndDeputiesByProviderAsync(providerId, userId, isBlocked);
     }
 
     [HttpPut("{providerAdminId}")]
     [HasPermission(Permissions.ProviderRemove)]
     public async Task<ResponseDto> Reinvite(string providerAdminId)
     {
-        logger.LogDebug($"Received request " +
-                        $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {userId}");
+        logger.LogDebug("Operation initiated by User(id): {UserId}", userId);
 
         return await providerAdminService
-            .ReinviteProviderAdminAsync(providerAdminId, userId, Url, Request.Headers["X-Request-ID"]);
+            .ReinviteProviderAdminAsync(providerAdminId, userId, Url);
     }
 }

--- a/OutOfSchool/OutOfSchool.AuthCommon/Controllers/RegionAdminController.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Controllers/RegionAdminController.cs
@@ -13,7 +13,6 @@ public class RegionAdminController : Controller
     private readonly ILogger<RegionAdminController> logger;
     private readonly ICommonMinistryAdminService<RegionAdminBaseDto> regionAdminService;
 
-    private string path;
     private string currentUserId;
 
     public RegionAdminController(
@@ -28,7 +27,6 @@ public class RegionAdminController : Controller
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        path = $"{context.HttpContext.Request.Path.Value}[{context.HttpContext.Request.Method}]";
         currentUserId = User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub);
     }
 
@@ -36,15 +34,11 @@ public class RegionAdminController : Controller
     [HttpPost]
     public async Task<ResponseDto> Create(RegionAdminBaseDto regionAdminBaseDto)
     {
-        logger.LogDebug(
-            "Received request {RequestHeader}. {Path} started. User(id): {UserId}",
-            Request.Headers["X-Request-ID"],
-            path,
-            currentUserId);
+        logger.LogDebug("Operation initiated by User(id): {UserId}", currentUserId);
 
         if (!ModelState.IsValid)
         {
-            logger.LogError($"Input data was not valid for User(id): {currentUserId}");
+            logger.LogError("Input data was not valid for User(id): {UserId}", currentUserId);
 
             return new ResponseDto()
             {
@@ -54,7 +48,7 @@ public class RegionAdminController : Controller
         }
 
         return await regionAdminService
-            .CreateMinistryAdminAsync(regionAdminBaseDto, Role.RegionAdmin, Url, currentUserId, Request.Headers["X-Request-ID"]);
+            .CreateMinistryAdminAsync(regionAdminBaseDto, Role.RegionAdmin, Url, currentUserId);
     }
 
     [HttpPut("{regionAdminId}")]
@@ -62,13 +56,11 @@ public class RegionAdminController : Controller
     public async Task<ResponseDto> Update(string regionAdminId, RegionAdminBaseDto updateRegionAdminDto)
     {
         logger.LogDebug(
-            "Received request {Headers}. {path} started. User(id): {userId}",
-            Request.Headers["X-Request-ID"],
-            path,
+            "Operation initiated by User(id): {UserId}",
             currentUserId);
 
         return await regionAdminService
-            .UpdateMinistryAdminAsync(updateRegionAdminDto, currentUserId, Request.Headers["X-Request-ID"]);
+            .UpdateMinistryAdminAsync(updateRegionAdminDto, currentUserId);
     }
 
     [HttpDelete("{regionAdminId}")]
@@ -78,13 +70,11 @@ public class RegionAdminController : Controller
         _ = regionAdminId ?? throw new ArgumentNullException(nameof(regionAdminId));
 
         logger.LogDebug(
-            "Received request {RequestHeader}. {Path} started. User(id): {UserId}",
-            Request.Headers["X-Request-ID"],
-            path,
+            "Operation initiated by User(id): {UserId}",
             currentUserId);
 
         return await regionAdminService
-            .DeleteMinistryAdminAsync(regionAdminId, currentUserId, Request.Headers["X-Request-ID"]);
+            .DeleteMinistryAdminAsync(regionAdminId, currentUserId);
     }
 
     [HttpPut("{regionAdminId}/{isBlocked}")]
@@ -92,22 +82,19 @@ public class RegionAdminController : Controller
     public async Task<ResponseDto> Block(string regionAdminId, bool isBlocked)
     {
         logger.LogDebug(
-            "Received request {RequestHeader}. {Path} started. User(id): {UserId}",
-            Request.Headers["X-Request-ID"],
-            path,
+            "Operation initiated by User(id): {UserId}",
             currentUserId);
 
         return await regionAdminService
-            .BlockMinistryAdminAsync(regionAdminId, currentUserId, Request.Headers["X-Request-ID"], isBlocked);
+            .BlockMinistryAdminAsync(regionAdminId, currentUserId, isBlocked);
     }
 
     [HttpPut("{regionAdminId}")]
     [HasPermission(Permissions.RegionAdminEdit)]
     public async Task<ResponseDto> Reinvite(string regionAdminId)
     {
-        logger.LogDebug($"Received request " +
-                        $"{Request.Headers["X-Request-ID"]}. {path} started. User(id): {currentUserId}");
+        logger.LogDebug("Operation initiated by User(id): {UserId}", currentUserId);
         return await regionAdminService
-            .ReinviteMinistryAdminAsync(regionAdminId, currentUserId, Url, Request.Headers["X-Request-ID"]);
+            .ReinviteMinistryAdminAsync(regionAdminId, currentUserId, Url);
     }
 }

--- a/OutOfSchool/OutOfSchool.AuthCommon/Extensions/IdentityResultErrorExtensions.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Extensions/IdentityResultErrorExtensions.cs
@@ -1,0 +1,7 @@
+namespace OutOfSchool.AuthCommon.Extensions;
+
+public static class IdentityResultErrorExtensions
+{
+    public static string ErrorMessages(this IdentityResult result) =>
+        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description));
+}

--- a/OutOfSchool/OutOfSchool.AuthCommon/Services/CommonMinistryAdminService.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Services/CommonMinistryAdminService.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
+using OutOfSchool.AuthCommon.Extensions;
 using OutOfSchool.AuthCommon.Services.Password;
 using OutOfSchool.Common.Models;
 using OutOfSchool.RazorTemplatesData.Models.Emails;
@@ -90,7 +91,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     logger.LogError(
                         "Error happened while creation MinistryAdmin. User(id): {UserId}. {Error}",
                         userId,
-                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                        result.ErrorMessages());
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.BadRequest;
@@ -112,7 +113,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     logger.LogError(
                         "Error happened while adding role to user. User(id): {UserId}. {Error}",
                         userId,
-                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                        result.ErrorMessages());
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -199,7 +200,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     logger.LogError(
                         "Error happened while deleting MinistryAdmin. User(id): {UserId}. {Error}",
                         userId,
-                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                        result.ErrorMessages());
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -489,7 +490,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     logger.LogError(
                         "Error happened while reinviting MinistryAdmin. User(id): {UserId}. {Errors}",
                         userId,
-                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                        result.ErrorMessages());
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;

--- a/OutOfSchool/OutOfSchool.AuthCommon/Services/CommonMinistryAdminService.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Services/CommonMinistryAdminService.cs
@@ -55,13 +55,11 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
         TDto ministryAdminBaseDto,
         Role role,
         IUrlHelper url,
-        string userId,
-        string requestId)
+        string userId)
     {
         ArgumentNullException.ThrowIfNull(ministryAdminBaseDto);
         ArgumentNullException.ThrowIfNull(url);
         ArgumentNullException.ThrowIfNull(userId);
-        ArgumentNullException.ThrowIfNull(requestId);
 
         var user = mapper.Map<User>(ministryAdminBaseDto);
 
@@ -90,9 +88,9 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     await transaction.RollbackAsync();
 
                     logger.LogError(
-                        $"Error happened while creation MinistryAdmin. Request(id): {requestId}" +
-                        $"User(id): {userId}" +
-                        $"{string.Join(Environment.NewLine, result.Errors.Select(e => e.Description))}");
+                        "Error happened while creation MinistryAdmin. User(id): {UserId}. {Error}",
+                        userId,
+                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.BadRequest;
@@ -112,9 +110,9 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     await transaction.RollbackAsync();
 
                     logger.LogError(
-                        $"Error happened while adding role to user. Request(id): {requestId}" +
-                        $"User(id): {userId}" +
-                        $"{string.Join(Environment.NewLine, result.Errors.Select(e => e.Description))}");
+                        "Error happened while adding role to user. User(id): {UserId}. {Error}",
+                        userId,
+                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -129,8 +127,9 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     .ConfigureAwait(false);
 
                 logger.LogInformation(
-                    $"MinistryAdmin(id):{ministryAdminBaseDto.UserId} was successfully created by " +
-                    $"User(id): {userId}. Request(id): {requestId}");
+                    "MinistryAdmin(id):{Id} was successfully created by User(id): {UserId}",
+                    ministryAdminBaseDto.UserId,
+                    userId);
 
                 await this.SendInvitationEmail(user, url, password);
 
@@ -147,7 +146,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
             {
                 await transaction.RollbackAsync();
 
-                logger.LogError($"{ex.Message} User(id): {userId}.");
+                logger.LogError(ex, "Error occured for User(id): {UserId}", userId);
 
                 response.IsSuccess = false;
                 response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -159,12 +158,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
 
     public async Task<ResponseDto> DeleteMinistryAdminAsync(
         string ministryAdminId,
-        string userId,
-        string requestId)
+        string userId)
     {
         ArgumentNullException.ThrowIfNull(ministryAdminId);
         ArgumentNullException.ThrowIfNull(userId);
-        ArgumentNullException.ThrowIfNull(requestId);
 
         var executionStrategy = context.Database.CreateExecutionStrategy();
         return await executionStrategy.Execute(DeleteMinistryAdminOperation).ConfigureAwait(false);
@@ -182,9 +179,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.NotFound;
 
-                    logger.LogError($"MinistryAdmin(id) {ministryAdminId} not found. " +
-                                    $"Request(id): {requestId}" +
-                                    $"User(id): {userId}");
+                    logger.LogError(
+                        "MinistryAdmin(id) {MinistryAdminId} not found. User(id): {UserId}",
+                        ministryAdminId,
+                        userId);
 
                     return response;
                 }
@@ -198,9 +196,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                 {
                     await transaction.RollbackAsync();
 
-                    logger.LogError($"Error happened while deleting MinistryAdmin. Request(id): {requestId}" +
-                                    $"User(id): {userId}" +
-                                    $"{string.Join(Environment.NewLine, result.Errors.Select(e => e.Description))}");
+                    logger.LogError(
+                        "Error happened while deleting MinistryAdmin. User(id): {UserId}. {Error}",
+                        userId,
+                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -212,8 +211,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                 response.IsSuccess = true;
                 response.HttpStatusCode = HttpStatusCode.OK;
 
-                logger.LogInformation($"MinistryAdmin(id):{ministryAdminId} was successfully deleted by " +
-                                      $"User(id): {userId}. Request(id): {requestId}");
+                logger.LogInformation(
+                    "MinistryAdmin(id):{MinistryAdminId} was successfully deleted by User(id): {UserId}",
+                    ministryAdminId,
+                    userId);
 
                 return response;
             }
@@ -221,8 +222,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
             {
                 await transaction.RollbackAsync();
 
-                logger.LogError($"Error happened while deleting MinistryAdmin. Request(id): {requestId}" +
-                                $"User(id): {userId} {ex.Message}");
+                logger.LogError(ex, "Error happened while deleting MinistryAdmin. User(id): {UserId}", userId);
 
                 response.IsSuccess = false;
                 response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -235,12 +235,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
     public async Task<ResponseDto> BlockMinistryAdminAsync(
         string ministryAdminId,
         string userId,
-        string requestId,
         bool isBlocked)
     {
         ArgumentNullException.ThrowIfNull(ministryAdminId);
         ArgumentNullException.ThrowIfNull(userId);
-        ArgumentNullException.ThrowIfNull(requestId);
 
         var response = new ResponseDto();
 
@@ -251,9 +249,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
             response.IsSuccess = false;
             response.HttpStatusCode = HttpStatusCode.NotFound;
 
-            logger.LogError($"ProviderAdmin(id) {ministryAdminId} not found. " +
-                            $"Request(id): {requestId}" +
-                            $"User(id): {userId}");
+            logger.LogError(
+                "MinistryAdmin(id) {MinistryAdminId} not found. User(id): {UserId}",
+                ministryAdminId,
+                userId);
 
             return response;
         }
@@ -275,9 +274,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                 {
                     await transaction.RollbackAsync().ConfigureAwait(false);
 
-                    logger.LogError($"Error happened while blocking ProviderAdmin. Request(id): {requestId}" +
-                                    $"User(id): {userId}" +
-                                    $"{string.Join(Environment.NewLine, updateResult.Errors.Select(e => e.Description))}");
+                    logger.LogError(
+                        "Error happened while blocking ProviderAdmin. User(id): {UserId}. {Error}",
+                        userId,
+                        string.Join(Environment.NewLine, updateResult.Errors.Select(e => e.Description)));
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -291,9 +291,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                 {
                     await transaction.RollbackAsync().ConfigureAwait(false);
 
-                    logger.LogError($"Error happened while updating security stamp. ProviderAdmin. Request(id): {requestId}" +
-                                    $"User(id): {userId}" +
-                                    $"{string.Join(Environment.NewLine, updateSecurityStamp.Errors.Select(e => e.Description))}");
+                    logger.LogError(
+                        "Error happened while updating security stamp. ProviderAdmin. User(id): {UserId}. {Error}",
+                        userId,
+                        string.Join(Environment.NewLine, updateSecurityStamp.Errors.Select(e => e.Description)));
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -303,8 +304,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
 
                 await transaction.CommitAsync().ConfigureAwait(false);
 
-                logger.LogInformation($"ProviderAdmin(id):{ministryAdminId} was successfully blocked by " +
-                                      $"User(id): {userId}. Request(id): {requestId}");
+                logger.LogInformation(
+                    "MinistryAdmin(id):{MinistryAdminId} was successfully blocked by User(id): {UserId}",
+                    ministryAdminId,
+                    userId);
 
                 response.IsSuccess = true;
                 response.HttpStatusCode = HttpStatusCode.OK;
@@ -315,8 +318,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
             {
                 await transaction.RollbackAsync().ConfigureAwait(false);
 
-                logger.LogError($"Error happened while blocking ProviderAdmin. Request(id): {requestId}" +
-                                $"User(id): {userId} {ex.Message}");
+                logger.LogError(ex, "Error happened while blocking ministryAdmin. User(id): {UserId}", userId);
 
                 response.IsSuccess = false;
                 response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -328,17 +330,16 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
 
     public async Task<ResponseDto> UpdateMinistryAdminAsync(
         TDto updateMinistryAdminDto,
-        string userId,
-        string requestId)
+        string userId)
     {
         _ = updateMinistryAdminDto ?? throw new ArgumentNullException(nameof(updateMinistryAdminDto));
 
         var response = new ResponseDto();
 
         if (await context.Users.AnyAsync(x => x.Email == updateMinistryAdminDto.Email
-            && x.Id != updateMinistryAdminDto.UserId).ConfigureAwait(false))
+                                              && x.Id != updateMinistryAdminDto.UserId).ConfigureAwait(false))
         {
-            logger.LogError("Cant update ministry admin with duplicate email: {email}", updateMinistryAdminDto.Email);
+            logger.LogError("Cant update ministry admin with duplicate email: {Email}", updateMinistryAdminDto.Email);
             response.IsSuccess = false;
             response.HttpStatusCode = HttpStatusCode.BadRequest;
             response.Message = $"Cant update provider admin with duplicate email: {updateMinistryAdminDto.Email}";
@@ -354,11 +355,8 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
             response.HttpStatusCode = HttpStatusCode.NotFound;
 
             logger.LogError(
-                "MinistryAdmin(id) {ministryAdminUpdateDto.Id} not found. " +
-                "Request(id): {requestId}" +
-                "User(id): {userId}",
+                "MinistryAdmin(id) {Id} not found. User(id): {UserId}",
                 updateMinistryAdminDto.UserId,
-                requestId,
                 userId);
 
             return response;
@@ -367,7 +365,8 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
         var user = await userManager.FindByIdAsync(updateMinistryAdminDto.UserId);
 
         var executionStrategy = context.Database.CreateExecutionStrategy();
-        return await executionStrategy.Execute(updateMinistryAdminDto, UpdateMinistryAdminOperation).ConfigureAwait(false);
+        return await executionStrategy.Execute(updateMinistryAdminDto, UpdateMinistryAdminOperation)
+            .ConfigureAwait(false);
 
         async Task<ResponseDto> UpdateMinistryAdminOperation(MinistryAdminBaseDto ministryAdminUpdateDto)
         {
@@ -388,10 +387,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     await transaction.RollbackAsync().ConfigureAwait(false);
 
                     logger.LogError(
-                        "Error happened while updating MinistryAdmin. Request(id): {requestId}" +
-                        "User(id): {userId}" +
-                        "{Errors}",
-                        requestId,
+                        "Error happened while updating MinistryAdmin. User(id): {UserId}. {Errors}",
                         userId,
                         string.Join(Environment.NewLine, updateResult.Errors.Select(e => e.Description)));
 
@@ -408,10 +404,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     await transaction.RollbackAsync().ConfigureAwait(false);
 
                     logger.LogError(
-                        "Error happened while updating security stamp. MinistryAdmin. Request(id): {requestId}" +
-                        "User(id): {userId}" +
-                        "{Errors}",
-                        requestId,
+                        "Error happened while updating security stamp. MinistryAdmin. User(id): {UserId}. {Errors}",
                         userId,
                         string.Join(Environment.NewLine, updateSecurityStamp.Errors.Select(e => e.Description)));
 
@@ -430,11 +423,9 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                 await transaction.CommitAsync().ConfigureAwait(false);
 
                 logger.LogInformation(
-                    "MinistryAdmin(id):{ministryAdminUpdateDto.UserId} was successfully updated by " +
-                    "User(id): {userId}. Request(id): {requestId}",
+                    "MinistryAdmin(id):{Id} was successfully updated by User(id): {UserId}",
                     ministryAdminUpdateDto.UserId,
-                    userId,
-                    requestId);
+                    userId);
 
                 response.IsSuccess = true;
                 response.HttpStatusCode = HttpStatusCode.OK;
@@ -447,11 +438,9 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                 await transaction.RollbackAsync().ConfigureAwait(false);
 
                 logger.LogError(
-                    "Error happened while updating MinistryAdmin. Request(id): {requestId}" +
-                    "User(id): {userId} {ex.Message}",
-                    requestId,
-                    userId,
-                    ex.Message);
+                    ex,
+                    "Error happened while updating MinistryAdmin. User(id): {UserId}",
+                    userId);
 
                 response.IsSuccess = false;
                 response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -464,8 +453,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
     public async Task<ResponseDto> ReinviteMinistryAdminAsync(
         string ministryAdminId,
         string userId,
-        IUrlHelper url,
-        string requestId)
+        IUrlHelper url)
     {
         var executionStrategy = context.Database.CreateExecutionStrategy();
         var result = await executionStrategy.Execute(async () =>
@@ -481,9 +469,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.NotFound;
 
-                    logger.LogError($"MinistryAdmin(id) {ministryAdminId} not found. " +
-                                    $"Request(id): {requestId}" +
-                                    $"User(id): {userId}");
+                    logger.LogError(
+                        "MinistryAdmin(id) {MinistryAdminId} not found. User(id): {UserId}",
+                        ministryAdminId,
+                        userId);
 
                     return response;
                 }
@@ -497,9 +486,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                 {
                     await transaction.RollbackAsync();
 
-                    logger.LogError($"Error happened while reinviting MinistryAdmin. Request(id): {requestId}" +
-                                    $"User(id): {userId}" +
-                                    $"{string.Join(Environment.NewLine, result.Errors.Select(e => e.Description))}");
+                    logger.LogError(
+                        "Error happened while reinviting MinistryAdmin. User(id): {UserId}. {Errors}",
+                        userId,
+                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -513,8 +503,10 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                 response.IsSuccess = true;
                 response.HttpStatusCode = HttpStatusCode.OK;
 
-                logger.LogInformation($"MinistryAdmin(id):{ministryAdminId} was successfully reinvited by " +
-                                      $"User(id): {userId}. Request(id): {requestId}");
+                logger.LogInformation(
+                    "MinistryAdmin(id):{MinistryAdminId} was successfully reinvited by User(id): {UserId}",
+                    ministryAdminId,
+                    userId);
 
                 return response;
             }
@@ -522,8 +514,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
             {
                 await transaction.RollbackAsync();
 
-                logger.LogError($"Error happened while reinviting MinistryAdmin. Request(id): {requestId}" +
-                                $"User(id): {userId} {ex.Message}");
+                logger.LogError(ex, "Error happened while reinviting MinistryAdmin. User(id): {UserId}", userId);
 
                 response.IsSuccess = false;
                 response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -540,7 +531,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
         var confirmationLink = url.Action(
             "EmailConfirmation",
             "Account",
-            new { email = user.Email, token },
+            new {email = user.Email, token},
             "https");
         var subject = localizer["Confirm email"];
         var adminInvitationViewModel = new AdminInvitationViewModel
@@ -549,7 +540,8 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
             Email = user.Email,
             Password = password,
         };
-        var content = await renderer.GetHtmlPlainStringAsync(RazorTemplates.NewAdminInvitation, adminInvitationViewModel);
+        var content =
+            await renderer.GetHtmlPlainStringAsync(RazorTemplates.NewAdminInvitation, adminInvitationViewModel);
 
         await emailSender.SendAsync(user.Email, subject, content);
     }

--- a/OutOfSchool/OutOfSchool.AuthCommon/Services/Interfaces/ICommonMinistryAdminService.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Services/Interfaces/ICommonMinistryAdminService.cs
@@ -11,28 +11,23 @@ public interface ICommonMinistryAdminService<TDto>
         TDto ministryAdminBaseDto,
         Role role,
         IUrlHelper url,
-        string userId,
-        string requestId);
+        string userId);
 
     Task<ResponseDto> UpdateMinistryAdminAsync(
         TDto updateMinistryAdminDto,
-        string userId,
-        string requestId);
+        string userId);
 
     Task<ResponseDto> DeleteMinistryAdminAsync(
         string ministryAdminId,
-        string userId,
-        string requestId);
+        string userId);
 
     Task<ResponseDto> BlockMinistryAdminAsync(
         string ministryAdminId,
         string userId,
-        string requestId,
         bool isBlocked);
 
     Task<ResponseDto> ReinviteMinistryAdminAsync(
         string ministryAdminId,
         string userId,
-        IUrlHelper url,
-        string requestId);
+        IUrlHelper url);
 }

--- a/OutOfSchool/OutOfSchool.AuthCommon/Services/Interfaces/IProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Services/Interfaces/IProviderAdminService.cs
@@ -8,34 +8,28 @@ public interface IProviderAdminService
     Task<ResponseDto> CreateProviderAdminAsync(
         CreateProviderAdminDto providerAdminDto,
         IUrlHelper url,
-        string userId,
-        string requestId);
+        string userId);
 
     Task<ResponseDto> UpdateProviderAdminAsync(
         UpdateProviderAdminDto providerAdminUpdateDto,
-        string userId,
-        string requestId);
+        string userId);
 
     Task<ResponseDto> DeleteProviderAdminAsync(
         string providerAdminId,
-        string userId,
-        string requestId);
+        string userId);
 
     Task<ResponseDto> BlockProviderAdminAsync(
         string providerAdminId,
         string userId,
-        string requestId,
         bool isBlocked);
 
     Task<ResponseDto> BlockProviderAdminsAndDeputiesByProviderAsync(
         Guid providerId,
         string userId,
-        string requestId,
         bool isBlocked);
 
     Task<ResponseDto> ReinviteProviderAdminAsync(
         string providerAdminId,
         string userId,
-        IUrlHelper url,
-        string requestId);
+        IUrlHelper url);
 }

--- a/OutOfSchool/OutOfSchool.AuthCommon/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Services/ProviderAdminService.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using OutOfSchool.AuthCommon.Config;
 using OutOfSchool.AuthCommon.Config.ExternalUriModels;
+using OutOfSchool.AuthCommon.Extensions;
 using OutOfSchool.AuthCommon.Services.Password;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Models;
@@ -93,7 +94,7 @@ public class ProviderAdminService : IProviderAdminService
                     logger.LogError(
                         "Error happened while creation ProviderAdmin. User(id): {UserId}. {Errors}",
                         userId,
-                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                        result.ErrorMessages());
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.BadRequest;
@@ -115,7 +116,7 @@ public class ProviderAdminService : IProviderAdminService
                     logger.LogError(
                         "Error happened while adding role to user. User(id): {UserId}. {Errors}",
                         userId,
-                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                        result.ErrorMessages());
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -353,7 +354,7 @@ public class ProviderAdminService : IProviderAdminService
                     logger.LogError(
                         "Error happened while deleting ProviderAdmin. User(id): {UserId}. {Errors}",
                         userId,
-                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                        result.ErrorMessages());
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;
@@ -569,7 +570,7 @@ public class ProviderAdminService : IProviderAdminService
                     logger.LogError(
                         "Error happened while updating ProviderAdmin. User(id): {UserId}. {Errors}",
                         userId,
-                        string.Join(Environment.NewLine, result.Errors.Select(e => e.Description)));
+                        result.ErrorMessages());
 
                     response.IsSuccess = false;
                     response.HttpStatusCode = HttpStatusCode.InternalServerError;

--- a/OutOfSchool/OutOfSchool.AuthCommon/Services/ProviderAdminServiceGRPC.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Services/ProviderAdminServiceGRPC.cs
@@ -24,7 +24,7 @@ public class ProviderAdminServiceGRPC : GRPCProviderAdmin.GRPCProviderAdminBase
         var createProviderAdminDto = mapper.Map<CreateProviderAdminDto>(request);
 
         var userId = context.GetHttpContext().User.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub);
-        var result = await providerAdminService.CreateProviderAdminAsync(createProviderAdminDto, null, userId, request.RequestId);
+        var result = await providerAdminService.CreateProviderAdminAsync(createProviderAdminDto, null, userId);
         CreateProviderAdminReply createProviderAdminReply;
 
         if (result.IsSuccess && result.Result is CreateProviderAdminDto resultCreateProviderAdminDto)

--- a/OutOfSchool/OutOfSchool.AuthServer.Tests/Controllers/MinistryAdminControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.AuthServer.Tests/Controllers/MinistryAdminControllerTests.cs
@@ -52,17 +52,16 @@ public class MinistryAdminControllerTests
         };
 
         fakeMinistryAdminService.Setup(s => s.CreateMinistryAdminAsync(It.IsAny<MinistryAdminBaseDto>(),
-            It.IsAny<Role>(), It.IsAny<IUrlHelper>(), It.IsAny<string>(),
-            It.IsAny<string>())).ReturnsAsync(fakeResponseDto);
+            It.IsAny<Role>(), It.IsAny<IUrlHelper>(), It.IsAny<string>())).ReturnsAsync(fakeResponseDto);
 
         fakeMinistryAdminService.Setup(s => s.DeleteMinistryAdminAsync(It.IsAny<string>(),
-            It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(fakeResponseDto);
+            It.IsAny<string>())).ReturnsAsync(fakeResponseDto);
         
         fakeMinistryAdminService.Setup(s => s.BlockMinistryAdminAsync(It.IsAny<string>(),
-            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(fakeResponseDto);
+            It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(fakeResponseDto);
 
         fakeMinistryAdminService.Setup(s => s.ReinviteMinistryAdminAsync(It.IsAny<string>(),
-            It.IsAny<string>(), It.IsAny<IUrlHelper>(), It.IsAny<string>())).ReturnsAsync(fakeResponseDto);
+            It.IsAny<string>(), It.IsAny<IUrlHelper>())).ReturnsAsync(fakeResponseDto);
 
         var fakeHttpContext = new Mock<HttpContext>();
         fakeHttpContext.Setup(s => s.Request.Headers[It.IsAny<string>()]).Returns("Ok");

--- a/OutOfSchool/OutOfSchool.AuthServer.Tests/Controllers/RegionAdminControllerTests .cs
+++ b/OutOfSchool/OutOfSchool.AuthServer.Tests/Controllers/RegionAdminControllerTests .cs
@@ -56,27 +56,23 @@ public class RegionAdminControllerTests
                 It.IsAny<RegionAdminBaseDto>(),
                 It.IsAny<Role>(),
                 It.IsAny<IUrlHelper>(),
-                It.IsAny<string>(),
                 It.IsAny<string>()))
             .ReturnsAsync(fakeResponseDto);
 
         fakeRegionAdminService.Setup(s => s
             .UpdateMinistryAdminAsync(
                 It.IsAny<RegionAdminBaseDto>(),
-                It.IsAny<string>(),
                 It.IsAny<string>()))
             .ReturnsAsync(fakeResponseDto);
 
         fakeRegionAdminService.Setup(s => s
             .DeleteMinistryAdminAsync(
                 It.IsAny<string>(),
-                It.IsAny<string>(),
                 It.IsAny<string>()))
             .ReturnsAsync(fakeResponseDto);
         
         fakeRegionAdminService.Setup(s => s
             .BlockMinistryAdminAsync(
-                It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<bool>()))
@@ -86,8 +82,7 @@ public class RegionAdminControllerTests
             .ReinviteMinistryAdminAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
-                It.IsAny<IUrlHelper>(),
-                It.IsAny<string>()))
+                It.IsAny<IUrlHelper>()))
             .ReturnsAsync(fakeResponseDto);
 
         var fakeHttpContext = new Mock<HttpContext>();

--- a/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
@@ -75,6 +75,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+        <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\OutOfSchool.Common\OutOfSchool.Common.csproj" />

--- a/OutOfSchool/OutOfSchool.WebApi/Services/AreaAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/AreaAdminService.cs
@@ -20,9 +20,8 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
     private readonly ICurrentUserService currentUserService;
     private readonly IMinistryAdminService ministryAdminService;
     private readonly IRegionAdminService regionAdminService;
-    private IAreaAdminService areaAdminServiceImplementation;
-    private ICodeficatorRepository codeficatorRepository;
     private readonly ICodeficatorService codeficatorService;
+    private ICodeficatorRepository codeficatorRepository;
 
 
     public AreaAdminService(
@@ -91,8 +90,10 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
         return mapper.Map<AreaAdminDto>(areaAdmin);
     }
 
-    public async Task<Either<ErrorResponse, AreaAdminBaseDto>> CreateAreaAdminAsync(string userId,
-        AreaAdminBaseDto areaAdminBaseDto, string token)
+    public async Task<Either<ErrorResponse, AreaAdminBaseDto>> CreateAreaAdminAsync(
+        string userId,
+        AreaAdminBaseDto areaAdminBaseDto,
+        string token)
     {
         Logger.LogDebug("RegionAdmin creating was started. User(id): {UserId}", userId);
 
@@ -100,7 +101,8 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
 
         if (await IsSuchEmailExisted(areaAdminBaseDto.Email))
         {
-            Logger.LogDebug("AreaAdmin creating is not possible. Username {Email} is already taken",
+            Logger.LogDebug(
+                "AreaAdmin creating is not possible. Username {Email} is already taken",
                 areaAdminBaseDto.Email);
             throw new InvalidOperationException($"Username {areaAdminBaseDto.Email} is already taken.");
         }
@@ -108,7 +110,8 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
         bool isValidCatottg = await IsValidCatottg(areaAdminBaseDto.CATOTTGId);
         if (!isValidCatottg)
         {
-            Logger.LogDebug("AreaAdmin creating is not possible. Catottg with Id {CatottgId} does not contain to area",
+            Logger.LogDebug(
+                "AreaAdmin creating is not possible. Catottg with Id {CatottgId} does not contain to area",
                 areaAdminBaseDto.CATOTTGId);
             throw new InvalidOperationException(
                 $"Catottg with Id {areaAdminBaseDto.CATOTTGId} does not contain to area.");
@@ -120,13 +123,11 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.CreateAreaAdmin),
             Token = token,
             Data = areaAdminBaseDto,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -192,11 +193,12 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
         if (otgAdmins.Any())
         {
             Logger.LogInformation(
-                $"All {otgAdmins.Count} records were successfully received from the AreaAdmins table");
+                "All {Count} records were successfully received from the AreaAdmins table",
+                otgAdmins.Count);
         }
         else
         {
-            Logger.LogInformation("AreaAdmins table is empty.");
+            Logger.LogInformation("AreaAdmins table is empty");
         }
 
         var otgAdminsDto = otgAdmins.Select(admin => mapper.Map<AreaAdminDto>(admin)).ToList();
@@ -218,7 +220,9 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
     {
         _ = updateAreaAdminDto ?? throw new ArgumentNullException(nameof(updateAreaAdminDto));
 
-        Logger.LogDebug("AreaAdmin(id): {AreaAdminDto} updating was started. User(id): {UserId}", updateAreaAdminDto.Id,
+        Logger.LogDebug(
+            "AreaAdmin(id): {AreaAdminDto} updating was started. User(id): {UserId}",
+            updateAreaAdminDto.Id,
             userId);
 
         var regionAdmin = await areaAdminRepository.GetByIdAsync(updateAreaAdminDto.Id)
@@ -226,7 +230,9 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
 
         if (regionAdmin is null)
         {
-            Logger.LogError("AreaAdmin(id) {AreaAdminDto} not found. User(id): {UserId}", updateAreaAdminDto.Id,
+            Logger.LogError(
+                "AreaAdmin(id) {AreaAdminDto} not found. User(id): {UserId}",
+                updateAreaAdminDto.Id,
                 userId);
 
             return new ErrorResponse
@@ -238,17 +244,16 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
         var request = new Request()
         {
             HttpMethodType = HttpMethodType.Put,
-            Url = new Uri(authorizationServerConfig.Authority,
+            Url = new Uri(
+                authorizationServerConfig.Authority,
                 CommunicationConstants.UpdateAreaAdmin + updateAreaAdminDto.Id),
             Token = token,
             Data = mapper.Map<AreaAdminBaseDto>(updateAreaAdminDto),
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -268,7 +273,9 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
                 : null);
     }
 
-    public async Task<Either<ErrorResponse, ActionResult>> DeleteAreaAdminAsync(string areaAdminId, string userId,
+    public async Task<Either<ErrorResponse, ActionResult>> DeleteAreaAdminAsync(
+        string areaAdminId,
+        string userId,
         string token)
     {
         Logger.LogDebug("AreaAdmin(id): {AreaAdminId} deleting was started. User(id): {UserId}", areaAdminId, userId);
@@ -291,13 +298,11 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
             HttpMethodType = HttpMethodType.Delete,
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.DeleteAreaAdmin + areaAdminId),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -318,8 +323,11 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
                 : null);
     }
 
-    public async Task<Either<ErrorResponse, ActionResult>> BlockAreaAdminAsync(string areaAdminId, string userId,
-        string token, bool isBlocked)
+    public async Task<Either<ErrorResponse, ActionResult>> BlockAreaAdminAsync(
+        string areaAdminId,
+        string userId,
+        string token,
+        bool isBlocked)
     {
         Logger.LogDebug("AreaAdmin(id): {AreaAdminId} blocking was started. User(id): {UserId}", areaAdminId, userId);
 
@@ -345,13 +353,11 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
                 "/",
                 isBlocked)),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -412,13 +418,11 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
                 areaAdminId,
                 new PathString("/"))),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -465,7 +469,6 @@ public class AreaAdminService : CommunicationService, IAreaAdminService
     {
         _ = ministryAdminUserId ?? throw new ArgumentNullException(nameof(ministryAdminUserId));
         var ministryAdmin = await ministryAdminService.GetByIdAsync(ministryAdminUserId).ConfigureAwait(false);
-
 
         return ministryAdmin.InstitutionId == institutionId;
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Communication/CommunicationService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Communication/CommunicationService.cs
@@ -53,9 +53,6 @@ public class CommunicationService : ICommunicationService
                     = new AuthenticationHeaderValue("Bearer", request.Token);
             }
 
-            httpClient.DefaultRequestHeaders
-                .Add("X-Request-ID", request.RequestId.ToString());
-
             using var requestMessage = new HttpRequestMessage();
 
             requestMessage.Headers

--- a/OutOfSchool/OutOfSchool.WebApi/Services/Communication/Request.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/Communication/Request.cs
@@ -2,8 +2,6 @@
 
 public class Request
 {
-    public Guid RequestId { get; set; }
-
     public object Data { get; set; }
 
     public Uri Url { get; set; }

--- a/OutOfSchool/OutOfSchool.WebApi/Services/MinistryAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/MinistryAdminService.cs
@@ -90,13 +90,11 @@ public class MinistryAdminService : CommunicationService, IMinistryAdminService
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.CreateMinistryAdmin),
             Token = token,
             Data = ministryAdminBaseDto,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -137,7 +135,10 @@ public class MinistryAdminService : CommunicationService, IMinistryAdminService
             }
             else if (ministryAdmin.InstitutionId != filter.InstitutionId)
             {
-                Logger.LogInformation($"Filter institutionId {filter.InstitutionId} is not equals to logined Ministry admin institutionId {ministryAdmin.InstitutionId}");
+                Logger.LogInformation(
+                    "Filter institutionId {FilterInstitutionId} is not equals to logined Ministry admin institutionId {MinistryAdminInstitutionId}",
+                    filter.InstitutionId,
+                    ministryAdmin.InstitutionId);
 
                 return new SearchResult<MinistryAdminDto>()
                 {
@@ -164,9 +165,9 @@ public class MinistryAdminService : CommunicationService, IMinistryAdminService
             .ToListAsync()
             .ConfigureAwait(false);
 
-        Logger.LogInformation(!institutionAdmins.Any()
-            ? "Parents table is empty."
-            : $"All {institutionAdmins.Count} records were successfully received from the Parent table");
+        Logger.LogInformation(
+            "All {Count} records were successfully received from the Parent table",
+            institutionAdmins.Count);
 
         var ministryAdminsDto = institutionAdmins.Select(admin => mapper.Map<MinistryAdminDto>(admin))
                                                  .OrderBy(admin => admin.AccountStatus).ToList();
@@ -210,13 +211,11 @@ public class MinistryAdminService : CommunicationService, IMinistryAdminService
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.UpdateMinistryAdmin + updateMinistryAdminDto.Id),
             Token = token,
             Data = mapper.Map<MinistryAdminBaseDto>(updateMinistryAdminDto),
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -258,13 +257,11 @@ public class MinistryAdminService : CommunicationService, IMinistryAdminService
             HttpMethodType = HttpMethodType.Delete,
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.DeleteMinistryAdmin + ministryAdminId),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -311,13 +308,11 @@ public class MinistryAdminService : CommunicationService, IMinistryAdminService
                 "/",
                 isBlocked)),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -378,13 +373,11 @@ public class MinistryAdminService : CommunicationService, IMinistryAdminService
                 ministryAdminId,
                 new PathString("/"))),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminOperations/ProviderAdminOperationsRESTService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminOperations/ProviderAdminOperationsRESTService.cs
@@ -40,13 +40,11 @@ public class ProviderAdminOperationsRESTService : CommunicationService, IProvide
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.CreateProviderAdmin),
             Token = token,
             Data = providerAdminDto,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
@@ -73,7 +73,10 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
 
         if (numberProviderAdminsLessThanMax >= providerAdminConfig.MaxNumberAdmins)
         {
-            Logger.LogError("Admin was not created by User(id): {UserId}. Limit on the number of admins has been exceeded for the Provider(id): {providerAdminDto.ProviderId}", userId, providerAdminDto.ProviderId);
+            Logger.LogError(
+                "Admin was not created by User(id): {UserId}. Limit on the number of admins has been exceeded for the Provider(id): {ProviderId}",
+                userId,
+                providerAdminDto.ProviderId);
 
             return new ErrorResponse
             {
@@ -128,13 +131,11 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.UpdateProviderAdmin + providerAdminModel.Id),
             Token = token,
             Data = providerAdminModel,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -194,13 +195,11 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
             HttpMethodType = HttpMethodType.Delete,
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.DeleteProviderAdmin + providerAdminId),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -268,13 +267,11 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
                 new PathString("/"),
                 isBlocked)),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -323,7 +320,6 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
                 new PathString("/"),
                 isBlocked)),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         var response = await SendRequest<ResponseDto>(request)
@@ -374,7 +370,7 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
     {
         var providersAdmins = await providerAdminRepository.GetByFilter(p => p.UserId == userId && !p.IsDeputy)
             .ConfigureAwait(false);
-        return providersAdmins.SelectMany(admin => admin.ManagedWorkshops, (admin, workshops) => new { workshops })
+        return providersAdmins.SelectMany(admin => admin.ManagedWorkshops, (_, workshops) => new { workshops })
             .Select(x => x.workshops.Id);
     }
 
@@ -625,13 +621,11 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
                 providerAdminId,
                 new PathString("/"))),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{HttpMethodType} Request was sent. User(id): {UserId}. Url: {Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Services/RegionAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/RegionAdminService.cs
@@ -96,13 +96,11 @@ public class RegionAdminService : CommunicationService, IRegionAdminService
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.CreateRegionAdmin),
             Token = token,
             Data = regionAdminBaseDto,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{request.HttpMethodType} Request was sent. User(id): {UserId}. Url: {request.Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -248,13 +246,11 @@ public class RegionAdminService : CommunicationService, IRegionAdminService
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.UpdateRegionAdmin + updateRegionAdminDto.Id),
             Token = token,
             Data = mapper.Map<RegionAdminBaseDto>(updateRegionAdminDto),
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{request.HttpMethodType} Request was sent. User(id): {UserId}. Url: {request.Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -296,13 +292,11 @@ public class RegionAdminService : CommunicationService, IRegionAdminService
             HttpMethodType = HttpMethodType.Delete,
             Url = new Uri(authorizationServerConfig.Authority, CommunicationConstants.DeleteRegionAdmin + regionAdminId),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{request.HttpMethodType} Request was sent. User(id): {UserId}. Url: {request.Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -349,13 +343,11 @@ public class RegionAdminService : CommunicationService, IRegionAdminService
                 "/",
                 isBlocked)),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{request.HttpMethodType} Request was sent. User(id): {UserId}. Url: {request.Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 
@@ -416,13 +408,11 @@ public class RegionAdminService : CommunicationService, IRegionAdminService
                 regionAdminId,
                 new PathString("/"))),
             Token = token,
-            RequestId = Guid.NewGuid(),
         };
 
         Logger.LogDebug(
-            "{request.HttpMethodType} Request(id): {request.RequestId} was sent. User(id): {UserId}. Url: {request.Url}",
+            "{request.HttpMethodType} Request was sent. User(id): {UserId}. Url: {request.Url}",
             request.HttpMethodType,
-            request.RequestId,
             userId,
             request.Url);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -61,6 +61,8 @@ public static class Startup
         app.UseAuthentication();
         app.UseAuthorization();
 
+        app.UseHeaderPropagation();
+
         app.MapHealthChecks("/healthz/ready", new HealthCheckOptions
             {
                 Predicate = healthCheck => healthCheck.Tags.Contains("readiness"),
@@ -124,7 +126,8 @@ public static class Startup
                 new HttpClientHandler()
                 {
                     AutomaticDecompression = DecompressionMethods.GZip,
-                });
+                })
+            .AddHeaderPropagation();
 
         services.AddHttpContextAccessor();
         services.AddScoped<IProviderAdminService, ProviderAdminService>();
@@ -392,5 +395,11 @@ public static class Startup
             .AddDbContextCheck<OutOfSchoolDbContext>(
                 "Database",
                 tags: new[] { "readiness" });
+
+        services.AddHeaderPropagation(options =>
+        {
+            options.Headers.Add("Request-Id");
+            options.Headers.Add("X-Request-Id");
+        });
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -1,7 +1,9 @@
 using System.Text.Json.Serialization;
 using AutoMapper;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HeaderPropagation;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Primitives;
 using OpenIddict.Validation.AspNetCore;
 using OutOfSchool.Services.Repository.Files;
 using OutOfSchool.WebApi.Services.AverageRatings;
@@ -396,10 +398,13 @@ public static class Startup
                 "Database",
                 tags: new[] { "readiness" });
 
+        Func<HeaderPropagationContext, StringValues> defaultHeaderDelegate = context =>
+            StringValues.IsNullOrEmpty(context.HeaderValue) ? Guid.NewGuid().ToString() : context.HeaderValue;
+
         services.AddHeaderPropagation(options =>
         {
-            options.Headers.Add("Request-Id");
-            options.Headers.Add("X-Request-Id");
+            options.Headers.Add("Request-Id", defaultHeaderDelegate);
+            options.Headers.Add("X-Request-Id", defaultHeaderDelegate);
         });
     }
 }


### PR DESCRIPTION
Propagate request tracing from inbound proxy to webapi to authserver.
Current http context enricher extracts `Request-Id` header automatically. Some other implementations use `X-Request-Id` so we propagate both to http client.