### PR TITLE
Vladp/change phone number format

### DIFF
--- a/OutOfSchool/OutOfSchool.AdminInitializer/AdminInitializer.cs
+++ b/OutOfSchool/OutOfSchool.AdminInitializer/AdminInitializer.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using OutOfSchool.AdminInitializer.Config;
-using OutOfSchool.Common;
 using OutOfSchool.Services;
 using OutOfSchool.Services.Models;
 
@@ -36,7 +35,7 @@ internal class AdminInitializer
             LastName = adminConfiguration.LastName,
             MiddleName = adminConfiguration.MiddleName,
             Email = adminConfiguration.Email,
-            PhoneNumber = Constants.PhonePrefix + adminConfiguration.PhoneNumber,
+            PhoneNumber = adminConfiguration.PhoneNumber,
             CreatingTime = DateTimeOffset.UtcNow,
             Role = adminConfiguration.Role,
             IsRegistered = true,

--- a/OutOfSchool/OutOfSchool.AdminInitializer/appsettings.json
+++ b/OutOfSchool/OutOfSchool.AdminInitializer/appsettings.json
@@ -24,7 +24,7 @@
     "MiddleName": "Прикладович",
     "Password": "replace_me",
     "Email": "admin@gmail.com",
-    "PhoneNumber": "671234567",
+    "PhoneNumber": "+380671234567",
     "Role": "techadmin",
     "Reset": false
   },

--- a/OutOfSchool/OutOfSchool.AuthCommon/Controllers/AuthController.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Controllers/AuthController.cs
@@ -357,7 +357,7 @@ public class AuthController : Controller
             LastName = model.LastName,
             MiddleName = model.MiddleName,
             Email = model.Email,
-            PhoneNumber = Constants.PhonePrefix + model.PhoneNumber,
+            PhoneNumber = model.PhoneNumber,
             CreatingTime = DateTimeOffset.UtcNow,
             Role = model.Role,
             IsRegistered = false,

--- a/OutOfSchool/OutOfSchool.AuthCommon/Services/CommonMinistryAdminService.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Services/CommonMinistryAdminService.cs
@@ -380,7 +380,7 @@ public class CommonMinistryAdminService<TId, TEntity, TDto, TRepositoty> : IComm
                 user.MiddleName = ministryAdminUpdateDto.MiddleName;
                 user.Email = ministryAdminUpdateDto.Email;
                 user.UserName = ministryAdminUpdateDto.Email;
-                user.PhoneNumber = Constants.PhonePrefix + ministryAdminUpdateDto.PhoneNumber;
+                user.PhoneNumber = ministryAdminUpdateDto.PhoneNumber;
 
                 var updateResult = await userManager.UpdateAsync(user);
 

--- a/OutOfSchool/OutOfSchool.AuthCommon/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Services/ProviderAdminService.cs
@@ -241,7 +241,7 @@ public class ProviderAdminService : IProviderAdminService
                 user.LastName = updateDto.LastName;
                 user.MiddleName = updateDto.MiddleName;
                 user.Email = updateDto.Email;
-                user.PhoneNumber = Constants.PhonePrefix + updateDto.PhoneNumber;
+                user.PhoneNumber = updateDto.PhoneNumber;
 
                 var newPropertiesValues = GetTrackedUserProperties(user);
 

--- a/OutOfSchool/OutOfSchool.AuthCommon/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Util/MappingProfile.cs
@@ -45,6 +45,5 @@ public class MappingProfile : Profile
         where TSource : AdminBaseDto
         => mappings
             .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.Email))
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => Constants.PhonePrefix + src.PhoneNumber.Right(Constants.PhoneShortLength)))
-        ;
+            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.PhoneNumber));
 }

--- a/OutOfSchool/OutOfSchool.AuthCommon/ViewModels/RegisterViewModel.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/ViewModels/RegisterViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using OutOfSchool.Common.Validators;
 using OutOfSchool.Services.Enums;
 
 namespace OutOfSchool.AuthCommon.ViewModels;
@@ -53,9 +54,7 @@ public class RegisterViewModel
 
     [DataType(DataType.PhoneNumber)]
     [Required(ErrorMessage = "Phone number is required")]
