### PR TITLE
Partly removed duplicates (mapping profiles as example)

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthCommon/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Util/MappingProfile.cs
@@ -10,8 +10,7 @@ public class MappingProfile : Profile
     public MappingProfile()
     {
         CreateMap<CreateProviderAdminDto, User>()
-            .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.Email))
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => Constants.PhonePrefix + src.PhoneNumber.Right(Constants.PhoneShortLength)));
+            .Apply(MapEmailAndPhone);
 
         CreateMap<CreateProviderAdminDto, ProviderAdmin>()
             .ForMember(dest => dest.ManagedWorkshops, opt => opt.Ignore());
@@ -19,49 +18,33 @@ public class MappingProfile : Profile
         CreateMap<CreateProviderAdminDto, CreateProviderAdminReply>()
             .ForMember(c => c.CreatingTime, m => m.MapFrom(c => Timestamp.FromDateTimeOffset(c.CreatingTime)))
             .ForMember(c => c.ProviderId, m => m.MapFrom(c => c.ProviderId.ToString()))
-            .ForMember(c => c.ManagedWorkshopIds, m => m.MapFrom((dto, entity) =>
-            {
-                var managedWorkshopIds = new List<string>();
-
-                foreach (var item in dto.ManagedWorkshopIds)
-                {
-                    managedWorkshopIds.Add(item.ToString());
-                }
-
-                return managedWorkshopIds;
-            }));
+            .ForMember(c => c.ManagedWorkshopIds, m => m.MapFrom(src => src.ManagedWorkshopIds.Select(id => id.ToString()).ToList()));
 
         CreateMap<CreateProviderAdminRequest, CreateProviderAdminDto>()
             .ForMember(c => c.CreatingTime, m => m.MapFrom(c => c.CreatingTime.ToDateTimeOffset()))
             .ForMember(c => c.ProviderId, m => m.MapFrom(c => Guid.Parse(c.ProviderId)))
-            .ForMember(c => c.ManagedWorkshopIds, opt => opt.MapFrom((dto, entity) =>
-            {
-                var managedWorkshopIds = new List<Guid>();
-
-                foreach (var item in dto.ManagedWorkshopIds)
-                {
-                    managedWorkshopIds.Add(Guid.Parse(item));
-                }
-
-                return managedWorkshopIds;
-            }));
+            .ForMember(c => c.ManagedWorkshopIds, opt => opt.MapFrom(src => src.ManagedWorkshopIds.Select(Guid.Parse).ToList()));
 
         CreateMap<MinistryAdminBaseDto, User>()
-            .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.Email))
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => Constants.PhonePrefix + src.PhoneNumber.Right(Constants.PhoneShortLength)));
+            .Apply(MapEmailAndPhone);
 
         CreateMap<MinistryAdminBaseDto, InstitutionAdmin>();
 
         CreateMap<RegionAdminBaseDto, User>()
-            .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.Email))
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => Constants.PhonePrefix + src.PhoneNumber.Right(Constants.PhoneShortLength)));
+            .Apply(MapEmailAndPhone);
 
         CreateMap<RegionAdminBaseDto, RegionAdmin>();
 
         CreateMap<AreaAdminBaseDto, User>()
-            .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.Email))
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => Constants.PhonePrefix + src.PhoneNumber.Right(Constants.PhoneShortLength)));
+            .Apply(MapEmailAndPhone);
 
         CreateMap<AreaAdminBaseDto, AreaAdmin>();
     }
+
+    private IMappingExpression<TSource, User> MapEmailAndPhone<TSource>(IMappingExpression<TSource, User> mappings)
+        where TSource : AdminBaseDto
+        => mappings
+            .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.Email))
+            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => Constants.PhonePrefix + src.PhoneNumber.Right(Constants.PhoneShortLength)))
+        ;
 }

--- a/OutOfSchool/OutOfSchool.Common/Extensions/MappingExtensions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Extensions/MappingExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using AutoMapper;
+
+namespace OutOfSchool.Common.Extensions;
+
+public static class MappingExtensions
+{
+    public static IMappingExpression<TSource, TDestination> Apply<TSource, TDestination>(
+        this IMappingExpression<TSource, TDestination> mappings,
+        Func<IMappingExpression<TSource, TDestination>, IMappingExpression<TSource, TDestination>> addMappings
+    )
+        where TSource : class
+        where TDestination : class
+        => addMappings(mappings);
+
+    public static IMapperConfigurationExpression UseProfile<T>(this IMapperConfigurationExpression cfg)
+        where T : Profile, new()
+    {
+        cfg.AddProfile<T>();
+        return cfg;
+    }
+}

--- a/OutOfSchool/OutOfSchool.Common/Models/IHasRating.cs
+++ b/OutOfSchool/OutOfSchool.Common/Models/IHasRating.cs
@@ -1,0 +1,8 @@
+﻿namespace OutOfSchool.Common.Models;
+
+public interface IHasRating
+{
+    float Rating { get; }
+
+    int NumberOfRatings { get; }
+}

--- a/OutOfSchool/OutOfSchool.Common/OutOfSchool.Common.csproj
+++ b/OutOfSchool/OutOfSchool.Common/OutOfSchool.Common.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ardalis.SmartEnum" />
+    <PackageReference Include="AutoMapper" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/CATOTTGAddressExtensions.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/CATOTTGAddressExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace OutOfSchool.Services.Models;
 
