### PR TITLE
Explicitly specify content type & frombody attribute

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AchievementController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AchievementController.cs
@@ -100,7 +100,7 @@ public class AchievementController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> Create(AchievementCreateDTO achievementDto)
+    public async Task<IActionResult> Create([FromBody] AchievementCreateDTO achievementDto)
     {
         if (achievementDto == null)
         {
@@ -162,12 +162,13 @@ public class AchievementController : ControllerBase
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.WorkshopEdit)]
     [HttpPut]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(AchievementDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult> Update(AchievementCreateDTO achievementDto)
+    public async Task<ActionResult> Update([FromBody] AchievementCreateDTO achievementDto)
     {
         var providerId = await providerService.GetProviderIdForWorkshopById(achievementDto.WorkshopId).ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ApplicationController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ApplicationController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.WebApi.Common;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Application;
@@ -282,6 +283,7 @@ public class ApplicationController : ControllerBase
     /// <response code="429">If too many requests have been sent.</response>
     /// <response code="500">If any server error occurs.</response>
     [HasPermission(Permissions.ApplicationAddNew)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(ApplicationDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -289,7 +291,7 @@ public class ApplicationController : ControllerBase
     [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<IActionResult> Create(ApplicationCreate applicationDto)
+    public async Task<IActionResult> Create([FromBody] ApplicationCreate applicationDto)
     {
         if (applicationDto == null)
         {
@@ -359,12 +361,13 @@ public class ApplicationController : ControllerBase
     /// <response code="401">If the user is not authorized.</response>
     /// <response code="500">If any server error occurres.</response>
     [HasPermission(Permissions.ApplicationEdit)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ApplicationDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
-    public async Task<IActionResult> Update(ApplicationUpdate applicationDto)
+    public async Task<IActionResult> Update([FromBody] ApplicationUpdate applicationDto)
     {
         if (applicationDto is null)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AreaAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AreaAdminController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -116,6 +117,7 @@ public class AreaAdminController : Controller
     /// </summary>
     /// <param name="areaAdminBase">Entity to add.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(AreaAdminBaseDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -124,7 +126,7 @@ public class AreaAdminController : Controller
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HasPermission(Permissions.AreaAdminAddNew)]
     [HttpPost]
-    public async Task<ActionResult> Create(AreaAdminBaseDto areaAdminBase)
+    public async Task<ActionResult> Create([FromBody] AreaAdminBaseDto areaAdminBase)
     {
         logger.LogDebug($"User(id): {currentUserId}");
 
@@ -172,13 +174,14 @@ public class AreaAdminController : Controller
     /// </summary>
     /// <param name="updateAreaAdminDto">BaseUserDto object with new properties.</param>
     /// <returns>AreaAdmin's key.</returns>
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(AreaAdminDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HasPermission(Permissions.AreaAdminEdit)]
     [HttpPut]
-    public async Task<ActionResult> Update(BaseUserDto updateAreaAdminDto)
+    public async Task<ActionResult> Update([FromBody] BaseUserDto updateAreaAdminDto)
     {
         if (updateAreaAdminDto == null)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/BlockedProviderParentController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/BlockedProviderParentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.WebApi.Models.BlockedProviderParent;
 using OutOfSchool.WebApi.Services.ProviderServices;
 
@@ -44,11 +45,12 @@ public class BlockedProviderParentController : ControllerBase
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.ProviderAdmins)]
     [HttpPost]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(BlockedProviderParentDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> Block(BlockedProviderParentBlockDto blockedProviderParentBlockDto)
+    public async Task<IActionResult> Block([FromBody] BlockedProviderParentBlockDto blockedProviderParentBlockDto)
     {
         if (blockedProviderParentBlockDto == null)
         {
@@ -91,11 +93,12 @@ public class BlockedProviderParentController : ControllerBase
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.ProviderAdmins)]
     [HttpPost]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(BlockedProviderParentDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> UnBlock(BlockedProviderParentUnblockDto blockedProviderParentUnblockDto)
+    public async Task<IActionResult> UnBlock([FromBody] BlockedProviderParentUnblockDto blockedProviderParentUnblockDto)
     {
         if (blockedProviderParentUnblockDto == null)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ChildController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ChildController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.WebApi.Common;
 using OutOfSchool.WebApi.Models;
@@ -198,13 +199,14 @@ public class ChildController : ControllerBase
     /// <param name="childCreateDto">Child entity to add.</param>
     /// <returns>The child that was created.</returns>
     [HasPermission(Permissions.ChildAddNew)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(ChildDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<IActionResult> Create(ChildCreateDto childCreateDto)
+    public async Task<IActionResult> Create([FromBody] ChildCreateDto childCreateDto)
     {
         string userId = GettingUserProperties.GetUserId(User);
 
@@ -222,13 +224,14 @@ public class ChildController : ControllerBase
     /// <param name="childrenCreateDtos">The list of the children entities to add.</param>
     /// <returns>The list of the children that were created.</returns>
     [HasPermission(Permissions.ChildAddNew)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(ChildDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost("batch")]
-    public async Task<IActionResult> CreateChildren(List<ChildCreateDto> childrenCreateDtos)
+    public async Task<IActionResult> CreateChildren([FromBody] List<ChildCreateDto> childrenCreateDtos)
     {
         string userId = GettingUserProperties.GetUserId(User);
 
@@ -248,13 +251,14 @@ public class ChildController : ControllerBase
     /// <param name="id">Child's Id.</param>
     /// <returns>The child that was updated.</returns>
     [HasPermission(Permissions.ChildEdit)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ChildDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut("{id}")]
-    public async Task<IActionResult> Update(ChildUpdateDto dto, Guid id)
+    public async Task<IActionResult> Update([FromBody] ChildUpdateDto dto, Guid id)
     {
         string userId = GettingUserProperties.GetUserId(User);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CompanyInformationController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CompanyInformationController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.WebApi.Models;
@@ -58,12 +59,13 @@ public abstract class CompanyInformationController : ControllerBase
     /// <param name="companyInformationModel">Entity to update.</param>
     /// <returns>Updated information about CompanyInformation.</returns>
     [HasPermission(Permissions.SystemManagement)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CompanyInformationDto))]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
-    public async Task<IActionResult> Update(CompanyInformationDto companyInformationModel)
+    public async Task<IActionResult> Update([FromBody] CompanyInformationDto companyInformationModel)
     {
         if (!ModelState.IsValid)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/DirectionController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/DirectionController.cs
@@ -105,7 +105,7 @@ public class DirectionController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> Create(DirectionDto directionDto)
+    public async Task<IActionResult> Create([FromBody] DirectionDto directionDto)
     {
         if (!ModelState.IsValid)
         {
@@ -140,12 +140,13 @@ public class DirectionController : ControllerBase
     /// <response code="403">If the user has no rights to use this method.</response>
     /// <response code="500">If any server error occures.</response>
     [HttpPut]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DirectionDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult> Update(DirectionDto directionDto)
+    public async Task<ActionResult> Update([FromBody] DirectionDto directionDto)
     {
         if (!ModelState.IsValid)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/FavoriteController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/FavoriteController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Models.Workshops;
@@ -114,12 +115,13 @@ public class FavoriteController : ControllerBase
     /// <param name="dto">Favorite entity to add.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
     [HasPermission(Permissions.FavoriteAddNew)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<IActionResult> Create(FavoriteDto dto)
+    public async Task<IActionResult> Create([FromBody] FavoriteDto dto)
     {
         var favorite = await service.Create(dto).ConfigureAwait(false);
 
@@ -135,12 +137,13 @@ public class FavoriteController : ControllerBase
     /// <param name="dto">Favorite to update.</param>
     /// <returns>Favorite.</returns>
     [HasPermission(Permissions.FavoriteEdit)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
-    public async Task<IActionResult> Update(FavoriteDto dto)
+    public async Task<IActionResult> Update([FromBody] FavoriteDto dto)
     {
         return Ok(await service.Update(dto).ConfigureAwait(false));
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/GeocodingController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/GeocodingController.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.Common.Models;
 using OutOfSchool.WebApi.Models.Geocoding;
@@ -24,12 +25,13 @@ public class GeocodingController : Controller
     /// </summary>
     /// <param name="request">Coordinates query.</param>
     /// <returns> The geocoding information about address or coordinates. </returns>
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<GeocodingResponse>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<IActionResult> Geocoding(GeocodingRequest? request)
+    public async Task<IActionResult> Geocoding([FromBody] GeocodingRequest? request)
     {
         if (request is null)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/InstitutionStatusController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/InstitutionStatusController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using OutOfSchool.WebApi.Enums;
 using OutOfSchool.WebApi.Models;
@@ -79,12 +80,13 @@ public class InstitutionStatusController : ControllerBase
     /// <param name="dto">Institution Status entity to add.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
     [HasPermission(Permissions.SystemManagement)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<IActionResult> Create(InstitutionStatusDTO dto)
+    public async Task<IActionResult> Create([FromBody] InstitutionStatusDTO dto)
     {
         var institutionStatus = await service.Create(dto).ConfigureAwait(false);
 
@@ -101,12 +103,13 @@ public class InstitutionStatusController : ControllerBase
     /// <param name="localization">Localization: Ua - 0, En - 1.</param>
     /// <returns>Institution Status.</returns>
     [HasPermission(Permissions.SystemManagement)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InstitutionStatusDTO))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
-    public async Task<IActionResult> Update(InstitutionStatusDTO dto, LocalizationType localization = LocalizationType.Ua)
+    public async Task<IActionResult> Update([FromBody] InstitutionStatusDTO dto, LocalizationType localization = LocalizationType.Ua)
     {
         var institutionStatus = await service.Update(dto).ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/MinistryAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/MinistryAdminController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authentication;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
@@ -117,6 +118,7 @@ public class MinistryAdminController : Controller
     /// </summary>
     /// <param name="ministryAdminBase">Entity to add.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(MinistryAdminBaseDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -125,7 +127,7 @@ public class MinistryAdminController : Controller
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HasPermission(Permissions.MinistryAdminAddNew)]
     [HttpPost]
-    public async Task<ActionResult> Create(MinistryAdminBaseDto ministryAdminBase)
+    public async Task<ActionResult> Create([FromBody] MinistryAdminBaseDto ministryAdminBase)
     {
         logger.LogDebug("{Path} started. User(id): {UserId}", path, userId);
 
@@ -158,11 +160,12 @@ public class MinistryAdminController : Controller
     /// <returns>MinistryAdmin's key.</returns>
     [HasPermission(Permissions.MinistryAdminEdit)]
     [HttpPut]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(MinistryAdminDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult> Update(BaseUserDto updateMinistryAdminDto)
+    public async Task<ActionResult> Update([FromBody] BaseUserDto updateMinistryAdminDto)
     {
         if (updateMinistryAdminDto == null)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/NotificationController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/NotificationController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.WebApi.Common;
 using OutOfSchool.WebApi.Models.Notifications;
@@ -33,11 +34,12 @@ public class NotificationController : ControllerBase
     /// <response code="500">If any server error occures.</response>
     [Authorize]
     [HttpPost]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> Create(NotificationDto notificationDto)
+    public async Task<IActionResult> Create([FromBody] NotificationDto notificationDto)
     {
         var notification = await notificationService.Create(notificationDto).ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ParentController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ParentController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.WebApi.Common;
 using OutOfSchool.WebApi.Models;
@@ -68,11 +69,12 @@ public class ParentController : ControllerBase
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
     [HasPermission(Permissions.ParentBlock)]
     [HttpPost("BlockUnblockParent")]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult> BlockUnblockParent(BlockUnblockParentDto parentBlockUnblock)
+    public async Task<ActionResult> BlockUnblockParent([FromBody] BlockUnblockParentDto parentBlockUnblock)
     {
         var result = await serviceParent.BlockUnblockParent(parentBlockUnblock).ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PermissionsForRoleController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PermissionsForRoleController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.WebApi.Models;
 
 namespace OutOfSchool.WebApi.Controllers.V1;
@@ -69,12 +70,13 @@ public class PermissionsForRoleController : ControllerBase
     /// </summary>
     /// <param name="dto">PermissionsForRole entity to add.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<IActionResult> Create(PermissionsForRoleDTO dto)
+    public async Task<IActionResult> Create([FromBody] PermissionsForRoleDTO dto)
     {
         var permissionsForRole = await service.Create(dto).ConfigureAwait(false);
 
@@ -89,12 +91,13 @@ public class PermissionsForRoleController : ControllerBase
     /// </summary>
     /// <param name="dto">PermissionsForRole to update.</param>
     /// <returns>PermissionsForRole</returns>
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
-    public async Task<IActionResult> Update(PermissionsForRoleDTO dto)
+    public async Task<IActionResult> Update([FromBody] PermissionsForRoleDTO dto)
     {
         try
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PersonalInfoController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PersonalInfoController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.WebApi.Models;
 
@@ -61,12 +62,13 @@ public class PersonalInfoController : ControllerBase
     /// <param name="dto">New User's personal information.</param>
     /// <returns>Updated User's personal information.</returns>
     [HttpPut]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ShortUserDto))]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> UpdatePersonalInfo(ShortUserDto dto)
+    public async Task<IActionResult> UpdatePersonalInfo([FromBody] ShortUserDto dto)
     {
         ShortUserDto result;
         if (currentUserService.IsInRole(Role.Parent))

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PrivateProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PrivateProviderController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.WebApi.Common;
 using OutOfSchool.WebApi.Models.Providers;
 using OutOfSchool.WebApi.Services.ProviderServices;
@@ -28,6 +29,7 @@ public class PrivateProviderController : Controller
     /// <returns><see cref="ProviderLicenseStatusDto"/>.</returns>
     [HttpPut]
     [HasPermission(Permissions.ProviderApprove)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProviderLicenseStatusDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authentication;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using OutOfSchool.Common.Models;
@@ -46,6 +47,7 @@ public class ProviderAdminController : Controller
     /// </summary>
     /// <param name="providerAdmin">Entity to add.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(CreateProviderAdminDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -53,7 +55,7 @@ public class ProviderAdminController : Controller
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<ActionResult> Create(CreateProviderAdminDto providerAdmin)
+    public async Task<ActionResult> Create([FromBody] CreateProviderAdminDto providerAdmin)
     {
         logger.LogDebug($"{path} started. User(id): {userId}.");
 
@@ -100,13 +102,14 @@ public class ProviderAdminController : Controller
     /// <param name="providerId">Provider's id for which operation perform.</param>
     /// <param name="providerAdminModel">Entity to update.</param>
     /// <returns>Updated ProviderAdmin.</returns>
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProviderAdminDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
-    public async Task<IActionResult> Update(Guid providerId, UpdateProviderAdminDto providerAdminModel)
+    public async Task<IActionResult> Update(Guid providerId, [FromBody] UpdateProviderAdminDto providerAdminModel)
     {
         if (providerAdminModel == null)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
@@ -128,11 +129,12 @@ public class ProviderController : ControllerBase
     /// <param name="providerModel">Entity to add.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
     [HasPermission(Permissions.ProviderAddNew)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [HttpPost]
-    public async Task<IActionResult> Create(ProviderCreateDto providerModel)
+    public async Task<IActionResult> Create([FromBody] ProviderCreateDto providerModel)
     {
         if (providerModel == null)
         {
@@ -180,12 +182,13 @@ public class ProviderController : ControllerBase
     /// <param name="providerModel">Entity to update.</param>
     /// <returns>Updated Provider.</returns>
     [HasPermission(Permissions.ProviderEdit)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProviderDto))]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
-    public async Task<IActionResult> Update(ProviderUpdateDto providerModel)
+    public async Task<IActionResult> Update([FromBody] ProviderUpdateDto providerModel)
     {
         if (!ModelState.IsValid)
         {
@@ -217,6 +220,7 @@ public class ProviderController : ControllerBase
     /// <param name="providerBlockDto">Entity to update.</param>
     /// <returns>Block Provider.</returns>
     [HasPermission(Permissions.ProviderBlock)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProviderBlockDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderTypeController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderTypeController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using OutOfSchool.WebApi.Models;
@@ -69,12 +70,13 @@ public class ProviderTypeController:ControllerBase
     /// <param name="dto">Social Group entity to add.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
     [HasPermission(Permissions.SystemManagement)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<IActionResult> Create(ProviderTypeDto dto)
+    public async Task<IActionResult> Create([FromBody] ProviderTypeDto dto)
     {
         var providerType = await service.Create(dto).ConfigureAwait(false);
 
@@ -90,12 +92,13 @@ public class ProviderTypeController:ControllerBase
     /// <param name="dto">Social Group to update.</param>
     /// <returns>Social Group.</returns>
     [HasPermission(Permissions.SystemManagement)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SocialGroupDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
-    public async Task<IActionResult> Update(ProviderTypeDto dto)
+    public async Task<IActionResult> Update([FromBody] ProviderTypeDto dto)
     {
         return Ok(await service.Update(dto).ConfigureAwait(false));
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PublicProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PublicProviderController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.WebApi.Common;
 using OutOfSchool.WebApi.Models.Providers;
 using OutOfSchool.WebApi.Services.ProviderServices;
@@ -28,6 +29,7 @@ public class PublicProviderController : ControllerBase
     /// <returns><see cref="ProviderStatusDto"/>.</returns>
     [HttpPut]
     [HasPermission(Permissions.ProviderApprove)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProviderStatusDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/RatingController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/RatingController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using OutOfSchool.WebApi.Models;
 using OutOfSchool.WebApi.Services.AverageRatings;
@@ -170,12 +171,13 @@ public class RatingController : ControllerBase
     /// <param name="dto">Rating entity to add.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
     [HasPermission(Permissions.RatingAddNew)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(RatingDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<IActionResult> Create(RatingDto dto)
+    public async Task<IActionResult> Create([FromBody] RatingDto dto)
     {
         var rating = await ratingService.Create(dto).ConfigureAwait(false);
 
@@ -199,12 +201,13 @@ public class RatingController : ControllerBase
     /// <param name="dto">Rating to update.</param>
     /// <returns>Rating.</returns>
     [HasPermission(Permissions.RatingEdit)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(RatingDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
-    public async Task<IActionResult> Update(RatingDto dto)
+    public async Task<IActionResult> Update([FromBody] RatingDto dto)
     {
         var rating = await ratingService.Update(dto).ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SocialGroupController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SocialGroupController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using OutOfSchool.WebApi.Enums;
 using OutOfSchool.WebApi.Models.SocialGroup;
@@ -72,12 +73,13 @@ public class SocialGroupController : ControllerBase
     /// <param name="dto">Social Group entity to add.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
     [HasPermission(Permissions.SystemManagement)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<IActionResult> Create(SocialGroupCreate dto)
+    public async Task<IActionResult> Create([FromBody] SocialGroupCreate dto)
     {
         var socialGroup = await service.Create(dto).ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SubordinationStructure/InstitutionHierarchyController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SubordinationStructure/InstitutionHierarchyController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.WebApi.Models.SubordinationStructure;
 
 namespace OutOfSchool.WebApi.Controllers.V1.SubordinationStructure;
@@ -142,12 +143,13 @@ public class InstitutionHierarchyController : Controller
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.SystemManagement)]
     [HttpPost]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> Create(InstitutionHierarchyDto institutionHierarchyDto)
+    public async Task<IActionResult> Create([FromBody] InstitutionHierarchyDto institutionHierarchyDto)
     {
         var institutionHierarchy = await service.Create(institutionHierarchyDto).ConfigureAwait(false);
 
@@ -169,12 +171,13 @@ public class InstitutionHierarchyController : Controller
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.SystemManagement)]
     [HttpPut]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InstitutionHierarchyDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult> Update(InstitutionHierarchyDto institutionHierarchyDto)
+    public async Task<ActionResult> Update([FromBody] InstitutionHierarchyDto institutionHierarchyDto)
     {
         return Ok(await service.Update(institutionHierarchyDto).ConfigureAwait(false));
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -250,7 +250,7 @@ public class WorkshopController : ControllerBase
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPost]
-    public async Task<IActionResult> Create(WorkshopBaseDto dto)
+    public async Task<IActionResult> Create([FromBody] WorkshopBaseDto dto)
     {
         if (dto == null)
         {
@@ -329,7 +329,7 @@ public class WorkshopController : ControllerBase
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
-    public async Task<IActionResult> Update(WorkshopBaseDto dto)
+    public async Task<IActionResult> Update([FromBody] WorkshopBaseDto dto)
     {
         if (dto == null)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
@@ -244,6 +245,7 @@ public class WorkshopController : ControllerBase
     /// <response code="403">If the user has no rights to use this method, or sets some properties that are forbidden.</response>
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.WorkshopAddNew)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(WorkshopBaseDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -323,6 +325,7 @@ public class WorkshopController : ControllerBase
     /// <response code="403">If the user has no rights to use this method, or sets some properties that are forbidden to change.</response>
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.WorkshopEdit)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(WorkshopBaseDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -372,6 +375,7 @@ public class WorkshopController : ControllerBase
     /// <response code="403">If the user has no rights to use this method, or sets some properties that are forbidden to change.</response>
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.WorkshopEdit)]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(WorkshopStatusDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]


### PR DESCRIPTION
Don't know if having both `[Comsumes]` & `[FromBody]` is overkill, because either of them fixes the problem that for some reason .Net 8 wants to process POST/PUT body as formdata.