-    [RegularExpression(
-        Constants.PhoneNumberRegexViewModel,
-        ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     public string PhoneNumber { get; set; }
 
     [DataType(DataType.DateTime)]

--- a/OutOfSchool/OutOfSchool.AuthCommon/Views/Auth/Register.cshtml
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Views/Auth/Register.cshtml
@@ -118,8 +118,7 @@
                             @SharedLocalizer["Phone"]<span class="registration_star">*</span>
                         </label>
                         <div class="registration_phone">
-                            <div class="registration_phone-code">+380</div>
-                            <input class="registration_input registration_input_required" maxlength="9" type="text"
+                            <input class="registration_input registration_input_required" maxlength="15" type="text"
                                    asp-for="PhoneNumber" id="phone_number">
                         </div>
                         <div>

--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -8,19 +8,9 @@ public static class Constants
 
     public const string DefaultAuthScheme = "bearer_or_cookie";
 
-    public const string PhonePrefix = "380";
-
-    public const int PhoneShortLength = 9;
-
-    public const string PhoneNumberFormat = "{0:+380 XX-XXX-XX-XX}";
-
-    public const string PhoneNumberRegexViewModel = @"([0-9]{2})([-]?)([0-9]{3})([-]?)([0-9]{2})([-]?)([0-9]{2})";
-
-    public const string PhoneNumberRegexModel = @"([\d]{9})";
+    public const string PhoneNumberFormat = "{0:XXXX XX-XXX-XX-XX}";
 
     public const string PhoneErrorMessage = "Error! Please check the number is correct";
-
-    public const int UnifiedPhoneLength = 15;
 
     public const int MySQLServerMinimalMajorVersion = 8;
 
@@ -56,4 +46,14 @@ public static class Constants
     /// Longest possible length of provider founder.
     /// </summary>
     public const int MaxProviderFounderLength = 60;
+
+    /// <summary>
+    /// Shortest possible phone number length without '+' prefix.
+    /// </summary>
+    public const int MinPhoneNumberLength = 7;
+
+    /// <summary>
+    /// Longest possible phone number length without '+' prefix.
+    /// </summary>
+    public const int MaxPhoneNumberLength = 15;
 }

--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -56,4 +56,14 @@ public static class Constants
     /// Longest possible phone number length without '+' prefix.
     /// </summary>
     public const int MaxPhoneNumberLength = 15;
+
+    /// <summary>
+    /// Shortest possible phone number length with '+' prefix.
+    /// </summary>
+    public const int MinPhoneNumberLengthWithPlusSign = MinPhoneNumberLength + 1;
+
+    /// <summary>
+    /// Longest possible phone number length with '+' prefix.
+    /// </summary>
+    public const int MaxPhoneNumberLengthWithPlusSign = MaxPhoneNumberLength + 1;
 }

--- a/OutOfSchool/OutOfSchool.Common/Models/AdminBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.Common/Models/AdminBaseDto.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using OutOfSchool.Common.Validators;
 
 namespace OutOfSchool.Common.Models;
 
@@ -18,10 +19,7 @@ public class AdminBaseDto
 
     [DataType(DataType.PhoneNumber)]
     [Required(ErrorMessage = "Phone number is required")]