-public static class CATOTTGAddressExtensions
+public static class CatottgAddressExtensions
 {
     public static string GetCityDistrictName(CATOTTG src)
         => src.Category == CodeficatorCategory.CityDistrict.Name ? src.Name : null;

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/CATOTTGAddressExtensions.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/CATOTTGAddressExtensions.cs
@@ -1,0 +1,21 @@
+﻿using OutOfSchool.Common.Enums;
+
+namespace OutOfSchool.Services.Models;
+
+public static class CATOTTGAddressExtensions
+{
+    public static string GetCityDistrictName(CATOTTG src)
+        => src.Category == CodeficatorCategory.CityDistrict.Name ? src.Name : null;
+
+    public static string GetSettlementName(CATOTTG src)
+        => src.Category == CodeficatorCategory.CityDistrict.Name ? src.Parent.Name : src.Name;
+
+    public static string GetTerritorialCommunityName(CATOTTG src)
+        => src.Category == CodeficatorCategory.CityDistrict.Name ? src.Parent.Parent.Name : src.Parent.Name;
+
+    public static string GetDistrictName(CATOTTG src)
+        => src.Category == CodeficatorCategory.CityDistrict.Name ? src.Parent.Parent.Parent.Name : src.Parent.Parent.Name;
+
+    public static string GetRegionName(CATOTTG src)
+        => src.Category == CodeficatorCategory.CityDistrict.Name ? src.Parent.Parent.Parent.Parent.Name : src.Parent.Parent.Parent.Name;
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/IHasUser.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/IHasUser.cs
@@ -1,0 +1,6 @@
+﻿namespace OutOfSchool.Services.Models;
+
+public interface IHasUser
+{
+    User User { get; }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Images/IHasEntityImages.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Images/IHasEntityImages.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace OutOfSchool.Services.Models.Images;
+
+public interface IHasEntityImages<TEntity>
+{
+    List<Image<TEntity>> Images { get; }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/InstitutionAdminBase.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/InstitutionAdminBase.cs
@@ -5,7 +5,7 @@ using OutOfSchool.Services.Models.SubordinationStructure;
 
 namespace OutOfSchool.Services.Models;
 
-public abstract class InstitutionAdminBase : ISoftDeleted
+public abstract class InstitutionAdminBase : ISoftDeleted, IHasUser
 {
     [Key]
     public string UserId { get; set; }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Parent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Parent.cs
@@ -8,7 +8,7 @@ using OutOfSchool.Services.Models.ChatWorkshop;
 
 namespace OutOfSchool.Services.Models;
 
-public class Parent : IKeyedEntity<Guid>, ISoftDeleted
+public class Parent : IKeyedEntity<Guid>, ISoftDeleted, IHasUser
 {
     public Parent()
     {

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Provider.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Provider.cs
@@ -10,7 +10,7 @@ using OutOfSchool.Services.Models.SubordinationStructure;
 
 namespace OutOfSchool.Services.Models;
 
-public class Provider : IKeyedEntity<Guid>, IImageDependentEntity<Provider>, ISoftDeleted
+public class Provider : IKeyedEntity<Guid>, IImageDependentEntity<Provider>, ISoftDeleted, IHasEntityImages<Provider>
 {
     public Guid Id { get; set; }
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -12,7 +12,7 @@ using OutOfSchool.Services.Models.SubordinationStructure;
 
 namespace OutOfSchool.Services.Models;
 
-public class Workshop : IKeyedEntity<Guid>, IImageDependentEntity<Workshop>, ISoftDeleted
+public class Workshop : IKeyedEntity<Guid>, IImageDependentEntity<Workshop>, ISoftDeleted, IHasEntityImages<Workshop>
 {
     public Guid Id { get; set; }
 

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/Models/WorkshopES.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/Models/WorkshopES.cs
@@ -2,11 +2,12 @@ using System;
 using System.Collections.Generic;
 using Nest;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Models;
 
 namespace OutOfSchool.ElasticsearchData.Models;
 
 // TODO: check Nested attribute
-public class WorkshopES
+public class WorkshopES: IHasRating
 {
     public const string TitleKeyword = "title.keyword";
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/AreaAdminControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/AreaAdminControllerTests.cs
@@ -20,6 +20,7 @@ using OutOfSchool.WebApi.Controllers.V1;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -38,7 +39,7 @@ public class AreaAdminControllerTests
     [SetUp]
     public void Setup()
     {
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         areaAdminServiceMock = new Mock<IAreaAdminService>();
         areaAdminController =
             new AreaAdminController(areaAdminServiceMock.Object, new Mock<ILogger<AreaAdminController>>().Object);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ExternalExportProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ExternalExportProviderControllerTests.cs
@@ -12,6 +12,7 @@ using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.ProvidersInfo;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -25,7 +26,7 @@ public class ExternalExportProviderControllerTests
     [SetUp]
     public void Setup()
     {
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         mockExternalProviderService = new Mock<IExternalExportProviderService>();
         controller = new ExternalExportProviderController(mockExternalProviderService.Object);
     }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/InstitutionStatusControllerTests.cs
@@ -15,6 +15,7 @@ using OutOfSchool.WebApi.Enums;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -32,7 +33,7 @@ public class InstitutionStatusControllerTests
     {
         // setup controller
         service = new Mock<IStatusService>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
         controller = new InstitutionStatusController(service.Object, localizer.Object);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/MinistryAdminControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/MinistryAdminControllerTests.cs
@@ -18,6 +18,7 @@ using OutOfSchool.WebApi.Controllers;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -34,7 +35,7 @@ public class MinistryAdminControllerTests
     [SetUp]
     public void Setup()
     {
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         ministryAdminServiceMock = new Mock<IMinistryAdminService>();
         ministryAdminController =
             new MinistryAdminController(ministryAdminServiceMock.Object, new Mock<ILogger<MinistryAdminController>>().Object);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PermissionsForRoleControllerTests.cs
@@ -17,6 +17,7 @@ using OutOfSchool.WebApi.Controllers.V1;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -34,7 +35,7 @@ public class PermissionsForRoleControllerTests
     public void Setup()
     {
         service = new Mock<IPermissionsForRoleService>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         controller = new PermissionsForRoleController(service.Object);
 
         permissionsForAllRoles = PermissionsForRolesGenerator.GenerateForExistingRoles();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllersTests/PrivateProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllersTests/PrivateProviderControllerTests.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using AutoMapper;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Localization;
 using Moq;
 using NUnit.Framework;
 using OutOfSchool.Common;
@@ -18,7 +16,6 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Controllers.V1;
 using OutOfSchool.WebApi.Models.Providers;
 using OutOfSchool.WebApi.Services.ProviderServices;
-using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Controllers.ProviderControllersTests;
 
@@ -28,16 +25,12 @@ public class PrivateProviderControllerTests
     private PrivateProviderController privateProviderController;
     private Mock<IPrivateProviderService> privateProviderService;
     private List<Provider> providers;
-    private Provider provider;
-    private IMapper mapper;
     private string userId;
 
     [SetUp]
     public void Setup()
     {
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         userId = Guid.NewGuid().ToString();
-        var localizer = new Mock<IStringLocalizer<SharedResource>>();
         var user = new ClaimsPrincipal
         (new ClaimsIdentity(
             new Claim[]
@@ -52,7 +45,6 @@ public class PrivateProviderControllerTests
 
         privateProviderController.ControllerContext.HttpContext = new DefaultHttpContext { User = user };
         providers = ProvidersGenerator.Generate(10);
-        provider = ProvidersGenerator.Generate();
     }
 
     [Test]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllersTests/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllersTests/ProviderControllerTests.cs
@@ -26,6 +26,7 @@ using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Providers;
 using OutOfSchool.WebApi.Services.ProviderServices;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Controllers.ProviderControllersTests;
 
@@ -42,7 +43,7 @@ public class ProviderControllerTests
     [SetUp]
     public void Setup()
     {
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         userId = Guid.NewGuid().ToString();
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllersTests/PublicProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllersTests/PublicProviderControllerTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using AutoMapper;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
@@ -18,7 +17,6 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Controllers.V1;
 using OutOfSchool.WebApi.Models.Providers;
 using OutOfSchool.WebApi.Services.ProviderServices;
-using OutOfSchool.WebApi.Util;
 
 namespace OutOfSchool.WebApi.Tests.Controllers.ProviderControllersTests;
 
@@ -28,14 +26,11 @@ public class PublicProviderControllerTests
     private PublicProviderController providerController;
     private Mock<IPublicProviderService> publicProviderService;
     private List<Provider> providers;
-    private Provider provider;
-    private IMapper mapper;
     private string userId;
 
     [SetUp]
     public void Setup()
     {
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
         userId = Guid.NewGuid().ToString();
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
         var user = new ClaimsPrincipal
@@ -52,7 +47,6 @@ public class PublicProviderControllerTests
 
         providerController.ControllerContext.HttpContext = new DefaultHttpContext { User = user };
         providers = ProvidersGenerator.Generate(10);
-        provider = ProvidersGenerator.Generate();
     }
 
     [Test]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/RegionAdminControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/RegionAdminControllerTests.cs
@@ -18,6 +18,7 @@ using OutOfSchool.WebApi.Controllers;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
 
@@ -36,7 +37,7 @@ public class RegionAdminControllerTests
     [SetUp]
     public void Setup()
     {
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         regionAdminServiceMock = new Mock<IRegionAdminService>();
         regionAdminController =
             new RegionAdminController(regionAdminServiceMock.Object, new Mock<ILogger<RegionAdminController>>().Object);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Extensions/MappingExtensionsTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Extensions/MappingExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using NUnit.Framework;
+using OutOfSchool.Common.Extensions;
 using OutOfSchool.WebApi.Util;
 using OutOfSchool.WebApi.Util.Mapping;
 
@@ -12,11 +13,8 @@ public class MappingExtensionsTests
     [Test]
     public void Mapping_MappingProfile_ConfigurationIsCorrect()
     {
-        // arrange
-        var profile = new MappingProfile();
-
         // act
-        var configuration = new MapperConfiguration(cfg => cfg.AddProfile(profile));
+        var configuration = new MapperConfiguration(cfg => MappingExtensions.UseProfile<MappingProfile>(MappingExtensions.UseProfile<CommonProfile>(cfg)));
 
         // assert
         configuration.AssertConfigurationIsValid();
@@ -25,11 +23,8 @@ public class MappingExtensionsTests
     [Test]
     public void Mapping_ElasticProfile_ConfigurationIsCorrect()
     {
-        // arrange
-        var profile = new ElasticProfile();
-
         // act
-        var configuration = new MapperConfiguration(cfg => cfg.AddProfile(profile));
+        var configuration = new MapperConfiguration(cfg => MappingExtensions.UseProfile<ElasticProfile>(MappingExtensions.UseProfile<CommonProfile>(cfg)));
 
         // assert
         configuration.AssertConfigurationIsValid();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/AchievementServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/AchievementServiceTest.cs
@@ -17,6 +17,7 @@ using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Achievement;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -46,7 +47,7 @@ public class AchievementServiceTest
         achievementRepository = new AchievementRepository(context);
         logger = new Mock<ILogger<AchievementService>>();
         localizer = new Mock<IStringLocalizer<SharedResource>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         service = new AchievementService(achievementRepository, logger.Object, localizer.Object, mapper);
 
         SeedDatabase();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceMemoryTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceMemoryTests.cs
@@ -20,6 +20,7 @@ using OutOfSchool.WebApi.Enums;
 using OutOfSchool.WebApi.Models.Application;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -68,7 +69,7 @@ public class ApplicationServiceMemoryTests
         codeficatorServiceMock = new Mock<ICodeficatorService>();
 
         logger = new Mock<ILogger<ApplicationService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
 
         applicationsConstraintsConfig = new Mock<IOptions<ApplicationsConstraintsConfig>>();
         applicationsConstraintsConfig.Setup(x => x.Value)

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/AreaAdminServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/AreaAdminServiceTests.cs
@@ -20,6 +20,7 @@ using OutOfSchool.WebApi.Config;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -41,16 +42,12 @@ public class AreaAdminServiceTests
     private AreaAdminService areaAdminService;
     private AreaAdmin areaAdmin;
     private List<AreaAdmin> areaAdmins;
-    private AreaAdminDto areaAdminDto;
-    private List<AreaAdminDto> areaAdminsDtos;
 
     [SetUp]
     public void SetUp()
     {
         areaAdmin = AdminGenerator.GenerateAreaAdmin().WithUserAndInstitution();
         areaAdmins = AdminGenerator.GenerateAreaAdmins(5).WithUserAndInstitution();
-        areaAdminDto = AdminGenerator.GenerateAreaAdminDto();
-        areaAdminsDtos = AdminGenerator.GenerateAreaAdminsDtos(5);
 
         codeficatorRepositoryMock = new Mock<ICodeficatorRepository>();
         codeficatorServiceMock = new Mock<ICodeficatorService>();
@@ -73,7 +70,7 @@ public class AreaAdminServiceTests
 
         areaAdminRepositoryMock = new Mock<IAreaAdminRepository>();
         var logger = new Mock<ILogger<AreaAdminService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         userRepositoryMock = new Mock<IEntityRepositorySoftDeleted<string, User>>();
         currentUserServiceMock = new Mock<ICurrentUserService>();
         institutionAdminServiceMock = new Mock<IMinistryAdminService>();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatMessageWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatMessageWorkshopServiceTests.cs
@@ -19,6 +19,7 @@ using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.ChatWorkshop;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -64,7 +65,7 @@ public class ChatMessageWorkshopServiceTests
         roomServiceMock = new Mock<IChatRoomWorkshopService>();
         workshopHub = new Mock<IHubContext<ChatWorkshopHub>>();
         loggerMock = new Mock<ILogger<ChatMessageWorkshopService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
 
         clientsMock = new Mock<IHubClients>();
         clientProxyMock = new Mock<IClientProxy>();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -18,6 +18,7 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Models.ChatWorkshop;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -87,7 +88,7 @@ public class ChatRoomWorkshopServiceTests
         roomRepository = new EntityRepositorySoftDeleted<Guid, ChatRoomWorkshop>(dbContext);
         roomWithSpecialModelRepositoryMock = new Mock<IChatRoomWorkshopModelForChatListRepository>();
         loggerMock = new Mock<ILogger<ChatRoomWorkshopService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
 
         roomService = new ChatRoomWorkshopService(
             roomRepository,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CodeficatorServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CodeficatorServiceTests.cs
@@ -14,6 +14,7 @@ using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Models.Codeficator;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -36,7 +37,7 @@ public class CodeficatorServiceTests
         options = builder.Options;
         context = new OutOfSchoolDbContext(options);
 
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         repository = new CodeficatorRepository(context);
         service = new CodeficatorService(repository, mapper);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -22,6 +22,7 @@ using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Services.AverageRatings;
 using OutOfSchool.WebApi.Services.Images;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -51,7 +52,7 @@ public class WorkshopServiceTests
         logger = new Mock<ILogger<WorkshopService>>();
         mapperMock = new Mock<IMapper>();
         workshopImagesMediator = new Mock<IImageDependentEntityImagesInteractionService<Workshop>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         providerAdminRepository = new Mock<IProviderAdminRepository>();
         averageRatingServiceMock = new Mock<IAverageRatingService>();
         providerRepositoryMock = new Mock<IProviderRepository>();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ExternalExportProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ExternalExportProviderServiceTests.cs
@@ -17,6 +17,7 @@ using OutOfSchool.WebApi.Models.ProvidersInfo;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Services.AverageRatings;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 [TestFixture]
@@ -35,7 +36,7 @@ public class ExternalExportProviderServiceTests
         mockProviderRepository = new Mock<IProviderRepository>();
         mockWorkshopRepository = new Mock<IWorkshopRepository>();
         mockAverageRatingService = new Mock<IAverageRatingService>();
-        mockMapper = OutOfSchool.Tests.Common.TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mockMapper = OutOfSchool.Tests.Common.TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         mockLogger = new Mock<ILogger<ExternalExportProviderService>>();
 
         externalExportProviderService = new ExternalExportProviderService(
@@ -225,7 +226,7 @@ public class ExternalExportProviderServiceTests
                 providerRepository,
                 workshopRepository,
                 new Mock<IAverageRatingService>().Object,
-                new Mapper(new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>())),
+                mockMapper,
                 new Mock<ILogger<ExternalExportProviderService>>().Object
             );
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/MinistryAdminServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/MinistryAdminServiceTests.cs
@@ -21,6 +21,7 @@ using OutOfSchool.WebApi.Config;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -64,7 +65,7 @@ public class MinistryAdminServiceTests
 
         institutionAdminRepositoryMock = new Mock<IInstitutionAdminRepository>();
         var logger = new Mock<ILogger<MinistryAdminService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         userRepositoryMock = new Mock<IEntityRepositorySoftDeleted<string, User>>();
         currentUserServiceMock = new Mock<ICurrentUserService>();
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ParentServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ParentServiceTests.cs
@@ -12,6 +12,7 @@ using OutOfSchool.WebApi.Common;
 using OutOfSchool.WebApi.Models.Parent;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -35,7 +36,7 @@ public class ParentServiceTests
         parentBlockedByAdminLogServiceMock = new Mock<IParentBlockedByAdminLogService>();
         loggerMock = new Mock<ILogger<ParentService>>();
         repositoryChildMock = new Mock<IEntityRepositorySoftDeleted<Guid, Child>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
 
         parentService = new ParentService(
             parentRepositoryMock.Object,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/PermissionsForRoleServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/PermissionsForRoleServiceTests.cs
@@ -16,6 +16,7 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -38,7 +39,7 @@ public class PermissionsForRoleServiceTests
         var context = new OutOfSchoolDbContext(options);
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
         repository = new EntityRepository<long, PermissionsForRole>(context);
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         var logger = new Mock<ILogger<PermissionsForRoleService>>();
         service = new PermissionsForRoleService(repository, logger.Object, localizer.Object, mapper);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderAdminServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderAdminServiceTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -17,6 +16,7 @@ using OutOfSchool.WebApi.Config;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Services.ProviderAdminOperations;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -74,7 +74,7 @@ public class ProviderAdminServiceTest
             });
         providerAdminRepository = new Mock<IProviderAdminRepository>();
         userRepositoryMock = new Mock<IEntityRepositorySoftDeleted<string, OutOfSchool.Services.Models.User>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         var logger = new Mock<ILogger<ProviderAdminService>>();
         providerAdminOperationsService = new Mock<IProviderAdminOperationsService>();
         workshopService = new Mock<IWorkshopService>();
@@ -100,8 +100,7 @@ public class ProviderAdminServiceTest
         // Arrange
         var expected = userDosntHavePermissionErrorResponse
             .ApiErrorResponse
-            .ApiErrors
-            .First();
+            .ApiErrors[0];
 
         // Act
         var response = await providerAdminService.CreateProviderAdminAsync(userId, new CreateProviderAdminDto(), It.IsAny<string>()).ConfigureAwait(false);
@@ -111,7 +110,7 @@ public class ProviderAdminServiceTest
             actionResult => errorResponse = actionResult,
             succeed => errorResponse = new ErrorResponse());
 
-        var result = errorResponse.ApiErrorResponse.ApiErrors.First();
+        var result = errorResponse.ApiErrorResponse.ApiErrors[0];
 
         // Assert
         Assert.AreEqual(expected.Group, result.Group);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
@@ -28,6 +28,7 @@ using OutOfSchool.WebApi.Services.Communication.ICommunication;
 using OutOfSchool.WebApi.Services.Images;
 using OutOfSchool.WebApi.Services.ProviderServices;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -89,7 +90,8 @@ public class ProviderServiceTests
         communicationService = new Mock<ICommunicationService>();
 
         var authorizationServerConfig = Options.Create(new AuthorizationServerConfig { Authority = new Uri("http://test.com") });
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
 
         providerService = new ProviderService(
             providersRepositoryMock.Object,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServicesTests/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServicesTests/ProviderServiceTests.cs
@@ -28,6 +28,7 @@ using OutOfSchool.WebApi.Services.Communication.ICommunication;
 using OutOfSchool.WebApi.Services.Images;
 using OutOfSchool.WebApi.Services.ProviderServices;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services.ProviderServicesTests;
 
@@ -90,7 +91,7 @@ public class ProviderServiceTests
         workshopServicesCombinerMock = new Mock<IWorkshopServicesCombiner>();
 
         var authorizationServerConfig = Options.Create(new AuthorizationServerConfig { Authority = new Uri("http://test.com") });
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
 
         providerService = new ProviderService(
             providersRepositoryMock.Object,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServicesTests/ProviderServiceV2Tests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServicesTests/ProviderServiceV2Tests.cs
@@ -28,6 +28,7 @@ using OutOfSchool.WebApi.Services.Communication.ICommunication;
 using OutOfSchool.WebApi.Services.Images;
 using OutOfSchool.WebApi.Services.ProviderServices;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services.ProviderServicesTests;
 
@@ -90,7 +91,7 @@ public class ProviderServiceV2Tests
         providerImagesService = new Mock<IImageDependentEntityImagesInteractionService<Provider>>();
 
         var authorizationServerConfig = Options.Create(new AuthorizationServerConfig { Authority = new Uri("http://test.com") });
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
 
         providerService = new ProviderServiceV2(
             providersRepositoryMock.Object,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/RegionAdminServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/RegionAdminServiceTests.cs
@@ -21,6 +21,7 @@ using OutOfSchool.WebApi.Config;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -69,7 +70,7 @@ public class RegionAdminServiceTests
 
         regionAdminRepositoryMock = new Mock<IRegionAdminRepository>();
         var logger = new Mock<ILogger<RegionAdminService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         userRepositoryMock = new Mock<IEntityRepositorySoftDeleted<string, User>>();
         currentUserServiceMock = new Mock<ICurrentUserService>();
         ministryAdminServiceMock = new Mock<IMinistryAdminService>();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SocialGroupServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SocialGroupServiceTests.cs
@@ -16,6 +16,7 @@ using OutOfSchool.WebApi.Enums;
 using OutOfSchool.WebApi.Models.SocialGroup;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -42,7 +43,7 @@ public class SocialGroupServiceTests
         localizer = new Mock<IStringLocalizer<SharedResource>>();
         repository = new EntityRepositorySoftDeleted<long, SocialGroup>(context);
         logger = new Mock<ILogger<SocialGroupService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         service = new SocialGroupService(repository, logger.Object, localizer.Object, mapper);
 
         SeedDatabase();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatusServiceTests.cs
@@ -16,6 +16,7 @@ using OutOfSchool.Tests.Common.TestDataGenerators;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -37,7 +38,7 @@ public class StatusServiceTests
         options = builder.Options;
         context = new OutOfSchoolDbContext(options);
         repository = new EntityRepositorySoftDeleted<long, InstitutionStatus>(context);
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         var logger = new Mock<ILogger<StatusService>>();
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
         service = new StatusService(repository, logger.Object, localizer.Object, mapper);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/UserServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/UserServiceTest.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using AutoMapper;
-using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -17,6 +16,7 @@ using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -43,7 +43,7 @@ public class UserServiceTest
         localizer = new Mock<IStringLocalizer<SharedResource>>();
         repo = new EntityRepositorySoftDeleted<string, User>(context);
         logger = new Mock<ILogger<UserService>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         service = new UserService(repo, logger.Object, localizer.Object, mapper);
 
         SeedDatabase();

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/AccountStatusExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/AccountStatusExtensions.cs
@@ -1,0 +1,16 @@
+﻿using OutOfSchool.WebApi.Enums;
+
+namespace OutOfSchool.WebApi.Extensions;
+
+internal static class AccountStatusExtensions
+{
+    public static AccountStatus Convert(bool isBlocked, DateTimeOffset lastLogin)
+        => isBlocked
+            ? AccountStatus.Blocked
+            : lastLogin == DateTimeOffset.MinValue
+                ? AccountStatus.NeverLogged
+                : AccountStatus.Accepted;
+
+    public static AccountStatus Convert(User user)
+        => Convert(user.IsBlocked, user.LastLogin);
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/AccountStatusExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/AccountStatusExtensions.cs
@@ -5,11 +5,16 @@ namespace OutOfSchool.WebApi.Extensions;
 internal static class AccountStatusExtensions
 {
     public static AccountStatus Convert(bool isBlocked, DateTimeOffset lastLogin)
-        => isBlocked
-            ? AccountStatus.Blocked
-            : lastLogin == DateTimeOffset.MinValue
-                ? AccountStatus.NeverLogged
-                : AccountStatus.Accepted;
+    {
+        if (isBlocked)
+        {
+            return AccountStatus.Blocked;
+        }
+
+        return lastLogin == DateTimeOffset.MinValue
+            ? AccountStatus.NeverLogged
+            : AccountStatus.Accepted;
+    }
 
     public static AccountStatus Convert(User user)
         => Convert(user.IsBlocked, user.LastLogin);

--- a/OutOfSchool/OutOfSchool.WebApi/Models/IHasCoverImage.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/IHasCoverImage.cs
@@ -1,0 +1,8 @@
+﻿namespace OutOfSchool.WebApi.Models;
+
+public interface IHasCoverImage
+{
+    IFormFile CoverImage { get; }
+
+    string CoverImageId { get; }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Models/IHasImages.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/IHasImages.cs
@@ -1,0 +1,8 @@
+﻿namespace OutOfSchool.WebApi.Models;
+
+public interface IHasImages
+{
+    IList<string> ImageIds { get; }
+
+    List<IFormFile> ImageFiles { get; }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Models/IHasImages.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/IHasImages.cs
@@ -2,7 +2,7 @@
 
 public interface IHasImages
 {
-    IList<string> ImageIds { get; }
+    IList<string> ImageIds { get; set; }
 
-    List<IFormFile> ImageFiles { get; }
+    List<IFormFile> ImageFiles { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Providers/ProviderBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Providers/ProviderBaseDto.cs
@@ -8,7 +8,7 @@ using OutOfSchool.WebApi.Util.JsonTools;
 
 namespace OutOfSchool.WebApi.Models.Providers;
 
-public class ProviderBaseDto
+public class ProviderBaseDto : IHasCoverImage, IHasImages
 {
     public Guid Id { get; set; }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Providers/ProviderDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Providers/ProviderDto.cs
@@ -1,9 +1,10 @@
-using OutOfSchool.Common.Enums;
 using System.ComponentModel.DataAnnotations;
+using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Models;
 
 namespace OutOfSchool.WebApi.Models.Providers;
 
-public class ProviderDto : ProviderBaseDto
+public class ProviderDto : ProviderBaseDto, IHasRating
 {
     [Required]
     [EnumDataType(typeof(OwnershipType), ErrorMessage = Constants.EnumErrorMessage)]

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ProvidersInfo/ProviderInfoDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ProvidersInfo/ProviderInfoDto.cs
@@ -1,13 +1,14 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.WebApi.Models.SubordinationStructure;
 using OutOfSchool.WebApi.Util.JsonTools;
 
 namespace OutOfSchool.WebApi.Models.ProvidersInfo;
 
-public class ProviderInfoDto : ProviderInfoBaseDto
+public class ProviderInfoDto : ProviderInfoBaseDto, IHasRating
 {
     [Required]
     [EnumDataType(typeof(OwnershipType), ErrorMessage = Constants.EnumErrorMessage)]

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ProvidersInfo/WorkshopInfoDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ProvidersInfo/WorkshopInfoDto.cs
@@ -2,13 +2,14 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Models;
 using OutOfSchool.WebApi.Models.Workshops;
 using OutOfSchool.WebApi.Util.CustomValidation;
 using OutOfSchool.WebApi.Util.JsonTools;
 
 namespace OutOfSchool.WebApi.Models.ProvidersInfo;
 
-public class WorkshopInfoDto : WorkshopInfoBaseDto
+public class WorkshopInfoDto : WorkshopInfoBaseDto, IHasRating
 {
     public uint TakenSeats { get; set; } = 0;
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Workshops/WorkshopBaseCard.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Workshops/WorkshopBaseCard.cs
@@ -1,10 +1,11 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Models;
 
 namespace OutOfSchool.WebApi.Models.Workshops;
 
-public class WorkshopBaseCard
+public class WorkshopBaseCard : IHasRating
 {
     [Required]
     public Guid WorkshopId { get; set; }

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Workshops/WorkshopDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Workshops/WorkshopDto.cs
@@ -1,10 +1,11 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Newtonsoft.Json;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Models;
 
 namespace OutOfSchool.WebApi.Models.Workshops;
 
-public class WorkshopDto : WorkshopBaseDto
+public class WorkshopDto : WorkshopBaseDto, IHasRating
 {
     public uint TakenSeats { get; set; } = 0;
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Workshops/WorkshopV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Workshops/WorkshopV2Dto.cs
@@ -5,7 +5,7 @@ using OutOfSchool.WebApi.Util.JsonTools;
 
 namespace OutOfSchool.WebApi.Models.Workshops;
 
-public class WorkshopV2Dto : WorkshopDto
+public class WorkshopV2Dto : WorkshopDto, IHasCoverImage, IHasImages
 {
     [MaxLength(256)]
     public string CoverImageId { get; set; } = string.Empty;

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderAdminService.cs
@@ -6,7 +6,6 @@ using Newtonsoft.Json;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Common.Responses;
-using OutOfSchool.WebApi.Enums;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Workshops;
 
@@ -515,17 +514,7 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
                 var user = (await userRepository.GetByFilter(u => u.Id == pa.UserId).ConfigureAwait(false)).Single();
                 var dto = mapper.Map<ProviderAdminDto>(user);
                 dto.IsDeputy = pa.IsDeputy;
-
-                if (user.IsBlocked)
-                {
-                    dto.AccountStatus = AccountStatus.Blocked;
-                }
-                else
-                {
-                    dto.AccountStatus = user.LastLogin == DateTimeOffset.MinValue
-                        ? AccountStatus.NeverLogged
-                        : AccountStatus.Accepted;
-                }
+                dto.AccountStatus = AccountStatusExtensions.Convert(user);
 
                 dtos.Add(dto);
             }
@@ -570,16 +559,7 @@ public class ProviderAdminService : CommunicationService, IProviderAdminService
         result.WorkshopTitles = await workshopService.GetWorkshopListByProviderAdminId(providerAdminId).ConfigureAwait(false);
 
         result.IsDeputy = providerAdmin.IsDeputy;
-        if (user.IsBlocked)
-        {
-            result.AccountStatus = AccountStatus.Blocked;
-        }
-        else
-        {
-            result.AccountStatus = user.LastLogin == DateTimeOffset.MinValue
-                ? AccountStatus.NeverLogged
-                : AccountStatus.Accepted;
-        }
+        result.AccountStatus = AccountStatusExtensions.Convert(user);
 
         return result;
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -210,7 +210,7 @@ public static class Startup
                 }))
             .AddCustomDataProtection("WebApi");
 
-        services.AddAutoMapper(typeof(MappingProfile), typeof(ElasticProfile));
+        services.AddAutoMapper(typeof(CommonProfile), typeof(MappingProfile), typeof(ElasticProfile));
 
         // Add Elasticsearch client
         var elasticConfig = configuration

--- a/OutOfSchool/OutOfSchool.WebApi/Util/Mapping/CommonProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/Mapping/CommonProfile.cs
@@ -1,0 +1,14 @@
+﻿using OutOfSchool.Common.Models;
+using Profile = AutoMapper.Profile;
+
+namespace OutOfSchool.WebApi.Util.Mapping;
+
+public class CommonProfile : Profile
+{
+    public CommonProfile()
+    {
+        CreateMap<object, IHasRating>()
+            .ForMember(dest => dest.Rating, opt => opt.Ignore())
+            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore());
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Util/Mapping/ElasticProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/Mapping/ElasticProfile.cs
@@ -126,11 +126,11 @@ public class ElasticProfile : Profile
                 opt => opt.Ignore());
 
         CreateMap<CATOTTG, CodeficatorAddressES>()
-            .ForMember(dest => dest.Settlement, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetSettlementName(src)))
-            .ForMember(dest => dest.TerritorialCommunity, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetTerritorialCommunityName(src)))
-            .ForMember(dest => dest.District, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetDistrictName(src)))
-            .ForMember(dest => dest.Region, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetRegionName(src)))
-            .ForMember(dest => dest.CityDistrict, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetCityDistrictName(src)))
+            .ForMember(dest => dest.Settlement, opt => opt.MapFrom(src => CatottgAddressExtensions.GetSettlementName(src)))
+            .ForMember(dest => dest.TerritorialCommunity, opt => opt.MapFrom(src => CatottgAddressExtensions.GetTerritorialCommunityName(src)))
+            .ForMember(dest => dest.District, opt => opt.MapFrom(src => CatottgAddressExtensions.GetDistrictName(src)))
+            .ForMember(dest => dest.Region, opt => opt.MapFrom(src => CatottgAddressExtensions.GetRegionName(src)))
+            .ForMember(dest => dest.CityDistrict, opt => opt.MapFrom(src => CatottgAddressExtensions.GetCityDistrictName(src)))
             .ForMember(dest => dest.FullAddress, opt => opt.Ignore())
             .ForMember(dest => dest.FullName, opt => opt.Ignore());
 

--- a/OutOfSchool/OutOfSchool.WebApi/Util/Mapping/ElasticProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/Mapping/ElasticProfile.cs
@@ -1,6 +1,5 @@
-using System.Linq.Expressions;
 using Nest;
-using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Codeficator;
@@ -14,6 +13,7 @@ public class ElasticProfile : Profile
     public ElasticProfile()
     {
         CreateMap<WorkshopBaseDto, WorkshopES>()
+            .IncludeBase<object, IHasRating>()
             .ForMember(
                 dest => dest.Keywords,
                 opt =>
@@ -32,8 +32,6 @@ public class ElasticProfile : Profile
             .ForMember(dest => dest.Status, opt => opt.Ignore())
             .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
             .ForMember(dest => dest.ProviderOwnership, opt => opt.Ignore())
-            .ForMember(dest => dest.Rating, opt => opt.Ignore())
-            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore())
             .ForMember(dest => dest.ProviderStatus, opt => opt.Ignore())
             .ForMember(dest => dest.Status, opt => opt.Ignore())
             .ForMember(dest => dest.TakenSeats, opt => opt.Ignore());
@@ -128,29 +126,11 @@ public class ElasticProfile : Profile
                 opt => opt.Ignore());
 
         CreateMap<CATOTTG, CodeficatorAddressES>()
-            .ForMember(
-                dest => dest.Settlement,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name ? src.Parent.Name : src.Name))
-            .ForMember(
-                dest => dest.TerritorialCommunity,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name ? src.Parent.Parent.Name : src.Parent.Name))
-            .ForMember(
-                dest => dest.District,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name
-                        ? src.Parent.Parent.Parent.Name
-                        : src.Parent.Parent.Name))
-            .ForMember(
-                dest => dest.Region,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name
-                        ? src.Parent.Parent.Parent.Parent.Name
-                        : src.Parent.Parent.Parent.Name))
-            .ForMember(
-                dest => dest.CityDistrict,
-                opt => opt.MapFrom(src => src.Category == CodeficatorCategory.CityDistrict.Name ? src.Name : null))
+            .ForMember(dest => dest.Settlement, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetSettlementName(src)))
+            .ForMember(dest => dest.TerritorialCommunity, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetTerritorialCommunityName(src)))
+            .ForMember(dest => dest.District, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetDistrictName(src)))
+            .ForMember(dest => dest.Region, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetRegionName(src)))
+            .ForMember(dest => dest.CityDistrict, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetCityDistrictName(src)))
             .ForMember(dest => dest.FullAddress, opt => opt.Ignore())
             .ForMember(dest => dest.FullName, opt => opt.Ignore());
 

--- a/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
@@ -1,10 +1,9 @@
 using AutoMapper;
 using Google.Protobuf.WellKnownTypes;
 using GrpcService;
-using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Enums;
-using OutOfSchool.WebApi.Enums;
+using OutOfSchool.Services.Models.Images;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Achievement;
 using OutOfSchool.WebApi.Models.Application;
@@ -82,13 +81,11 @@ public class MappingProfile : Profile
 
         CreateMap<Workshop, WorkshopDto>()
             .IncludeBase<Workshop, WorkshopBaseDto>()
-            .ForMember(dest => dest.TakenSeats, opt =>
-                opt.MapFrom(src =>
-                    src.Applications.Count(x =>
-                        x.Status == ApplicationStatus.Approved
-                        || x.Status == ApplicationStatus.StudyingForYears)))
-            .ForMember(dest => dest.Rating, opt => opt.Ignore())
-            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore())
+            .ForMember(
+                dest => dest.TakenSeats,
+                opt => opt.MapFrom(src
+                    => src.Applications.Count(x => x.Status == ApplicationStatus.Approved || x.Status == ApplicationStatus.StudyingForYears)))
+            .IncludeBase<object, IHasRating>()
             .ForMember(dest => dest.IsBlocked, opt => opt.MapFrom(src => src.Provider.IsBlocked))
             .ForMember(dest => dest.ProviderStatus, opt => opt.MapFrom(src => src.Provider.Status));
 
@@ -97,9 +94,9 @@ public class MappingProfile : Profile
 
         CreateMap<Workshop, WorkshopV2Dto>()
             .IncludeBase<Workshop, WorkshopDto>()
-            .ForMember(dest => dest.CoverImage, opt => opt.Ignore())
-            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)))
-            .ForMember(dest => dest.ImageFiles, opt => opt.Ignore());
+            .Apply(MapImageIds)
+            .Apply(IgnoreAllImages)
+            ;
 
         CreateMap<WorkshopV2Dto, Workshop>()
             .IncludeBase<WorkshopDto, Workshop>();
@@ -145,66 +142,43 @@ public class MappingProfile : Profile
         CreateMap<ProviderType, ProviderTypeDto>().ReverseMap();
 
         CreateMap<Provider, ProviderDto>()
-            .ForMember(dest => dest.ActualAddress, opt => opt.MapFrom(src => src.ActualAddress))
-            .ForMember(dest => dest.LegalAddress, opt => opt.MapFrom(src => src.LegalAddress))
-            .ForMember(dest => dest.Institution, opt => opt.MapFrom(src => src.Institution))
-            .ForMember(dest => dest.Rating, opt => opt.Ignore())
-            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore())
-            .ForMember(dest => dest.CoverImage, opt => opt.Ignore())
-            .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())
-            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)))
+            .Apply(AddCommonProvider2ProviderBaseDto)
+            .IncludeBase<object, IHasRating>()
             .ForMember(dest => dest.ProviderSectionItems, opt => opt.MapFrom(src => src.ProviderSectionItems.Where(x => !x.IsDeleted)));
 
         CreateSoftDeletedMap<ProviderDto, Provider>()
+            .Apply(IgnoreCommonProviderBaseDto2Provider)
             .ForMember(dest => dest.Workshops, opt => opt.Ignore())
             .ForMember(dest => dest.User, opt => opt.Ignore())
-            .ForMember(dest => dest.Institution, opt => opt.Ignore())
             .ForMember(dest => dest.InstitutionStatus, opt => opt.Ignore())
             .ForMember(dest => dest.Images, opt => opt.Ignore())
-            .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
-            .ForMember(dest => dest.Status, opt => opt.Ignore())
-            .ForMember(dest => dest.LicenseStatus, opt => opt.Ignore())
-            .ForMember(dest => dest.ProviderAdmins, opt => opt.Ignore())
             .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
             .ForMember(dest => dest.ProviderAdmins, opt => opt.Ignore());
 
         CreateSoftDeletedMap<ProviderUpdateDto, Provider>()
+            .Apply(IgnoreCommonProviderBaseDto2Provider)
             .ForMember(dest => dest.Ownership, opt => opt.Ignore())
             .ForMember(dest => dest.Workshops, opt => opt.Ignore())
             .ForMember(dest => dest.User, opt => opt.Ignore())
-            .ForMember(dest => dest.Institution, opt => opt.Ignore())
             .ForMember(dest => dest.InstitutionStatus, opt => opt.Ignore())
             .ForMember(dest => dest.Images, opt => opt.Ignore())
-            .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
-            .ForMember(dest => dest.Status, opt => opt.Ignore())
-            .ForMember(dest => dest.StatusReason, opt => opt.Ignore())
-            .ForMember(dest => dest.LicenseStatus, opt => opt.Ignore())
             .ForMember(dest => dest.ProviderAdmins, opt => opt.Ignore())
             .ForMember(dest => dest.BlockPhoneNumber, opt => opt.Ignore())
-            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore()) 
+            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
             .ForMember(dest => dest.BlockReason, opt => opt.Ignore())
             .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore());
 
         CreateMap<Provider, ProviderUpdateDto>()
-            .ForMember(dest => dest.ActualAddress, opt => opt.MapFrom(src => src.ActualAddress))
-            .ForMember(dest => dest.LegalAddress, opt => opt.MapFrom(src => src.LegalAddress))
-            .ForMember(dest => dest.Institution, opt => opt.MapFrom(src => src.Institution))
-            .ForMember(dest => dest.CoverImage, opt => opt.Ignore())
-            .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())
-            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)));
+            .Apply(AddCommonProvider2ProviderBaseDto);
 
         CreateMap<ProviderDto, ProviderUpdateDto>();
 
         CreateSoftDeletedMap<ProviderCreateDto, Provider>()
+            .Apply(IgnoreCommonProviderBaseDto2Provider)
             .ForMember(dest => dest.Workshops, opt => opt.Ignore())
             .ForMember(dest => dest.User, opt => opt.Ignore())
-            .ForMember(dest => dest.Institution, opt => opt.Ignore())
             .ForMember(dest => dest.InstitutionStatus, opt => opt.Ignore())
             .ForMember(dest => dest.Images, opt => opt.Ignore())
-            .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
-            .ForMember(dest => dest.Status, opt => opt.Ignore())
-            .ForMember(dest => dest.StatusReason, opt => opt.Ignore())
-            .ForMember(dest => dest.LicenseStatus, opt => opt.Ignore())
             .ForMember(dest => dest.ProviderAdmins, opt => opt.Ignore())
             .ForMember(dest => dest.BlockPhoneNumber, opt => opt.Ignore())
             .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
@@ -212,18 +186,12 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore());
 
         CreateMap<Provider, ProviderCreateDto>()
-            .ForMember(dest => dest.ActualAddress, opt => opt.MapFrom(src => src.ActualAddress))
-            .ForMember(dest => dest.LegalAddress, opt => opt.MapFrom(src => src.LegalAddress))
-            .ForMember(dest => dest.Institution, opt => opt.MapFrom(src => src.Institution))
-            .ForMember(dest => dest.CoverImage, opt => opt.Ignore())
-            .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())
-            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)));
+            .Apply(AddCommonProvider2ProviderBaseDto);
 
         CreateMap<ProviderCreateDto, ProviderDto>()
             .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
             .ForMember(dest => dest.BlockReason, opt => opt.Ignore())
