### PR TITLE
Adding isBlocked

### DIFF
--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Application.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Application.cs
@@ -20,7 +20,7 @@ public class Application : IKeyedEntity<Guid>, ISoftDeleted
 
     public DateTimeOffset? ApprovedTime { get; set; }
 
-    public bool IsBlocked { get; set; }
+    public bool IsBlockedByProvider { get; set; }
 
     public Guid WorkshopId { get; set; }
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ChatWorkshop/ChatRoomWorkshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ChatWorkshop/ChatRoomWorkshop.cs
@@ -16,7 +16,7 @@ public class ChatRoomWorkshop : IKeyedEntity<Guid>, ISoftDeleted
     [Required]
     public Guid ParentId { get; set; }
 
-    public bool IsBlocked { get; set; }
+    public bool IsBlockedByProvider { get; set; }
 
     public virtual Workshop Workshop { get; set; }
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ChatWorkshop/ModelsForChatLists/ChatRoomWorkshopForChatList.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ChatWorkshop/ModelsForChatLists/ChatRoomWorkshopForChatList.cs
@@ -17,4 +17,6 @@ public class ChatRoomWorkshopForChatList
     public int NotReadByCurrentUserMessagesCount { get; set; }
 
     public ChatMessageInfoForChatList LastMessage { get; set; }
