### PR TITLE
Tsylia / Fix block/unblock service provider by admins

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
@@ -837,6 +837,15 @@ public class ProviderServiceTests
     #region Block
 
     [Test]
+    public void Block_ReturnsArgumentNullException_IfDtoIsNull()
+    {
+        // Arrange
+
+        // Act, Assert
+        Assert.ThrowsAsync<ArgumentNullException>(async () => await providerService.Block(null).ConfigureAwait(false));
+    }
+
+    [Test]
     public async Task Block_ReturnsNull_IfDtoIsNotValid()
     {
         // Arrange

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderServices/IProviderService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderServices/IProviderService.cs
@@ -95,10 +95,7 @@ public interface IProviderService
     /// <param name="addStatusData"></param>
     /// <param name="addLicenseStatusData"></param>
     /// <returns></returns>
-    void SendNotification(Provider provider,
-        NotificationAction notificationAction,
-        bool addStatusData,
-        bool addLicenseStatusData);
+    Task SendNotification(Provider provider, NotificationAction notificationAction, bool addStatusData, bool addLicenseStatusData);
 
     /// <summary>
     /// Updates workshop's provider status

--- a/OutOfSchool/OutOfSchool.WebApi/Services/ProviderServices/ProviderService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Services/ProviderServices/ProviderService.cs
@@ -364,7 +364,7 @@ public class ProviderService : IProviderService, INotificationReciever
             logger.LogInformation($"Provider(id) {providerBlockDto.Id} IsBlocked was changed to {provider.IsBlocked}");
         });
 
-        SendNotification(provider, providerBlockDto.IsBlocked ? NotificationAction.Block : NotificationAction.Unblock, false, false);
+        await SendNotification(provider, providerBlockDto.IsBlocked ? NotificationAction.Block : NotificationAction.Unblock, false, false);
 
         logger.LogInformation("Block/Unblock the particular provider admins and deputy providers belonging to the Provider starts.");
 
@@ -390,7 +390,7 @@ public class ProviderService : IProviderService, INotificationReciever
         return (await providerRepository.GetById(providerId).ConfigureAwait(false))?.IsBlocked;
     }
 
-    public void SendNotification(Provider provider, NotificationAction notificationAction, bool addStatusData, bool addLicenseStatusData)
+    public async Task SendNotification(Provider provider, NotificationAction notificationAction, bool addStatusData, bool addLicenseStatusData)
     {
         if (provider == null)
         {
@@ -409,7 +409,7 @@ public class ProviderService : IProviderService, INotificationReciever
             additionalData.Add("LicenseStatus", provider.LicenseStatus.ToString());
         }
 
-        notificationService.Create(
+        await notificationService.Create(
                 NotificationType.Provider,
                 notificationAction,
                 provider.Id,


### PR DESCRIPTION
- made the SendNotification method in the ProviderService asynchronous to ensure proper functionality of the ServiceProvider\Block endpoint;
- in the previous pullrequests the Provider\StatusUpdate endpoint was moved to a new one PublicProviderController\StatusUpdate for the state providers (to approve or send it for editing) and to a new one PrivateProviderController\LicenseStatusUpdate for the private providers.