-            .ForMember(dest => dest.Rating, opt => opt.Ignore())
-            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore())
+            .IncludeBase<object, IHasRating>()
             .ForMember(dest => dest.BlockPhoneNumber, opt => opt.Ignore())
             .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())
             .ForMember(dest => dest.ImageIds, opt => opt.Ignore());
@@ -251,18 +219,13 @@ public class MappingProfile : Profile
                         src.Applications.Count(x =>
                             x.Status == ApplicationStatus.Approved
                             || x.Status == ApplicationStatus.StudyingForYears)))
-                .ForMember(dest => dest.Rating, opt => opt.Ignore())
-                .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore());
+            .IncludeBase<object, IHasRating>();
 
         CreateMap<Provider, ProviderInfoBaseDto>();
 
         CreateMap<Provider, ProviderInfoDto>()
             .IncludeBase<Provider, ProviderInfoBaseDto>()
-            .ForMember(dest => dest.Institution, opt => opt.MapFrom(src => src.Institution))
-            .ForMember(dest => dest.LicenseStatus, opt => opt.MapFrom(src => src.LicenseStatus))
-            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status))
-            .ForMember(dest => dest.Rating, opt => opt.Ignore())
-            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore());
+            .IncludeBase<object, IHasRating>();
 
         CreateSoftDeletedMap<TeacherDTO, Teacher>()
             .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