-    [RegularExpression(
-        Constants.PhoneNumberRegexViewModel,
-        ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
-    [MaxLength(Constants.UnifiedPhoneLength)]
     public string PhoneNumber { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.Common/Validators/CustomPhoneNumberAttribute.cs
+++ b/OutOfSchool/OutOfSchool.Common/Validators/CustomPhoneNumberAttribute.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Buffers;
+using System.ComponentModel.DataAnnotations;
+
+namespace OutOfSchool.Common.Validators;
+
+/// <summary>
+/// Validation attribute for phone number. It allows only digits and '+' sign, length must be between 7 and 15 symbols.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+public class CustomPhoneNumberAttribute : DataTypeAttribute
+{
+    public CustomPhoneNumberAttribute()
+        : base(DataType.PhoneNumber)
+    {
+    }
+
+    private static SearchValues<char> DigitSearchValues { get; } = SearchValues.Create("0123456789");
+
+    /// <summary>
+    /// Checks that the phone number is valid.
+    /// </summary>
+    /// <param name="value">Value to validate.</param>
+    /// <returns><c>true</c> if valid, otherwise <c>false</c>.</returns>
+    /// <exception cref="InvalidOperationException"> is thrown if the current attribute is ill-formed. Inherited from <see cref="DataTypeAttribute.IsValid(object)"/>.</exception>
+    public override bool IsValid(object value)
+    {
+        // If value is required then consumer should use RequiredAttribute with this attribute
+        if (value is null)
+        {
+            return true;
+        }
+
+        if (value is not string phoneNumber)
+        {
+            return false;
+        }
+
+        var phoneNumberSpan = phoneNumber.AsSpan();
+
+        if (phoneNumberSpan is not ['+', .. var possibleDigits])
+        {
+            return false;
+        }
+
+        if (possibleDigits is { Length: < Constants.MinPhoneNumberLength or > Constants.MaxPhoneNumberLength })
+        {
+            return false;
+        }
+
+        if (possibleDigits.IndexOfAnyExcept(DigitSearchValues) != -1)
+        {
+            return false;
+        }
+
+        // base.IsValid - always returns true
+        return base.IsValid(value);
+    }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/ProviderConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/ProviderConfiguration.cs
@@ -52,7 +52,7 @@ internal class ProviderConfiguration : IEntityTypeConfiguration<Provider>
             .HasColumnType(nameof(DataType.Date));
 
         builder.Property(x => x.PhoneNumber)
-            .HasMaxLength(15);
+            .HasMaxLength(Constants.MaxPhoneNumberLengthWithPlusSign);
 
         builder.Property(x => x.Founder)
             .IsRequired()

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Provider.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Provider.cs
@@ -67,6 +67,7 @@ public class Provider : IKeyedEntity<Guid>, IImageDependentEntity<Provider>, ISo
     [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
     [Required(ErrorMessage = "PhoneNumber is required")]
+    [MaxLength(Constants.MaxPhoneNumberLengthWithPlusSign)]
     public string PhoneNumber { get; set; } = string.Empty;
 
     [Required]
@@ -98,6 +99,7 @@ public class Provider : IKeyedEntity<Guid>, IImageDependentEntity<Provider>, ISo
     [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
     [Required(ErrorMessage = "PhoneNumber is required")]
+    [MaxLength(Constants.MaxPhoneNumberLengthWithPlusSign)]
     public string BlockPhoneNumber { get; set; } = string.Empty;
 
     [MaxLength(500)]

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Provider.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Provider.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using OutOfSchool.Common;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Validators;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Models.Images;
 using OutOfSchool.Services.Models.SubordinationStructure;
@@ -63,11 +64,8 @@ public class Provider : IKeyedEntity<Guid>, IImageDependentEntity<Provider>, ISo
     public DateTime? DirectorDateOfBirth { get; set; } = default;
 
     [DataType(DataType.PhoneNumber)]
-    [RegularExpression(
-        Constants.PhoneNumberRegexModel,
-        ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
-    [MaxLength(Constants.UnifiedPhoneLength)]
     [Required(ErrorMessage = "PhoneNumber is required")]
     public string PhoneNumber { get; set; } = string.Empty;
 
@@ -97,11 +95,8 @@ public class Provider : IKeyedEntity<Guid>, IImageDependentEntity<Provider>, ISo
     public bool IsBlocked { get; set; } = false;
 
     [DataType(DataType.PhoneNumber)]
-    [RegularExpression(
-       Constants.PhoneNumberRegexModel,
-       ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
-    [MaxLength(Constants.UnifiedPhoneLength)]
     [Required(ErrorMessage = "PhoneNumber is required")]
     public string BlockPhoneNumber { get; set; } = string.Empty;
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -28,6 +28,7 @@ public class Workshop : IKeyedEntity<Guid>, IImageDependentEntity<Workshop>, ISo
     [Required(ErrorMessage = "Phone number is required")]
     [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
+    [MaxLength(Constants.MaxPhoneNumberLengthWithPlusSign)]
     public string Phone { get; set; } = string.Empty;
 
     [DataType(DataType.EmailAddress)]

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Newtonsoft.Json;
 using OutOfSchool.Common;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Validators;
 using OutOfSchool.Services.Models.ChatWorkshop;
 using OutOfSchool.Services.Models.Images;
 using OutOfSchool.Services.Models.SubordinationStructure;
@@ -25,11 +26,8 @@ public class Workshop : IKeyedEntity<Guid>, IImageDependentEntity<Workshop>, ISo
 
     [DataType(DataType.PhoneNumber)]
     [Required(ErrorMessage = "Phone number is required")]
-    [RegularExpression(
-        Constants.PhoneNumberRegexModel,
-        ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
-    [MaxLength(Constants.UnifiedPhoneLength)]
     public string Phone { get; set; } = string.Empty;
 
     [DataType(DataType.EmailAddress)]

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240401152400_ChangePhoneNumberFormat.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240401152400_ChangePhoneNumberFormat.Designer.cs
@@ -2,17 +2,20 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
 #nullable disable
 
-namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240401152400_ChangePhoneNumberFormat")]
+    partial class ChangePhoneNumberFormat
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240401152400_ChangePhoneNumberFormat.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240401152400_ChangePhoneNumberFormat.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations;
+
+/// <inheritdoc />
+public partial class ChangePhoneNumberFormat : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "Phone",
+            table: "Workshops",
+            type: "varchar(16)",
+            maxLength: 16,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "varchar(15)",
+            oldMaxLength: 15)
+            .Annotation("MySql:CharSet", "utf8mb4")
+            .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "PhoneNumber",
+            table: "Providers",
+            type: "varchar(16)",
+            maxLength: 16,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "varchar(15)",
+            oldMaxLength: 15)
+            .Annotation("MySql:CharSet", "utf8mb4")
+            .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "BlockPhoneNumber",
+            table: "Providers",
+            type: "varchar(16)",
+            maxLength: 16,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "varchar(15)",
+            oldMaxLength: 15)
+            .Annotation("MySql:CharSet", "utf8mb4")
+            .OldAnnotation("MySql:CharSet", "utf8mb4");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "Phone",
+            table: "Workshops",
+            type: "varchar(15)",
+            maxLength: 15,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "varchar(16)",
+            oldMaxLength: 16)
+            .Annotation("MySql:CharSet", "utf8mb4")
+            .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "PhoneNumber",
+            table: "Providers",
+            type: "varchar(15)",
+            maxLength: 15,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "varchar(16)",
+            oldMaxLength: 16)
+            .Annotation("MySql:CharSet", "utf8mb4")
+            .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "BlockPhoneNumber",
+            table: "Providers",
+            type: "varchar(15)",
+            maxLength: 15,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "varchar(16)",
+            oldMaxLength: 16)
+            .Annotation("MySql:CharSet", "utf8mb4")
+            .OldAnnotation("MySql:CharSet", "utf8mb4");
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Validators/CustomPhoneNumberAttributeTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Validators/CustomPhoneNumberAttributeTests.cs
@@ -1,0 +1,106 @@
+﻿using NUnit.Framework;
+using OutOfSchool.Common.Validators;
+
+namespace OutOfSchool.WebApi.Tests.Validators;
+
+[TestFixture]
+public class CustomPhoneNumberAttributeTests
+{
+    [Test]
+    public void IsValid_WhenPhoneNumberIsNull_ShouldReturnTrue()
+    {
+        // Arrange
+        var phoneNumber = null as string;
+        var customPhoneNumberAttribute = new CustomPhoneNumberAttribute();
+
+        // Act
+        var isValid = customPhoneNumberAttribute.IsValid(phoneNumber);
+
+        // Assert
+        Assert.IsTrue(isValid);
+    }
+
+    [Test]
+    public void IsValid_WhenPhoneNumberIsEmpty_ShouldReturnFalse()
+    {
+        // Arrange
+        var phoneNumber = string.Empty;
+        var customPhoneNumberAttribute = new CustomPhoneNumberAttribute();
+
+        // Act
+        var isValid = customPhoneNumberAttribute.IsValid(phoneNumber);
+
+        // Assert
+        Assert.IsFalse(isValid);
+    }
+
+    [Test]
+    public void IsValid_WhenPhoneNumberIsNotStartsWithPlus_ShouldReturnFalse()
+    {
+        // Arrange
+        var phoneNumber = "1111111";
+        var customPhoneNumberAttribute = new CustomPhoneNumberAttribute();
+
+        // Act
+        var isValid = customPhoneNumberAttribute.IsValid(phoneNumber);
+
+        // Assert
+        Assert.IsFalse(isValid);
+    }
+
+    [Test]
+    public void IsValid_WhenPhoneNumberIsShort_ShouldReturnFalse()
+    {
+        // Arrange
+        var phoneNumber = "+111111";
+        var customPhoneNumberAttribute = new CustomPhoneNumberAttribute();
+
+        // Act
+        var isValid = customPhoneNumberAttribute.IsValid(phoneNumber);
+
+        // Assert
+        Assert.IsFalse(isValid);
+    }
+
+    [Test]
+    public void IsValid_WhenPhoneNumberIsLong_ShouldReturnFalse()
+    {
+        // Arrange
+        var phoneNumber = "+1111111111111111";
+        var customPhoneNumberAttribute = new CustomPhoneNumberAttribute();
+
+        // Act
+        var isValid = customPhoneNumberAttribute.IsValid(phoneNumber);
+
+        // Assert
+        Assert.IsFalse(isValid);
+    }
+
+    [Test]
+    public void IsValid_WhenPhoneNumberIsContainsNotDigits_ShouldReturnFalse()
+    {
+        // Arrange
+        var phoneNumber = "+111111abc11";
+        var customPhoneNumberAttribute = new CustomPhoneNumberAttribute();
+
+        // Act
+        var isValid = customPhoneNumberAttribute.IsValid(phoneNumber);
+
+        // Assert
+        Assert.IsFalse(isValid);
+    }
+
+    [Test]
+    public void IsValid_WhenPhoneNumberIsValid_ShouldReturnTrue()
+    {
+        // Arrange
+        var phoneNumber = "+11111111111";
+        var customPhoneNumberAttribute = new CustomPhoneNumberAttribute();
+
+        // Act
+        var isValid = customPhoneNumberAttribute.IsValid(phoneNumber);
+
+        // Assert
+        Assert.IsTrue(isValid);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Validators/CustomPhoneNumberAttributeTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Validators/CustomPhoneNumberAttributeTests.cs
@@ -21,6 +21,20 @@ public class CustomPhoneNumberAttributeTests
     }
 
     [Test]
+    public void IsValid_WhenPhoneNumberIsNotString_ShouldReturnFalse()
+    {
+        // Arrange
+        var phoneNumber = 111111111;
+        var customPhoneNumberAttribute = new CustomPhoneNumberAttribute();
+
+        // Act
+        var isValid = customPhoneNumberAttribute.IsValid(phoneNumber);
+
+        // Assert
+        Assert.IsFalse(isValid);
+    }
+
+    [Test]
     public void IsValid_WhenPhoneNumberIsEmpty_ShouldReturnFalse()
     {
         // Arrange

--- a/OutOfSchool/OutOfSchool.WebApi/Models/BaseUserDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/BaseUserDto.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using OutOfSchool.Common.Validators;
 
 namespace OutOfSchool.WebApi.Models;
 
@@ -11,9 +12,7 @@ public class BaseUserDto
 
     [DataType(DataType.PhoneNumber)]
     [Required(ErrorMessage = "Phone number is required")]
-    [RegularExpression(
-        Constants.PhoneNumberRegexModel,
-        ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
     public string PhoneNumber { get; set; }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Providers/ProviderBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Providers/ProviderBaseDto.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Validators;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.WebApi.Models.SubordinationStructure;
 using OutOfSchool.WebApi.Util.JsonTools;
@@ -58,11 +59,8 @@ public class ProviderBaseDto : IHasCoverImage, IHasImages
     public DateTime? DirectorDateOfBirth { get; set; } = default;
 
     [DataType(DataType.PhoneNumber)]
-    [RegularExpression(
-        Constants.PhoneNumberRegexModel,
-        ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
-    [MaxLength(Constants.UnifiedPhoneLength)]
     [Required(ErrorMessage = "The phone number is required")]
     public string PhoneNumber { get; set; } = string.Empty;
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Providers/ProviderBlockDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Providers/ProviderBlockDto.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel.DataAnnotations;
+using OutOfSchool.Common.Validators;
 using OutOfSchool.WebApi.Validators;
+
 namespace OutOfSchool.WebApi.Models.Providers;
 
 public class ProviderBlockDto
@@ -11,11 +13,8 @@ public class ProviderBlockDto
     public bool IsBlocked { get; set; }
 
     [DataType(DataType.PhoneNumber)]
-    [RegularExpression(
-       Constants.PhoneNumberRegexModel,
-       ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
-    [MaxLength(Constants.UnifiedPhoneLength)]
     [RequiredIf("IsBlocked", true, ErrorMessage = "PhoneNumber is required")]
     public string BlockPhoneNumber { get; set; } = string.Empty;
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ProvidersInfo/ProviderInfoDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ProvidersInfo/ProviderInfoDto.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Models;
+using OutOfSchool.Common.Validators;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.WebApi.Models.SubordinationStructure;
 using OutOfSchool.WebApi.Util.JsonTools;
@@ -59,11 +60,8 @@ public class ProviderInfoDto : ProviderInfoBaseDto, IHasRating
     public DateTime? DirectorDateOfBirth { get; set; } = default;
 
     [DataType(DataType.PhoneNumber)]
-    [RegularExpression(
-        Constants.PhoneNumberRegexModel,
-        ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
-    [MaxLength(Constants.UnifiedPhoneLength)]
     [Required(ErrorMessage = "The phone number is required")]
     public string PhoneNumber { get; set; } = string.Empty;
 

--- a/OutOfSchool/OutOfSchool.WebApi/Models/ProvidersInfo/WorkshopInfoDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/ProvidersInfo/WorkshopInfoDto.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Models;
+using OutOfSchool.Common.Validators;
 using OutOfSchool.WebApi.Models.Workshops;
 using OutOfSchool.WebApi.Util.CustomValidation;
 using OutOfSchool.WebApi.Util.JsonTools;
@@ -27,11 +28,8 @@ public class WorkshopInfoDto : WorkshopInfoBaseDto, IHasRating
 
     [DataType(DataType.PhoneNumber)]
     [Required(ErrorMessage = "Phone number is required")]
-    [RegularExpression(
-        Constants.PhoneNumberRegexModel,
-        ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
-    [MaxLength(Constants.UnifiedPhoneLength)]
     public string Phone { get; set; } = string.Empty;
 
     [DataType(DataType.EmailAddress)]

--- a/OutOfSchool/OutOfSchool.WebApi/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Models/Workshops/WorkshopBaseDto.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Validators;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.WebApi.Util.CustomValidation;
 using OutOfSchool.WebApi.Util.JsonTools;
@@ -20,11 +21,8 @@ public class WorkshopBaseDto : IValidatableObject
 
     [DataType(DataType.PhoneNumber)]
     [Required(ErrorMessage = "Phone number is required")]
-    [RegularExpression(
-        Constants.PhoneNumberRegexModel,
-        ErrorMessage = Constants.PhoneErrorMessage)]
+    [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
-    [MaxLength(Constants.UnifiedPhoneLength)]
     public string Phone { get; set; } = string.Empty;
 
     [DataType(DataType.EmailAddress)]

--- a/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/MappingProfile.cs
@@ -305,7 +305,7 @@ public class MappingProfile : Profile
         CreateMap<Parent, ParentDtoWithContactInfo>()
             .ForMember(dest => dest.Email, opt => opt.MapFrom(s => s.User.Email))
             .ForMember(dest => dest.EmailConfirmed, opt => opt.MapFrom(s => s.User.EmailConfirmed))
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(s => s.User.PhoneNumber.Right(Constants.PhoneShortLength)))
+            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(s => s.User.PhoneNumber))
             .ForMember(dest => dest.LastName, opt => opt.MapFrom(s => s.User.LastName))
             .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(s => s.User.MiddleName ?? string.Empty))
             .ForMember(dest => dest.FirstName, opt => opt.MapFrom(s => s.User.FirstName))
@@ -340,7 +340,7 @@ public class MappingProfile : Profile
         CreateMap<User, ProviderAdminDto>()
             .ForMember(dest => dest.IsDeputy, opt => opt.Ignore())
             .ForMember(dest => dest.AccountStatus, m => m.Ignore())
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.PhoneNumber.Right(Constants.PhoneShortLength)));
+            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.PhoneNumber));
 
         CreateMap<User, FullProviderAdminDto>()
             .IncludeBase<User, ProviderAdminDto>()
@@ -378,7 +378,7 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.User.FirstName))
             .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.User.LastName))
             .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.User.MiddleName ?? string.Empty))
-            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.User.PhoneNumber.Right(Constants.PhoneShortLength)))
+            .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.User.PhoneNumber))
             .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.User.Email))
         ;
 


### PR DESCRIPTION
## Summary
Update the phone number format from `XX-XXX-XX-XX`, where each `X` represents a digit, to the international format `+CCC-XX-XXX-XX-XX`, where `C` denotes the country code. The new format supports phone numbers with lengths ranging from 7 (the shortest possible) to 15 digits.

## Remarks
I decided to create my own validation attribute because the existing one relied on regular expressions, which could occasionally be slow. Instead of using the [default implementation](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.phoneattribute?view=net-8.0), I benchmarked my approach against other implementations, including regular expressions and the default method. My custom variant proved to be faster, so I decided to go with it.

**Benchmark  source code:** https://github.com/MrVenik/PhoneNumberValidation
**Benchmark results:** 
![image](https://github.com/ita-social-projects/OoS-Backend/assets/27528831/e48a75fe-d7f0-4b6e-8d8f-c129bf1e285e)