+
+    public bool IsBlocked { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ChatWorkshop/ModelsForChatLists/ChatRoomWorkshopForChatList.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ChatWorkshop/ModelsForChatLists/ChatRoomWorkshopForChatList.cs
@@ -18,5 +18,5 @@ public class ChatRoomWorkshopForChatList
 
     public ChatMessageInfoForChatList LastMessage { get; set; }
 
-    public bool IsBlocked { get; set; }
+    public bool IsBlockedByProvider { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ChatWorkshop/ModelsForChatLists/ParentInfoForChatList.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ChatWorkshop/ModelsForChatLists/ParentInfoForChatList.cs
@@ -20,6 +20,4 @@ public class ParentInfoForChatList
     public string FirstName { get; set; }
 
     public Gender? Gender { get; set; }
-
-    public bool IsBlocked { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/BlockedProviderParentRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/BlockedProviderParentRepository.cs
@@ -53,10 +53,10 @@ public class BlockedProviderParentRepository : SensitiveEntityRepositorySoftDele
     {
         var applications = db.Applications.Where(a => a.ParentId == parentId
                                                       && a.Workshop.ProviderId == providerId);
-        await applications.ForEachAsync(a => a.IsBlocked = block);
+        await applications.ForEachAsync(a => a.IsBlockedByProvider = block);
 
         var chatRooms = db.ChatRoomWorkshops.Where(c => c.ParentId == parentId
                                                         && c.Workshop.ProviderId == providerId);
-        await chatRooms.ForEachAsync(a => a.IsBlocked = block);
+        await chatRooms.ForEachAsync(a => a.IsBlockedByProvider = block);
     }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/ChatRoomWorkshopModelForChatListRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/ChatRoomWorkshopModelForChatListRepository.cs
@@ -103,7 +103,7 @@ public class ChatRoomWorkshopModelForChatListRepository : IChatRoomWorkshopModel
                     Email = item.Parent.User.Email,
                     PhoneNumber = item.Parent.User.PhoneNumber,
                 },
-                    IsBlocked = item.IsBlocked,
+                IsBlocked = item.IsBlocked,
                 LastMessage = item.ChatMessages.Where(mess => !mess.IsDeleted && mess.CreatedDateTime == item.ChatMessages.Where(m => !m.IsDeleted).Max(m => m.CreatedDateTime))
                     .Select(message => new ChatMessageInfoForChatList()
                     {

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/ChatRoomWorkshopModelForChatListRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/ChatRoomWorkshopModelForChatListRepository.cs
@@ -103,7 +103,7 @@ public class ChatRoomWorkshopModelForChatListRepository : IChatRoomWorkshopModel
                     Email = item.Parent.User.Email,
                     PhoneNumber = item.Parent.User.PhoneNumber,
                 },
-                IsBlocked = item.IsBlocked,
+                IsBlockedByProvider = item.IsBlockedByProvider,
                 LastMessage = item.ChatMessages.Where(mess => !mess.IsDeleted && mess.CreatedDateTime == item.ChatMessages.Where(m => !m.IsDeleted).Max(m => m.CreatedDateTime))
                     .Select(message => new ChatMessageInfoForChatList()
                     {

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/ChatRoomWorkshopModelForChatListRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/ChatRoomWorkshopModelForChatListRepository.cs
@@ -102,8 +102,8 @@ public class ChatRoomWorkshopModelForChatListRepository : IChatRoomWorkshopModel
                     Gender = item.Parent.Gender,
                     Email = item.Parent.User.Email,
                     PhoneNumber = item.Parent.User.PhoneNumber,
-                    IsBlocked = item.IsBlocked,
                 },
+                    IsBlocked = item.IsBlocked,
                 LastMessage = item.ChatMessages.Where(mess => !mess.IsDeleted && mess.CreatedDateTime == item.ChatMessages.Where(m => !m.IsDeleted).Max(m => m.CreatedDateTime))
                     .Select(message => new ChatMessageInfoForChatList()
                     {

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240116141813_SpecifiedIsBlockedPropertyName.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240116141813_SpecifiedIsBlockedPropertyName.Designer.cs
@@ -2,17 +2,19 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
 #nullable disable
 
-namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240116141813_SpecifiedIsBlockedPropertyName")]
+    partial class SpecifiedIsBlockedPropertyName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240116141813_SpecifiedIsBlockedPropertyName.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240116141813_SpecifiedIsBlockedPropertyName.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations;
+
+public partial class SpecifiedIsBlockedPropertyName : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.RenameColumn(
+            name: "IsBlocked",
+            table: "ChatRoomWorkshops",
+            newName: "IsBlockedByProvider");
+
+        migrationBuilder.RenameColumn(
+            name: "IsBlocked",
+            table: "Applications",
+            newName: "IsBlockedByProvider");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.RenameColumn(
+            name: "IsBlockedByProvider",
+            table: "ChatRoomWorkshops",
+            newName: "IsBlocked");
+
+        migrationBuilder.RenameColumn(
+            name: "IsBlockedByProvider",
+            table: "Applications",
+            newName: "IsBlocked");
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceMemoryTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceMemoryTests.cs
@@ -136,7 +136,7 @@ public class ApplicationServiceMemoryTests
     public async Task GetApplications_WhenCalled_ShouldReturnBlockedApplications()
     {
         // Arrange
-        var application = GetAllFromMemory().Where(a => a.IsBlocked).ToList();
+        var application = GetAllFromMemory().Where(a => a.IsBlockedByProvider).ToList();
         currentUserServiceMock.Setup(c => c.IsAdmin()).Returns(true);
         currentUserServiceMock.Setup(c => c.IsMinistryAdmin()).Returns(false);
         currentUserServiceMock.Setup(c => c.IsRegionAdmin()).Returns(false);
@@ -146,14 +146,14 @@ public class ApplicationServiceMemoryTests
 
         // Assert
         Assert.AreEqual(result.Entities.Count, application.Count);
-        Assert.IsTrue(result.Entities.All(a => a.IsBlocked));
+        Assert.IsTrue(result.Entities.All(a => a.IsBlockedByProvider));
     }
 
     [Test]
     public async Task GetApplications_WhenCalled_ShouldReturnUnblockedApplications()
     {
         // Arrange
-        var application = GetAllFromMemory().Where(a => !a.IsBlocked).ToList();
+        var application = GetAllFromMemory().Where(a => !a.IsBlockedByProvider).ToList();
         currentUserServiceMock.Setup(c => c.IsAdmin()).Returns(true);
         currentUserServiceMock.Setup(c => c.IsMinistryAdmin()).Returns(false);
         currentUserServiceMock.Setup(c => c.IsRegionAdmin()).Returns(false);
@@ -163,7 +163,7 @@ public class ApplicationServiceMemoryTests
 
         // Assert
         Assert.AreEqual(result.Entities.Count, application.Count);
-        Assert.IsTrue(result.Entities.All(a => !a.IsBlocked));
+        Assert.IsTrue(result.Entities.All(a => !a.IsBlockedByProvider));
     }
 
     private void SeedDatabase()
@@ -191,7 +191,7 @@ public class ApplicationServiceMemoryTests
                 new Application()
                 {
                     Id = new Guid("1745d16a-6181-43d7-97d0-a1d6cc34a8db"),
-                    IsBlocked = false,
+                    IsBlockedByProvider = false,
                     Status = ApplicationStatus.Pending,
                     WorkshopId = workshop.Id,
                     ChildId = child.Id,
@@ -200,7 +200,7 @@ public class ApplicationServiceMemoryTests
                 new Application()
                 {
                     Id = new Guid("7c5f8f7c-d850-44d0-8d4e-fd2de99453be"),
-                    IsBlocked = false,
+                    IsBlockedByProvider = false,
                     Status = ApplicationStatus.Rejected,
                     WorkshopId = workshop.Id,
                     ChildId = child.Id,
@@ -209,7 +209,7 @@ public class ApplicationServiceMemoryTests
                 new Application()
                 {
                     Id = new Guid("0083633f-4e5b-4c09-a89d-52d8a9b89cdb"),
-                    IsBlocked = true,
+                    IsBlockedByProvider = true,
                     Status = ApplicationStatus.Pending,
                     WorkshopId = workshop.Id,
                     ChildId = child.Id,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
@@ -1211,7 +1211,7 @@ public class ApplicationServiceTests
             new Application()
             {
                 Id = new Guid("1745d16a-6181-43d7-97d0-a1d6cc34a8db"),
-                IsBlocked = false,
+                IsBlockedByProvider = false,
                 Status = ApplicationStatus.Pending,
                 WorkshopId = new Guid("953708d7-8c35-4607-bd9b-f034e853bb89"),
                 ChildId = new Guid("64988abc-776a-4ff8-961c-ba73c7db1986"),
@@ -1238,7 +1238,7 @@ public class ApplicationServiceTests
             new Application()
             {
                 Id = new Guid("7c5f8f7c-d850-44d0-8d4e-fd2de99453be"),
-                IsBlocked = false,
+                IsBlockedByProvider = false,
                 Status = ApplicationStatus.Rejected,
                 WorkshopId = new Guid("953708d7-8c35-4607-bd9b-f034e853bb89"),
                 ChildId = new Guid("64988abc-776a-4ff8-961c-ba73c7db1986"),
@@ -1265,7 +1265,7 @@ public class ApplicationServiceTests
             new Application()
             {
                 Id = new Guid("0083633f-4e5b-4c09-a89d-52d8a9b89cdb"),
-                IsBlocked = true,
+                IsBlockedByProvider = true,
                 Status = ApplicationStatus.Pending,
                 WorkshopId = new Guid("953708d7-8c35-4607-bd9b-f034e853bb89"),
                 ChildId = new Guid("64988abc-776a-4ff8-961c-ba73c7db1986"),

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/BlockedProviderParentRepositoryTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/BlockedProviderParentRepositoryTests.cs
@@ -19,7 +19,7 @@ public class BlockedProviderParentRepositoryTests
     private List<Parent> parents;
     private List<Provider> providers;
     private List<Workshop> workshops;
-    private List<Application> aplications;
+    private List<Application> applications;
     private List<ChatRoomWorkshop> chatRooms;
 
     [SetUp]
@@ -97,7 +97,7 @@ public class BlockedProviderParentRepositoryTests
     }
 
     [Test]
-    public async Task Block_ShouldBlockApplicaionAndChatRoomWorkshop()
+    public async Task Block_ShouldBlockApplicationAndChatRoomWorkshop()
     {
         // Arrange
         using var context = GetContext();
@@ -113,7 +113,7 @@ public class BlockedProviderParentRepositoryTests
             UserIdBlock = "TestId",
         };
 
-        var expectedBlockedAplications = context.Applications.Count(a => a.IsBlockedByProvider) + 1;
+        var expectedBlockedApplications = context.Applications.Count(a => a.IsBlockedByProvider) + 1;
         var expectedBlockedChatRooms = context.ChatRoomWorkshops.Count(c => c.IsBlockedByProvider) + 1;
         var aplication = context.Applications.FirstOrDefault(
             a => a.ParentId == parentId &&
@@ -128,14 +128,14 @@ public class BlockedProviderParentRepositoryTests
 
         // Assert
         Assert.That(result is not null);
-        Assert.AreEqual(expectedBlockedAplications, context.Applications.Count(a => a.IsBlockedByProvider));
+        Assert.AreEqual(expectedBlockedApplications, context.Applications.Count(a => a.IsBlockedByProvider));
         Assert.AreEqual(expectedBlockedChatRooms, context.ChatRoomWorkshops.Count(c => c.IsBlockedByProvider));
         Assert.True(aplication.IsBlockedByProvider);
         Assert.True(chatRoom.IsBlockedByProvider);
     }
 
     [Test]
-    public async Task UnBlock_ShouldUnBlockApplicaionAndChatRoomWorkshop()
+    public async Task UnBlock_ShouldUnBlockApplicationAndChatRoomWorkshop()
     {
         // Arrange
         using var context = GetContext();
@@ -153,7 +153,7 @@ public class BlockedProviderParentRepositoryTests
 
         await repository.Block(blockedProviderParent);
 
-        var expectedUnBlockedAplications = context.Applications.Count(a => !a.IsBlockedByProvider) + 1;
+        var expectedUnBlockedApplications = context.Applications.Count(a => !a.IsBlockedByProvider) + 1;
         var expectedUnBlockedChatRooms = context.ChatRoomWorkshops.Count(c => !c.IsBlockedByProvider) + 1;
         var aplication = context.Applications.FirstOrDefault(
             a => a.ParentId == parentId &&
@@ -176,7 +176,7 @@ public class BlockedProviderParentRepositoryTests
 
         // Assert
         Assert.That(result is not null);
-        Assert.AreEqual(expectedUnBlockedAplications, context.Applications.Count(a => !a.IsBlockedByProvider));
+        Assert.AreEqual(expectedUnBlockedApplications, context.Applications.Count(a => !a.IsBlockedByProvider));
         Assert.AreEqual(expectedUnBlockedChatRooms, context.ChatRoomWorkshops.Count(c => !c.IsBlockedByProvider));
         Assert.False(aplication.IsBlockedByProvider);
         Assert.False(chatRoom.IsBlockedByProvider);
@@ -204,12 +204,12 @@ public class BlockedProviderParentRepositoryTests
         workshops[1].ProviderId = providers[1].Id;
         context.AddRange(workshops);
 
-        aplications = ApplicationGenerator.Generate(2);
-        aplications[0].Workshop = workshops[0];
-        aplications[1].Workshop = workshops[1];
-        aplications[0].ParentId = parents[0].Id;
-        aplications[1].ParentId = parents[1].Id;
-        context.AddRange(aplications);
+        applications = ApplicationGenerator.Generate(2);
+        applications[0].Workshop = workshops[0];
+        applications[1].Workshop = workshops[1];
+        applications[0].ParentId = parents[0].Id;
+        applications[1].ParentId = parents[1].Id;
+        context.AddRange(applications);
 
         chatRooms = new List<ChatRoomWorkshop>
         {

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/BlockedProviderParentRepositoryTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/BlockedProviderParentRepositoryTests.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using OutOfSchool.Services;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Services.Models.ChatWorkshop;
+using OutOfSchool.Services.Repository;
+using OutOfSchool.Tests.Common.TestDataGenerators;
+
+namespace OutOfSchool.WebApi.Tests.Services.Database;
+
+[TestFixture]
+public class BlockedProviderParentRepositoryTests
+{
+    private DbContextOptions<OutOfSchoolDbContext> dbContextOptions;
+    private List<Parent> parents;
+    private List<Provider> providers;
+    private List<Workshop> workshops;
+    private List<Application> aplications;
+    private List<ChatRoomWorkshop> chatRooms;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        dbContextOptions = new DbContextOptionsBuilder<OutOfSchoolDbContext>()
+            .UseInMemoryDatabase(databaseName: "OutOfSchoolTestDB")
+            .Options;
+
+        await Seed();
+    }
+
+    [Test]
+    public async Task Block_ShouldAddBlockedProviderParentModelToDatabase()
+    {
+        // Arrange
+        using var context = GetContext();
+        var repository = GetRepository(context);
+        var blockedProviderParent = new BlockedProviderParent
+        {
+            Id = Guid.NewGuid(),
+            ParentId = Guid.NewGuid(),
+            ProviderId = Guid.NewGuid(),
+            Reason = "Test",
+            UserIdBlock = "TestId",
+        };
+
+        var expectedBlockedProviderParentCount = context.BlockedProviderParents.Count() + 1;
+
+        // Act
+        var result = await repository.Block(blockedProviderParent);
+
+        // Assert
+        Assert.AreEqual(expectedBlockedProviderParentCount, context.BlockedProviderParents.Count());
+        Assert.That(result is not null);
+        Assert.AreEqual(result.Id, blockedProviderParent.Id);
+        Assert.That(result.DateTimeTo is null);
+    }
+
+    [Test]
+    public async Task UnBlock_ShouldModifyBlockedProviderParentDateTimeToProperty()
+    {
+        // Arrange
+        using var context = GetContext();
+        var repository = GetRepository(context);
+        var blockedProviderParent = new BlockedProviderParent
+        {
+            Id = Guid.NewGuid(),
+            ParentId = Guid.NewGuid(),
+            ProviderId = Guid.NewGuid(),
+            Reason = "Test",
+            UserIdBlock = "TestId",
+        };
+        var expectedBlockedProviderParentCount = context.BlockedProviderParents.Count() + 1;
+
+        await repository.Block(blockedProviderParent);
+
+        var blockedProviderParentToUnblock = new BlockedProviderParent
+        {
+            Id = blockedProviderParent.Id,
+            ParentId = blockedProviderParent.ParentId,
+            ProviderId = blockedProviderParent.ProviderId,
+            DateTimeTo = DateTime.Now,
+            UserIdUnblock = "TestId",
+        };
+
+        // Act
+        var result = await repository.UnBlock(blockedProviderParentToUnblock);
+
+        // Assert
+        Assert.AreEqual(expectedBlockedProviderParentCount, context.BlockedProviderParents.Count());
+        Assert.That(result is not null);
+        Assert.AreEqual(result.Id, blockedProviderParentToUnblock.Id);
+        Assert.That(result.DateTimeTo is not null);
+    }
+
+    [Test]
+    public async Task Block_ShouldBlockApplicaionAndChatRoomWorkshop()
+    {
+        // Arrange
+        using var context = GetContext();
+        var repository = GetRepository(context);
+        var parentId = parents[0].Id;
+        var providerId = providers[0].Id;
+        var blockedProviderParent = new BlockedProviderParent
+        {
+            Id = Guid.NewGuid(),
+            ParentId = parentId,
+            ProviderId = providerId,
+            Reason = "Test",
+            UserIdBlock = "TestId",
+        };
+
+        var expectedBlockedAplications = context.Applications.Count(a => a.IsBlockedByProvider) + 1;
+        var expectedBlockedChatRooms = context.ChatRoomWorkshops.Count(c => c.IsBlockedByProvider) + 1;
+        var aplication = context.Applications.FirstOrDefault(
+            a => a.ParentId == parentId &&
+            a.Workshop.ProviderId == providerId);
+
+        var chatRoom = context.ChatRoomWorkshops.FirstOrDefault(
+            c => c.ParentId == parentId &&
+            c.Workshop.ProviderId == providerId);
+
+        // Act
+        var result = await repository.Block(blockedProviderParent);
+
+        // Assert
+        Assert.That(result is not null);
+        Assert.AreEqual(expectedBlockedAplications, context.Applications.Count(a => a.IsBlockedByProvider));
+        Assert.AreEqual(expectedBlockedChatRooms, context.ChatRoomWorkshops.Count(c => c.IsBlockedByProvider));
+        Assert.True(aplication.IsBlockedByProvider);
+        Assert.True(chatRoom.IsBlockedByProvider);
+    }
+
+    [Test]
+    public async Task UnBlock_ShouldUnBlockApplicaionAndChatRoomWorkshop()
+    {
+        // Arrange
+        using var context = GetContext();
+        var repository = GetRepository(context);
+        var parentId = parents[1].Id;
+        var providerId = providers[1].Id;
+        var blockedProviderParent = new BlockedProviderParent
+        {
+            Id = Guid.NewGuid(),
+            ParentId = parentId,
+            ProviderId = providerId,
+            Reason = "Test",
+            UserIdBlock = "TestId",
+        };
+
+        await repository.Block(blockedProviderParent);
+
+        var expectedUnBlockedAplications = context.Applications.Count(a => !a.IsBlockedByProvider) + 1;
+        var expectedUnBlockedChatRooms = context.ChatRoomWorkshops.Count(c => !c.IsBlockedByProvider) + 1;
+        var aplication = context.Applications.FirstOrDefault(
+            a => a.ParentId == parentId &&
+            a.Workshop.ProviderId == providerId);
+
+        var chatRoom = context.ChatRoomWorkshops.FirstOrDefault(
+            c => c.ParentId == parentId &&
+            c.Workshop.ProviderId == providerId);
+
+        var unBlockedProviderParent = new BlockedProviderParent
+        {
+            Id = blockedProviderParent.Id,
+            ParentId = parentId,
+            ProviderId = providerId,
+            DateTimeTo = DateTime.Now,
+        };
+
+        // Act
+        var result = await repository.UnBlock(unBlockedProviderParent);
+
+        // Assert
+        Assert.That(result is not null);
+        Assert.AreEqual(expectedUnBlockedAplications, context.Applications.Count(a => !a.IsBlockedByProvider));
+        Assert.AreEqual(expectedUnBlockedChatRooms, context.ChatRoomWorkshops.Count(c => !c.IsBlockedByProvider));
+        Assert.False(aplication.IsBlockedByProvider);
+        Assert.False(chatRoom.IsBlockedByProvider);
+    }
+
+    private OutOfSchoolDbContext GetContext() => new OutOfSchoolDbContext(dbContextOptions);
+
+    private IBlockedProviderParentRepository GetRepository(OutOfSchoolDbContext dbContext)
+        => new BlockedProviderParentRepository(dbContext);
+
+    private async Task Seed()
+    {
+        using var context = GetContext();
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+
+        parents = ParentGenerator.Generate(2);
+        context.AddRange(parents);
+
+        providers = ProvidersGenerator.Generate(2);
+        context.AddRange(providers);
+
+        workshops = WorkshopGenerator.Generate(2);
+        workshops[0].ProviderId = providers[0].Id;
+        workshops[1].ProviderId = providers[1].Id;
+        context.AddRange(workshops);
+
+        aplications = ApplicationGenerator.Generate(2);
+        aplications[0].Workshop = workshops[0];
+        aplications[1].Workshop = workshops[1];
+        aplications[0].ParentId = parents[0].Id;
+        aplications[1].ParentId = parents[1].Id;
+        context.AddRange(aplications);
+
+        chatRooms = new List<ChatRoomWorkshop>
+        {
+            new ChatRoomWorkshop()
+            {
+                Id = Guid.NewGuid(),
+                Workshop = workshops[0],
+                ParentId = parents[0].Id,
+            },
+            new ChatRoomWorkshop()
+            {
+                Id = Guid.NewGuid(),
+                Workshop = workshops[1],
+                ParentId = parents[1].Id,
+            },
+        };
+        context.AddRange(chatRooms);
+
+        await context.SaveChangesAsync();
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ApplicationController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ApplicationController.cs
@@ -29,6 +29,7 @@ public class ApplicationController : ControllerBase
     /// <param name="providerAdminService">Service for ProviderAdmin model.</param>
     /// <param name="workshopService">Service for Workshop model.</param>
     /// <param name="userService">Service for operations with users.</param>
+    /// <param name="blockedProviderParentService">Service for blocking parents for providers.</param>
     public ApplicationController(
         IApplicationService applicationService,
         IProviderService providerService,

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Application/ApplicationDTO.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Application/ApplicationDTO.cs
@@ -18,7 +18,7 @@ public class ApplicationDto
 
     public DateTimeOffset? ApprovedTime { get; set; }
 
-    public bool IsBlocked { get; set; }
+    public bool IsBlockedByProvider { get; set; }
 
     [Required]
     public Guid WorkshopId { get; set; }

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ChatWorkshop/ChatRoomWorkshopDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ChatWorkshop/ChatRoomWorkshopDto.cs
@@ -8,7 +8,7 @@ public class ChatRoomWorkshopDto
 
     public Guid ParentId { get; set; }
 
-    public bool IsBlocked { get; set; }
+    public bool IsBlockedByProvider { get; set; }
 
     public WorkshopInfoForChatListDto Workshop { get; set; }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ChatWorkshop/ChatRoomWorkshopDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ChatWorkshop/ChatRoomWorkshopDto.cs
@@ -8,6 +8,8 @@ public class ChatRoomWorkshopDto
 
     public Guid ParentId { get; set; }
 
+    public bool IsBlocked { get; set; }
+
     public WorkshopInfoForChatListDto Workshop { get; set; }
 
     public ParentDtoWithContactInfo Parent { get; set; }

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ApplicationService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ApplicationService.cs
@@ -633,7 +633,7 @@ public class ApplicationService : IApplicationService, INotificationReciever
 
         if (filter.Show != ShowApplications.All)
         {
-            predicate = predicate.And(a => a.IsBlocked == (filter.Show == ShowApplications.Blocked));
+            predicate = predicate.And(a => a.IsBlockedByProvider == (filter.Show == ShowApplications.Blocked));
         }
 
         return predicate;
@@ -646,7 +646,7 @@ public class ApplicationService : IApplicationService, INotificationReciever
 
         if (filter.Show == ShowApplications.All)
         {
-            sortExpression.Add(a => a.IsBlocked, SortDirection.Ascending);
+            sortExpression.Add(a => a.IsBlockedByProvider, SortDirection.Ascending);
         }
 
         if (filter.OrderByStatus)

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ChatRoomWorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ChatRoomWorkshopService.cs
@@ -1,9 +1,8 @@
-﻿using AutoMapper;
-
+﻿using System.Linq.Expressions;
+using AutoMapper;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.ChatWorkshop;
-using System.Linq.Expressions;
 
 namespace OutOfSchool.WebApi.Services;
 
@@ -16,6 +15,7 @@ public class ChatRoomWorkshopService : IChatRoomWorkshopService
     private readonly IChatRoomWorkshopModelForChatListRepository roomWorkshopWithLastMessageRepository;
     private readonly ILogger<ChatRoomWorkshopService> logger;
     private readonly IMapper mapper;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ChatRoomWorkshopService"/> class.
     /// </summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
@@ -540,6 +540,7 @@ public class MappingProfile : Profile
 
         CreateMap<ParentInfoForChatList, ParentDtoWithContactInfo>()
             .ForMember(dest => dest.EmailConfirmed, opt => opt.Ignore())
+            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
             .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.MiddleName ?? string.Empty));
 
         CreateMap<ChatMessageInfoForChatList, ChatMessageWorkshopDto>();


### PR DESCRIPTION
Added IsBlockedByProvider property to ChatRoomWorkshopDto
Moved IsBlocked property from ParentInfoForChatList to ChatRoomWorkshopForChatList and renamed to IsBlockedByProvider to avoid misunderstanding because when parent isBlocked it means that user is blocked for service ( as it is in ParentDtoWithContactInfo ) and when user is blocked by provider, then ChatRoomWorkshop IsBlocked(now IsBlockedByProvider) becomes true. So chat IsBlocked(now IsBlockedByProvider) is for blocking by provider, and parent IsBlocked is for blocking by admins
Also renamed same property for aplications for same reason