@@ -301,8 +264,7 @@ public class MappingProfile : Profile
             .IncludeBase<Workshop, WorkshopBaseCard>()
             .ForMember(dest => dest.InstitutionId, opt => opt.MapFrom(src => src.InstitutionHierarchy.InstitutionId))
             .ForMember(dest => dest.Institution, opt => opt.MapFrom(src => src.InstitutionHierarchy.Institution.Title))
-            .ForMember(dest => dest.Rating, opt => opt.Ignore())
-            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore())
+            .IncludeBase<object, IHasRating>()
             .ForMember(dest => dest.TakenSeats, opt =>
                 opt.MapFrom(src =>
                     src.Applications.Count(x =>
@@ -315,8 +277,7 @@ public class MappingProfile : Profile
             .ForMember(
                 dest => dest.DirectionIds,
                 opt => opt.MapFrom(src => src.InstitutionHierarchy.Directions.Where(x => !x.IsDeleted).Select(x => x.Id)))
-            .ForMember(dest => dest.Rating, opt => opt.Ignore())
-            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore())
+            .IncludeBase<object, IHasRating>()
             .ForMember(dest => dest.ProviderLicenseStatus, opt =>
                 opt.MapFrom(src => src.Provider.LicenseStatus));
 
@@ -394,10 +355,8 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.PhoneNumber.Right(Constants.PhoneShortLength)));
 
         CreateMap<User, FullProviderAdminDto>()
