### PR TITLE
hot fix of mapping & search

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi/Util/Mapping/CommonWorkshopEsMapping.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/Mapping/CommonWorkshopEsMapping.cs
@@ -1,0 +1,22 @@
+using AutoMapper;
+using OutOfSchool.WebApi.Models.Workshops;
+
+namespace OutOfSchool.WebApi.Util.Mapping;
+
+public static class CommonWorkshopEsMapping
+{
+    public static IMappingExpression<TSource, WorkshopES> CommonFieldsMapping<TSource>(this IMappingExpression<TSource, WorkshopES> mapper)
+        where TSource : WorkshopDto
+    {
+        return mapper
+            .ForMember(dest => dest.InstitutionHierarchy, opt => opt.MapFrom(src => src.InstitutionHierarchyId))
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status))
+            .ForMember(dest => dest.IsBlocked, opt => opt.MapFrom(src => src.IsBlocked))
+            .ForMember(dest => dest.ProviderOwnership, opt => opt.MapFrom(src => src.ProviderOwnership))
+            .ForMember(dest => dest.Rating, opt => opt.MapFrom(src => src.Rating))
+            .ForMember(dest => dest.NumberOfRatings, opt => opt.MapFrom(src => src.NumberOfRatings))
+            .ForMember(dest => dest.ProviderStatus, opt => opt.MapFrom(src => src.ProviderStatus))
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status))
+            .ForMember(dest => dest.TakenSeats, opt => opt.MapFrom(src => src.TakenSeats));
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Util/Mapping/ElasticProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/Mapping/ElasticProfile.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Nest;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Services.Enums;
@@ -38,10 +39,13 @@ public class ElasticProfile : Profile
             .ForMember(dest => dest.TakenSeats, opt => opt.Ignore());
 
         CreateMap<WorkshopDto, WorkshopES>()
-            .IncludeBase<WorkshopBaseDto, WorkshopES>();
+            .IncludeBase<WorkshopBaseDto, WorkshopES>()
+            .CommonFieldsMapping();
 
         CreateMap<WorkshopV2Dto, WorkshopES>()
-        .IncludeBase<WorkshopDto, WorkshopES>();
+            .IncludeBase<WorkshopDto, WorkshopES>()
+            .CommonFieldsMapping()
+            .ForMember(dest => dest.CoverImageId, opt => opt.MapFrom(src => src.CoverImageId));
 
         CreateMap<AddressDto, AddressES>()
             .ForMember(


### PR DESCRIPTION
Fields were ignored due to mapping refactoring 3 months ago 😃 . For now only old workshops were visible in search and we didn't see the issue. Can't re-start test environment without this fix or it will return to "bad" indexing. So i will merge it without reviews.

Bug was due to priority of mappings in derived classes:
* Explicit Mapping (using .MapFrom())
* Inherited Explicit Mapping
* Ignore Property Mapping // <-- this caused the problem because fields were ignored in base class
* Convention Mapping (Properties that are matched via convention)