### PR TITLE
add config object for emails content url

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthCommon/Extensions/AuthCommonServiceExtensions.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Extensions/AuthCommonServiceExtensions.cs
@@ -8,6 +8,7 @@ using OutOfSchool.AuthCommon.Util;
 using OutOfSchool.AuthCommon.Validators;
 using OutOfSchool.AuthCommon.ViewModels;
 using OutOfSchool.Common.Models;
+using OutOfSchool.RazorTemplatesData.Config;
 
 namespace OutOfSchool.AuthCommon.Extensions;
 
@@ -32,7 +33,8 @@ public static class AuthCommonServiceExtensions
         services.AddEmailSenderService(
             isDevelopment,
             mailConfig.SendGridKey,
-            builder => builder.Bind(config.GetSection(EmailOptions.SectionName)));
+            builder => builder.Bind(config.GetSection(EmailOptions.SectionName)))
+            .AddEmailRendererConfiguration(new EmailContentConfig(config.GetSection("Identity")["Authority"]));
 
         services.Configure<ChangesLogConfig>(config.GetSection(ChangesLogConfig.Name));
         services.Configure<HostsConfig>(config.GetSection(HostsConfig.Name));

--- a/OutOfSchool/OutOfSchool.RazorTemplatesData/Config/EmailContentConfig.cs
+++ b/OutOfSchool/OutOfSchool.RazorTemplatesData/Config/EmailContentConfig.cs
@@ -1,0 +1,20 @@
+namespace OutOfSchool.RazorTemplatesData.Config;
+
+public class EmailContentConfig
+{
+    private readonly string EmailContentHost;
+    private static readonly string EmailContentPath = "/_content/email";
+
+    public string EmailContentUrl
+    {
+        get
+        {
+            return string.Concat(EmailContentHost, EmailContentPath);
+        }
+    }
+
+    public EmailContentConfig(string emailContentHost)
+    {
+        EmailContentHost = emailContentHost;
+    }
+}

--- a/OutOfSchool/OutOfSchool.RazorTemplatesData/Config/EmailContentConfig.cs
+++ b/OutOfSchool/OutOfSchool.RazorTemplatesData/Config/EmailContentConfig.cs
@@ -5,13 +5,7 @@ public class EmailContentConfig
     private readonly string EmailContentHost;
     private static readonly string EmailContentPath = "/_content/email";
 
-    public string EmailContentUrl
-    {
-        get
-        {
-            return string.Concat(EmailContentHost, EmailContentPath);
-        }
-    }
+    public string EmailContentUrl => string.Concat(EmailContentHost, EmailContentPath);
 
     public EmailContentConfig(string emailContentHost)
     {

--- a/OutOfSchool/OutOfSchool.RazorTemplatesData/Config/ServiceProviderExtensions.cs
+++ b/OutOfSchool/OutOfSchool.RazorTemplatesData/Config/ServiceProviderExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OutOfSchool.RazorTemplatesData.Config;
+
+public static class ServiceProviderExtensions
+{
+    public static IServiceCollection AddEmailRendererConfiguration(
+        this IServiceCollection services,
+        EmailContentConfig emailContentConfig)
+    {
+        services.AddSingleton(emailContentConfig);
+        return services;
+    }
+}

--- a/OutOfSchool/OutOfSchool.RazorTemplatesData/Views/Shared/EmailLayout.cshtml
+++ b/OutOfSchool/OutOfSchool.RazorTemplatesData/Views/Shared/EmailLayout.cshtml
@@ -1,9 +1,8 @@
-﻿@using Microsoft.Extensions.Configuration
-@inject IConfiguration configuration
+﻿@using OutOfSchool.RazorTemplatesData.Config
+@inject EmailContentConfig configuration
 
 @{
-    var host = configuration.GetSection("Hosts")["BackendUrl"];
-    var pathToContent = string.Concat(host, "/_content/email");
+    var pathToContent = configuration.EmailContentUrl;
 }  
 
 <!DOCTYPE html>

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -16,6 +16,7 @@ using OutOfSchool.BusinessLogic.Services.Strategies.WorkshopStrategies;
 using OutOfSchool.BusinessLogic.Util.Mapping;
 using OutOfSchool.EmailSender;
 using OutOfSchool.EmailSender.Services;
+using OutOfSchool.RazorTemplatesData.Config;
 using OutOfSchool.RazorTemplatesData.Services;
 using OutOfSchool.Services.Repository.Files;
 
@@ -495,7 +496,8 @@ public static class Startup
         services.AddEmailSenderService(
             builder.Environment.IsDevelopment(),
             mailConfig.SendGridKey,
-            builder => builder.Bind(configuration.GetSection(EmailOptions.SectionName)));
+            builder => builder.Bind(configuration.GetSection(EmailOptions.SectionName)))
+            .AddEmailRendererConfiguration(new EmailContentConfig(configuration.GetSection("Hosts")["BackendUrl"]));
 
         // Hosts options
         services.Configure<HostsConfig>(configuration.GetSection(HostsConfig.Name));


### PR DESCRIPTION
As different projects have differently named configuration fields - a way to unify them and show email data correctly