-            .ForMember(dest => dest.IsDeputy, opt => opt.Ignore())
-            .ForMember(dest => dest.AccountStatus, m => m.Ignore())
+            .IncludeBase<User, ProviderAdminDto>()
             .ForMember(dest => dest.WorkshopTitles, opt => opt.Ignore())
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.PhoneNumber.Right(Constants.PhoneShortLength)))
             .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.MiddleName ?? string.Empty));
 
         CreateSoftDeletedMap<DirectionDto, Direction>()
@@ -410,32 +369,12 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.RequestId, opt => opt.Ignore())
             .ForMember(c => c.CreatingTime, m => m.MapFrom(c => Timestamp.FromDateTimeOffset(c.CreatingTime)))
             .ForMember(c => c.ProviderId, m => m.MapFrom(c => c.ProviderId.ToString()))
-            .ForMember(c => c.ManagedWorkshopIds, m => m.MapFrom((dto, entity) =>
-            {
-                var managedWorkshopIds = new List<string>();
-
-                foreach (var item in dto.ManagedWorkshopIds)
-                {
-                    managedWorkshopIds.Add(item.ToString());
-                }
-
-                return managedWorkshopIds;
-            }));
+            .ForMember(c => c.ManagedWorkshopIds, m => m.MapFrom(src => src.ManagedWorkshopIds.Select(id => id.ToString()).ToList()));
 
         CreateMap<CreateProviderAdminReply, CreateProviderAdminDto>()
             .ForMember(c => c.CreatingTime, m => m.MapFrom(c => c.CreatingTime.ToDateTimeOffset()))
             .ForMember(c => c.ProviderId, m => m.MapFrom(c => Guid.Parse(c.ProviderId)))
-            .ForMember(c => c.ManagedWorkshopIds, opt => opt.MapFrom((dto, entity) =>
-            {
-                var managedWorkshopIds = new List<Guid>();
-
-                foreach (var item in dto.ManagedWorkshopIds)
-                {
-                    managedWorkshopIds.Add(Guid.Parse(item));
-                }
-
-                return managedWorkshopIds;
-            }));
+            .ForMember(c => c.ManagedWorkshopIds, opt => opt.MapFrom(src => src.ManagedWorkshopIds.Select(Guid.Parse).ToList()));
 
         CreateMap<User, ShortUserDto>()
             .ForMember(dest => dest.Gender, opt => opt.Ignore())
@@ -443,37 +382,23 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.MiddleName ?? string.Empty));
 
         CreateSoftDeletedMap<ShortUserDto, User>()
-            .ForMember(dest => dest.IsRegistered, opt => opt.Ignore())
-            .ForMember(dest => dest.Role, opt => opt.Ignore())
-            .ForMember(dest => dest.Email, opt => opt.Ignore())
-            .ForMember(dest => dest.UserName, opt => opt.Ignore())
-            .ForMember(dest => dest.LastLogin, opt => opt.Ignore())
-            .ForMember(dest => dest.NormalizedEmail, opt => opt.Ignore())
-            .ForMember(dest => dest.NormalizedUserName, opt => opt.Ignore())
-            .ForMember(dest => dest.EmailConfirmed, opt => opt.Ignore())
-            .ForMember(dest => dest.PasswordHash, opt => opt.Ignore())
-            .ForMember(dest => dest.SecurityStamp, opt => opt.Ignore())
-            .ForMember(dest => dest.ConcurrencyStamp, opt => opt.Ignore())
-            .ForMember(dest => dest.PhoneNumberConfirmed, opt => opt.Ignore())
-            .ForMember(dest => dest.TwoFactorEnabled, opt => opt.Ignore())
-            .ForMember(dest => dest.LockoutEnabled, opt => opt.Ignore())
-            .ForMember(dest => dest.LockoutEnd, opt => opt.Ignore())
-            .ForMember(dest => dest.CreatingTime, opt => opt.Ignore())
-            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
-            .ForMember(dest => dest.IsDerived, opt => opt.Ignore())
-            .ForMember(dest => dest.MustChangePassword, opt => opt.Ignore())
-            .ForMember(dest => dest.AccessFailedCount, opt => opt.Ignore());
-
-        CreateMap<Parent, ShortUserDto>()
+            .IncludeBase<BaseUserDto, User>()
+            .ForMember(dest => dest.Email, opt => opt.Ignore());
+        
+        CreateMap<IHasUser, BaseUserDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.User.Id))
-            .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.User.Email))
-            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.User.Role))
             .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.User.FirstName))
             .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.User.LastName))
             .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.User.MiddleName ?? string.Empty))
+            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.User.PhoneNumber.Right(Constants.PhoneShortLength)))
+            .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.User.Email))
+        ;
+
+        CreateMap<Parent, ShortUserDto>()
+            .IncludeBase<IHasUser, BaseUserDto>()
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.User.Role))
             .ForMember(dest => dest.IsRegistered, opt => opt.MapFrom(src => src.User.IsRegistered))
             .ForMember(dest => dest.EmailConfirmed, opt => opt.MapFrom(src => src.User.EmailConfirmed))
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.User.PhoneNumber.Right(Constants.PhoneShortLength)))
             .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.User.UserName));
 
         CreateSoftDeletedMap<BaseUserDto, User>()
@@ -498,21 +423,9 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.MustChangePassword, m => m.Ignore());
 
         CreateMap<InstitutionAdmin, MinistryAdminDto>()
+            .IncludeBase<IHasUser, BaseUserDto>()
             .ForMember(dest => dest.InstitutionTitle, opt => opt.MapFrom(src => src.Institution.Title))
-            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.User.Id))
-            .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.User.FirstName))
-            .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.User.LastName))
-            .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.User.MiddleName ?? string.Empty))
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.User.PhoneNumber.Right(Constants.PhoneShortLength)))
-            .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.User.Email))
-            .ForMember(
-                dest => dest.AccountStatus,
-                opt => opt.MapFrom(src =>
-                    src.User.IsBlocked
-                        ? AccountStatus.Blocked
-                        : src.User.LastLogin == DateTimeOffset.MinValue
-                            ? AccountStatus.NeverLogged
-                            : AccountStatus.Accepted));
+            .ForMember(dest => dest.AccountStatus, opt => opt.MapFrom(src => AccountStatusExtensions.Convert(src.User)));
 
         CreateMap<MinistryAdminDto, MinistryAdminBaseDto>()
             .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.Id))
@@ -524,23 +437,11 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.InstitutionTitle, opt => opt.Ignore());
 
         CreateMap<RegionAdmin, RegionAdminDto>()
+            .IncludeBase<IHasUser, BaseUserDto>()
             .ForMember(dest => dest.InstitutionTitle, opt => opt.MapFrom(src => src.Institution.Title))
-            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.User.Id))
-            .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.User.FirstName))
-            .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.User.LastName))
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.User.PhoneNumber.Right(Constants.PhoneShortLength)))
-            .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.User.MiddleName ?? string.Empty))
-            .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.User.Email))
             .ForMember(dest => dest.CATOTTGCategory, opt => opt.MapFrom(src => src.CATOTTG.Category))
             .ForMember(dest => dest.CATOTTGName, opt => opt.MapFrom(src => src.CATOTTG.Name))
-            .ForMember(
-                dest => dest.AccountStatus,
-                opt => opt.MapFrom(src =>
-                    src.User.IsBlocked
-                        ? AccountStatus.Blocked
-                        : src.User.LastLogin == DateTimeOffset.MinValue
-                            ? AccountStatus.NeverLogged
-                            : AccountStatus.Accepted));
+            .ForMember(dest => dest.AccountStatus, opt => opt.MapFrom(src => AccountStatusExtensions.Convert(src.User)));
 
         CreateMap<RegionAdminDto, RegionAdminBaseDto>()
             .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.Id))
@@ -554,29 +455,17 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.CATOTTGName, opt => opt.Ignore());
 
         CreateMap<AreaAdmin, AreaAdminDto>()
-                   .ForMember(dest => dest.InstitutionTitle, opt => opt.MapFrom(src => src.Institution.Title))
-                   .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.User.Id))
-                   .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.User.FirstName))
-                   .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.User.LastName))
-                   .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.User.PhoneNumber.Right(Constants.PhoneShortLength)))
-                   .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.User.MiddleName ?? string.Empty))
-                   .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.User.Email))
-                   .ForMember(dest => dest.CATOTTGCategory, opt => opt.MapFrom(src => src.CATOTTG.Category))
-                   .ForMember(dest => dest.CATOTTGName, opt => opt.MapFrom(src => src.CATOTTG.Name))
-                   .ForMember(dest => dest.RegionId, opt => opt.MapFrom(src => src.CATOTTG != null ? src.CATOTTG.Parent != null ? src.CATOTTG.Parent.Parent != null ? src.CATOTTG.Parent.Parent.Id :0 :0 :0))
-                   .ForMember(dest => dest.RegionName, opt => opt.MapFrom(src => src.CATOTTG != null ? src.CATOTTG.Parent != null ? src.CATOTTG.Parent.Parent != null ? src.CATOTTG.Parent.Parent.Name :String.Empty :String.Empty :String.Empty))
-                   .ForMember(
-                       dest => dest.AccountStatus,
-                       opt => opt.MapFrom(src =>
-                           src.User.IsBlocked
-                               ? AccountStatus.Blocked
-                               : src.User.LastLogin == DateTimeOffset.MinValue
-                                   ? AccountStatus.NeverLogged
-                                   : AccountStatus.Accepted));
+            .IncludeBase<IHasUser, BaseUserDto>()
+            .ForMember(dest => dest.InstitutionTitle, opt => opt.MapFrom(src => src.Institution.Title))
+            .ForMember(dest => dest.CATOTTGCategory, opt => opt.MapFrom(src => src.CATOTTG.Category))
+            .ForMember(dest => dest.CATOTTGName, opt => opt.MapFrom(src => src.CATOTTG.Name))
+            .ForMember(dest => dest.RegionId, opt => opt.MapFrom(src => src.CATOTTG != null ? src.CATOTTG.Parent != null ? src.CATOTTG.Parent.Parent != null ? src.CATOTTG.Parent.Parent.Id : 0 : 0 : 0))
+            .ForMember(dest => dest.RegionName, opt => opt.MapFrom(src => src.CATOTTG != null ? src.CATOTTG.Parent != null ? src.CATOTTG.Parent.Parent != null ? src.CATOTTG.Parent.Parent.Name : string.Empty : string.Empty : string.Empty))
+            .ForMember(dest => dest.AccountStatus, opt => opt.MapFrom(src => AccountStatusExtensions.Convert(src.User)));
 
         CreateMap<AreaAdminDto, AreaAdminBaseDto>()
-                   .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.Id))
-                   .ForMember(dest => dest.CreatingTime, opt => opt.Ignore());
+            .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.CreatingTime, opt => opt.Ignore());
 
         CreateMap<AreaAdminBaseDto, AreaAdminDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.UserId))
@@ -605,16 +494,14 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.InstitutionId, opt => opt.Ignore());
 
         CreateMap<ProviderChangesLogRequest, ChangesLogFilter>()
-            .ForMember(dest => dest.EntityType, opt => opt.Ignore())
+            .ForMember(dest => dest.EntityType, opt => opt.MapFrom(src => "Provider"))
             .ForMember(dest => dest.From, opt => opt.Ignore())
-            .ForMember(dest => dest.Size, opt => opt.MapFrom(o => default(int)))
-            .AfterMap((src, dest) => dest.EntityType = "Provider");
+            .ForMember(dest => dest.Size, opt => opt.MapFrom(o => default(int)));
 
         CreateMap<ApplicationChangesLogRequest, ChangesLogFilter>()
-            .ForMember(dest => dest.EntityType, opt => opt.Ignore())
+            .ForMember(dest => dest.EntityType, opt => opt.MapFrom(src => "Application"))
             .ForMember(dest => dest.From, opt => opt.Ignore())
-            .ForMember(dest => dest.Size, opt => opt.MapFrom(o => default(int)))
-            .AfterMap((src, dest) => dest.EntityType = "Application");
+            .ForMember(dest => dest.Size, opt => opt.MapFrom(o => default(int)));
 
         CreateMap<AchievementType, AchievementTypeDto>();
 
@@ -691,18 +578,12 @@ public class MappingProfile : Profile
         CreateMap<InstitutionStatus, InstitutionStatusDTO>().ReverseMap();
 
         CreateMap<PermissionsForRole, PermissionsForRoleDTO>()
-            .ForMember(
-                dest => dest.Permissions,
-                opt => opt.MapFrom(c => c.PackedPermissions.UnpackPermissionsFromString()));
+            .ForMember(dest => dest.Permissions, opt => opt.MapFrom(c => c.PackedPermissions.UnpackPermissionsFromString()));
         CreateMap<PermissionsForRoleDTO, PermissionsForRole>()
-            .ForMember(
-                dest => dest.PackedPermissions,
-                opt => opt.MapFrom(c => c.Permissions.PackPermissionsIntoString()));
+            .ForMember(dest => dest.PackedPermissions, opt => opt.MapFrom(c => c.Permissions.PackPermissionsIntoString()));
 
         CreateMap<Child, ShortEntityDto>()
-            .ForMember(
-                dest => dest.Title,
-                opt => opt.MapFrom(src => src.LastName + " " + src.FirstName + " " + src.MiddleName));
+            .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.LastName + " " + src.FirstName + " " + src.MiddleName));
 
         CreateMap<Workshop, ShortEntityDto>()
             .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.Title));
@@ -717,58 +598,22 @@ public class MappingProfile : Profile
             });
 
         CreateMap<CATOTTG, CodeficatorAddressDto>()
-            .ForMember(
-                dest => dest.Settlement,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name ? src.Parent.Name : src.Name))
-            .ForMember(
-                dest => dest.TerritorialCommunity,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name ? src.Parent.Parent.Name : src.Parent.Name))
-            .ForMember(
-                dest => dest.District,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name
-                        ? src.Parent.Parent.Parent.Name
-                        : src.Parent.Parent.Name))
-            .ForMember(
-                dest => dest.Region,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name
-                        ? src.Parent.Parent.Parent.Parent.Name
-                        : src.Parent.Parent.Parent.Name))
-            .ForMember(
-                dest => dest.CityDistrict,
-                opt => opt.MapFrom(src => src.Category == CodeficatorCategory.CityDistrict.Name ? src.Name : null));
+            .ForMember(dest => dest.Settlement, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetSettlementName(src)))
+            .ForMember(dest => dest.TerritorialCommunity, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetTerritorialCommunityName(src)))
+            .ForMember(dest => dest.District, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetDistrictName(src)))
+            .ForMember(dest => dest.Region, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetRegionName(src)))
+            .ForMember(dest => dest.CityDistrict, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetCityDistrictName(src)));
 
         CreateMap<CATOTTG, AllAddressPartsDto>()
             .IncludeBase<CATOTTG, CodeficatorAddressDto>()
             .ForMember(dest => dest.AddressParts, opt => opt.MapFrom(src => src));
 
         CreateMap<CATOTTG, CodeficatorAddressInfoDto>()
-             .ForMember(
-                dest => dest.Settlement,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name ? src.Parent.Name : src.Name))
-            .ForMember(
-                dest => dest.TerritorialCommunity,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name ? src.Parent.Parent.Name : src.Parent.Name))
-            .ForMember(
-                dest => dest.District,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name
-                        ? src.Parent.Parent.Parent.Name
-                        : src.Parent.Parent.Name))
-            .ForMember(
-                dest => dest.Region,
-                opt => opt.MapFrom(src =>
-                    src.Category == CodeficatorCategory.CityDistrict.Name
-                        ? src.Parent.Parent.Parent.Parent.Name
-                        : src.Parent.Parent.Parent.Name))
-            .ForMember(
-                dest => dest.CityDistrict,
-                opt => opt.MapFrom(src => src.Category == CodeficatorCategory.CityDistrict.Name ? src.Name : null));
+            .ForMember(dest => dest.Settlement, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetSettlementName(src)))
+            .ForMember(dest => dest.TerritorialCommunity, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetTerritorialCommunityName(src)))
+            .ForMember(dest => dest.District, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetDistrictName(src)))
+            .ForMember(dest => dest.Region, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetRegionName(src)))
+            .ForMember(dest => dest.CityDistrict, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetCityDistrictName(src)));
 
         CreateMap<Provider, ProviderStatusDto>()
             .ForMember(dest => dest.ProviderId, opt => opt.MapFrom(src => src.Id))
@@ -779,9 +624,43 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.SettlementsIds, opt => opt.Ignore());
     }
 
-    private IMappingExpression<TSource, TDestination> CreateSoftDeletedMap<TSource, TDestination>()
+    public IMappingExpression<TSource, TDestination> CreateSoftDeletedMap<TSource, TDestination>()
         where TSource : class
         where TDestination : class, ISoftDeleted
         => CreateMap<TSource, TDestination>()
             .ForMember(dest => dest.IsDeleted, opt => opt.Ignore());
+
+    private IMappingExpression<Provider, T> AddCommonProvider2ProviderBaseDto<T>(IMappingExpression<Provider, T> mappings)
+        where T : ProviderBaseDto
+        => mappings
+            .ForMember(dest => dest.ActualAddress, opt => opt.MapFrom(src => src.ActualAddress))
+            .ForMember(dest => dest.LegalAddress, opt => opt.MapFrom(src => src.LegalAddress))
+            .ForMember(dest => dest.Institution, opt => opt.MapFrom(src => src.Institution))
+            .Apply(IgnoreAllImages)
+            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)))
+        ;
+
+    private IMappingExpression<T, Provider> IgnoreCommonProviderBaseDto2Provider<T>(IMappingExpression<T, Provider> mappings)
+        where T : ProviderBaseDto
+        => mappings
+            .ForMember(dest => dest.Institution, opt => opt.Ignore())
+            .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
+            .ForMember(dest => dest.Status, opt => opt.Ignore())
+            .ForMember(dest => dest.StatusReason, opt => opt.Ignore())
+            .ForMember(dest => dest.LicenseStatus, opt => opt.Ignore())
+        ;
+
+    private IMappingExpression<TSource, TDestination> IgnoreAllImages<TSource, TDestination>(IMappingExpression<TSource, TDestination> mappings)
+        where TDestination : IHasCoverImage, IHasImages
+        => mappings
+            .ForMember(dest => dest.CoverImage, opt => opt.Ignore())
+            .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())
+        ;
+
+    private IMappingExpression<TSource, TDestination> MapImageIds<TSource, TDestination>(IMappingExpression<TSource, TDestination> mappings)
+        where TSource : IHasEntityImages<TSource>
+        where TDestination : IHasImages
+        => mappings
+            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)))
+        ;
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
@@ -459,9 +459,10 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.InstitutionTitle, opt => opt.MapFrom(src => src.Institution.Title))
             .ForMember(dest => dest.CATOTTGCategory, opt => opt.MapFrom(src => src.CATOTTG.Category))
             .ForMember(dest => dest.CATOTTGName, opt => opt.MapFrom(src => src.CATOTTG.Name))
-            .ForMember(dest => dest.RegionId, opt => opt.MapFrom(src => src.CATOTTG != null ? src.CATOTTG.Parent != null ? src.CATOTTG.Parent.Parent != null ? src.CATOTTG.Parent.Parent.Id : 0 : 0 : 0))
-            .ForMember(dest => dest.RegionName, opt => opt.MapFrom(src => src.CATOTTG != null ? src.CATOTTG.Parent != null ? src.CATOTTG.Parent.Parent != null ? src.CATOTTG.Parent.Parent.Name : string.Empty : string.Empty : string.Empty))
-            .ForMember(dest => dest.AccountStatus, opt => opt.MapFrom(src => AccountStatusExtensions.Convert(src.User)));
+            .ForMember(dest => dest.RegionId, opt => opt.MapFrom(src => src.CATOTTG.Parent.Parent.Id))
+            .ForMember(dest => dest.RegionName, opt => opt.MapFrom(src => src.CATOTTG.Parent.Parent.Name))
+            .ForMember(dest => dest.AccountStatus, opt => opt.MapFrom(src => AccountStatusExtensions.Convert(src.User)))
+            .AfterMap((src, dest) => dest.RegionName ??= string.Empty);
 
         CreateMap<AreaAdminDto, AreaAdminBaseDto>()
             .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.Id))
@@ -598,22 +599,22 @@ public class MappingProfile : Profile
             });
 
         CreateMap<CATOTTG, CodeficatorAddressDto>()
-            .ForMember(dest => dest.Settlement, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetSettlementName(src)))
-            .ForMember(dest => dest.TerritorialCommunity, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetTerritorialCommunityName(src)))
-            .ForMember(dest => dest.District, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetDistrictName(src)))
-            .ForMember(dest => dest.Region, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetRegionName(src)))
-            .ForMember(dest => dest.CityDistrict, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetCityDistrictName(src)));
+            .ForMember(dest => dest.Settlement, opt => opt.MapFrom(src => CatottgAddressExtensions.GetSettlementName(src)))
+            .ForMember(dest => dest.TerritorialCommunity, opt => opt.MapFrom(src => CatottgAddressExtensions.GetTerritorialCommunityName(src)))
+            .ForMember(dest => dest.District, opt => opt.MapFrom(src => CatottgAddressExtensions.GetDistrictName(src)))
+            .ForMember(dest => dest.Region, opt => opt.MapFrom(src => CatottgAddressExtensions.GetRegionName(src)))
+            .ForMember(dest => dest.CityDistrict, opt => opt.MapFrom(src => CatottgAddressExtensions.GetCityDistrictName(src)));
 
         CreateMap<CATOTTG, AllAddressPartsDto>()
             .IncludeBase<CATOTTG, CodeficatorAddressDto>()
             .ForMember(dest => dest.AddressParts, opt => opt.MapFrom(src => src));
 
         CreateMap<CATOTTG, CodeficatorAddressInfoDto>()
-            .ForMember(dest => dest.Settlement, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetSettlementName(src)))
-            .ForMember(dest => dest.TerritorialCommunity, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetTerritorialCommunityName(src)))
-            .ForMember(dest => dest.District, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetDistrictName(src)))
-            .ForMember(dest => dest.Region, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetRegionName(src)))
-            .ForMember(dest => dest.CityDistrict, opt => opt.MapFrom(src => CATOTTGAddressExtensions.GetCityDistrictName(src)));
+            .ForMember(dest => dest.Settlement, opt => opt.MapFrom(src => CatottgAddressExtensions.GetSettlementName(src)))
+            .ForMember(dest => dest.TerritorialCommunity, opt => opt.MapFrom(src => CatottgAddressExtensions.GetTerritorialCommunityName(src)))
+            .ForMember(dest => dest.District, opt => opt.MapFrom(src => CatottgAddressExtensions.GetDistrictName(src)))
+            .ForMember(dest => dest.Region, opt => opt.MapFrom(src => CatottgAddressExtensions.GetRegionName(src)))
+            .ForMember(dest => dest.CityDistrict, opt => opt.MapFrom(src => CatottgAddressExtensions.GetCityDistrictName(src)));
 
         CreateMap<Provider, ProviderStatusDto>()
             .ForMember(dest => dest.ProviderId, opt => opt.MapFrom(src => src.Id))

--- a/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
@@ -384,7 +384,7 @@ public class MappingProfile : Profile
         CreateSoftDeletedMap<ShortUserDto, User>()
             .IncludeBase<BaseUserDto, User>()
             .ForMember(dest => dest.Email, opt => opt.Ignore());
-        
+
         CreateMap<IHasUser, BaseUserDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.User.Id))
             .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.User.FirstName))
@@ -638,7 +638,7 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.LegalAddress, opt => opt.MapFrom(src => src.LegalAddress))
             .ForMember(dest => dest.Institution, opt => opt.MapFrom(src => src.Institution))
             .Apply(IgnoreAllImages)
-            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)))
+            .Apply(MapImageIds)
         ;
 
     private IMappingExpression<T, Provider> IgnoreCommonProviderBaseDto2Provider<T>(IMappingExpression<T, Provider> mappings)
@@ -659,8 +659,8 @@ public class MappingProfile : Profile
         ;
 
     private IMappingExpression<TSource, TDestination> MapImageIds<TSource, TDestination>(IMappingExpression<TSource, TDestination> mappings)
-        where TSource : IHasEntityImages<TSource>
-        where TDestination : IHasImages
+        where TSource : class, IHasEntityImages<TSource>
+        where TDestination : class, IHasImages
         => mappings
             .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)))
         ;

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
+using OutOfSchool.Common.Extensions;
 
 namespace OutOfSchool.Tests.Common;
 
@@ -17,6 +18,14 @@ public static class TestHelper
         where TProfile : Profile, new()
     {
         var config = new MapperConfiguration(cfg => cfg.AddProfile<TProfile>());
+        return config.CreateMapper();
+    }
+
+    public static IMapper CreateMapperInstanceOfProfileTypes<TProfile1, TProfile2>()
+        where TProfile1 : Profile, new()
+        where TProfile2 : Profile, new()
+    {
+        var config = new MapperConfiguration(cfg => cfg.UseProfile<TProfile1>().UseProfile<TProfile2>());
         return config.CreateMapper();
     }
 

--- a/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/AdminsUpdateTests/AdminsUpdate.cs
+++ b/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/AdminsUpdateTests/AdminsUpdate.cs
@@ -2,8 +2,10 @@
 using AutoMapper;
 using NUnit.Framework;
 using OutOfSchool.Common.Models;
+using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.IntegrationTests.AdminsUpdateTests;
 
@@ -15,7 +17,7 @@ public class AdminsUpdate
     [SetUp]
     public void SetUp()
     {
-        this.mapper = new Mapper(new MapperConfiguration(cfg => cfg.AddProfile(typeof(MappingProfile))));
+        this.mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
     }
 
     [Test]

--- a/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/ChangeLogControllerTests/ChangeLogControllerTests.cs
+++ b/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/ChangeLogControllerTests/ChangeLogControllerTests.cs
@@ -19,6 +19,7 @@ using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Changes;
 using OutOfSchool.WebApi.Services;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.IntegrationTests.ChangeLogControllerTests;
 
@@ -35,7 +36,7 @@ public class ChangeLogControllerTests
     {
         var context = GetContext();
         parentBlockedByAdminLogRepository = new EntityRepository<long, ParentBlockedByAdminLog>(context);
-        mapper = TestHelper.CreateMapperInstanceOfProfileType<MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         changesLogService = new ChangesLogService(
             new Mock<IOptions<ChangesLogConfig>>().Object,
             new Mock<IChangesLogRepository>().Object,

--- a/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/MappingIntergrationTests/WorkshopMappingTests.cs
+++ b/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/MappingIntergrationTests/WorkshopMappingTests.cs
@@ -4,8 +4,10 @@ using AutoMapper;
 using NUnit.Framework;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Models;
+using OutOfSchool.Tests.Common;
 using OutOfSchool.WebApi.Models.Workshops;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.IntegrationTests.MappingIntergrationTests;
 
@@ -17,8 +19,7 @@ public class WorkshopMappingTests
     [SetUp]
     public void SetUp()
     {
-        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
-        this.mapper = new Mapper(config);
+        this.mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
     }
 
     [Test]

--- a/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/OutOfSchool.WebApi.IntegrationTests.csproj
+++ b/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/OutOfSchool.WebApi.IntegrationTests.csproj
@@ -27,7 +27,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\OutOfSchool.AuthorizationServer\OutOfSchool.AuthorizationServer.csproj" />
         <ProjectReference Include="..\..\OutOfSchool.WebApi.Tests\OutOfSchool.WebApi.Tests.csproj"/>
         <ProjectReference Include="..\..\OutOfSchool.WebApi\OutOfSchool.WebApi.csproj"/>
     </ItemGroup>

--- a/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/OutOfSchool.WebApi.IntegrationTests.csproj
+++ b/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/OutOfSchool.WebApi.IntegrationTests.csproj
@@ -27,6 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\OutOfSchool.AuthorizationServer\OutOfSchool.AuthorizationServer.csproj" />
         <ProjectReference Include="..\..\OutOfSchool.WebApi.Tests\OutOfSchool.WebApi.Tests.csproj"/>
         <ProjectReference Include="..\..\OutOfSchool.WebApi\OutOfSchool.WebApi.csproj"/>
     </ItemGroup>

--- a/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/ProviderServiceIntergrationTests/ProviderServiceUpdate.cs
+++ b/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/ProviderServiceIntergrationTests/ProviderServiceUpdate.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
+using OutOfSchool.Common.Extensions;
 using OutOfSchool.Services;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Repository;
@@ -20,6 +21,7 @@ using OutOfSchool.WebApi.Services.Communication.ICommunication;
 using OutOfSchool.WebApi.Services.Images;
 using OutOfSchool.WebApi.Services.ProviderServices;
 using OutOfSchool.WebApi.Util;
+using OutOfSchool.WebApi.Util.Mapping;
 
 namespace OutOfSchool.WebApi.IntegrationTests.ProviderServiceIntergrationTests;
 
@@ -46,7 +48,7 @@ public class ProviderServiceUpdate
             await context.SaveChangesAsync();
         }
 
-        this.mapper = new Mapper(new MapperConfiguration(cfg => cfg.AddProfile(typeof(MappingProfile))));
+        this.mapper = new Mapper(new MapperConfiguration(cfg => cfg.UseProfile<CommonProfile>().UseProfile<MappingProfile>()));
 
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
         var logger = new Mock<ILogger<ProviderService>>();


### PR DESCRIPTION
This PR tries to address duplicates and wrong code placement issues. 
As a playground mapping profiles area was chosen.

Key takeaways:
- make your models "smart" - logic should reside closer to the model or in extension classes, not in usage sites, because for latter case you'll write same code again and again (see CATOTTG mapping, or usage of `User.LastLogin` and `AccountStatus`);
- when some logic is span over several models - marker interfaces could help a lot (`IHasRatings` ...);
- mapping profiles could be writen in more elgant way using mapping rules from base class, helper methods, etc.

Suggested review process:
- To get a main idea of suggested changes - please check the MappingProfile.cs changes.
- To look through changes step-by-step - it's better to review PR by separate commit.

Notes:
- Not all possible "deduplication" changes were introduced, as PR is already slightly big.
- (Tests for uncovered code will be written here soon) Irrelevant, as it's already covered