### PR TITLE
Fixed datetime format for JobDataMap

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthServer.Tests/EmailSender/EmailSenderJobTests.cs
+++ b/OutOfSchool/OutOfSchool.AuthServer.Tests/EmailSender/EmailSenderJobTests.cs
@@ -67,7 +67,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddMinutes(-10) }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddMinutes(-10).ToString() }
             });
 
         // Act
@@ -92,7 +92,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1) }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString() }
             });
         _mockSendGridClient.Setup(client => client.SendEmailAsync(It.IsAny<SendGridMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Response(HttpStatusCode.OK, null, null));
@@ -119,7 +119,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1) }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString() }
             });
         _mockSendGridClient.Setup(client => client.SendEmailAsync(It.IsAny<SendGridMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Response(HttpStatusCode.TooManyRequests, null, null));
@@ -141,7 +141,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1) }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString() }
             });
         _mockSendGridClient.Setup(client => client.SendEmailAsync(It.IsAny<SendGridMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Response(HttpStatusCode.BadRequest, null, null));

--- a/OutOfSchool/OutOfSchool.AuthServer.Tests/EmailSender/EmailSenderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.AuthServer.Tests/EmailSender/EmailSenderServiceTests.cs
@@ -33,11 +33,12 @@ public class EmailSenderServiceTests
         string email = "test@example.com";
         string subject = "Test Email";
         var content = ("<html><body><h1>Hello</h1></body></html>", "Hello");
+        var expirationTime = DateTimeOffset.Now.AddHours(1);
         mockSchedulerFactory.Setup(f => f.GetScheduler(It.IsAny<CancellationToken>()))
             .ReturnsAsync(mockScheduler.Object);
 
         // Act
-        await emailSenderService.SendAsync(email, subject, content);
+        await emailSenderService.SendAsync(email, subject, content, expirationTime);
 
         // Assert
         mockScheduler.Verify(

--- a/OutOfSchool/OutOfSchool.EmailSender/Quartz/EmailSenderJob.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/Quartz/EmailSenderJob.cs
@@ -45,7 +45,7 @@ public class EmailSenderJob : IJob
             var subject = dataMap.GetString(EmailSenderStringConstants.Subject);
             var htmlContent = dataMap.GetString(EmailSenderStringConstants.HtmlContent);
             var plainContent = dataMap.GetString(EmailSenderStringConstants.PlainContent);
-            var expirationTime = dataMap.GetDateTime(EmailSenderStringConstants.ExpirationTime);
+            var expirationTime = DateTimeOffset.Parse(dataMap.GetString(EmailSenderStringConstants.ExpirationTime));
 
             if (expirationTime < DateTimeOffset.Now)
             {

--- a/OutOfSchool/OutOfSchool.EmailSender/Quartz/EmailSenderJob.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/Quartz/EmailSenderJob.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -45,7 +46,7 @@ public class EmailSenderJob : IJob
             var subject = dataMap.GetString(EmailSenderStringConstants.Subject);
             var htmlContent = dataMap.GetString(EmailSenderStringConstants.HtmlContent);
             var plainContent = dataMap.GetString(EmailSenderStringConstants.PlainContent);
-            var expirationTime = DateTimeOffset.Parse(dataMap.GetString(EmailSenderStringConstants.ExpirationTime));
+            var expirationTime = DateTimeOffset.Parse(dataMap.GetString(EmailSenderStringConstants.ExpirationTime), CultureInfo.CurrentCulture);
 
             if (expirationTime < DateTimeOffset.Now)
             {

--- a/OutOfSchool/OutOfSchool.EmailSender/Services/DevEmailSender.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/Services/DevEmailSender.cs
@@ -13,9 +13,9 @@ public class DevEmailSender : IEmailSenderService
         this.logger = logger;
     }
 
-    public Task SendAsync(string email, string subject, (string html, string plain) content, DateTime? expirationTime = null)
+    public Task SendAsync(string email, string subject, (string html, string plain) content, DateTimeOffset? expirationTime = null)
     {
-        expirationTime ??= DateTime.MaxValue;
+        expirationTime ??= DateTimeOffset.MaxValue;
         // This code runs only in dev for testing purposes
         // so can ignore "not log user-controlled data".
 #pragma warning disable S5145

--- a/OutOfSchool/OutOfSchool.EmailSender/Services/EmailSenderService.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/Services/EmailSenderService.cs
@@ -15,9 +15,9 @@ public class EmailSenderService : IEmailSenderService
         this.schedulerFactory = schedulerFactory;
     }
 
-    public async Task SendAsync(string email, string subject, (string html, string plain) content, DateTime? expirationTime = null)
+    public async Task SendAsync(string email, string subject, (string html, string plain) content, DateTimeOffset? expirationTime = null)
     {
-        expirationTime ??= DateTime.MaxValue;
+        expirationTime ??= DateTimeOffset.MaxValue;
 
         var jobData = new JobDataMap
         {
@@ -25,7 +25,7 @@ public class EmailSenderService : IEmailSenderService
             { EmailSenderStringConstants.Subject, subject },
             { EmailSenderStringConstants.HtmlContent, EncodeToBase64(content.html) },
             { EmailSenderStringConstants.PlainContent, EncodeToBase64(content.plain) },
-            { EmailSenderStringConstants.ExpirationTime, expirationTime },
+            { EmailSenderStringConstants.ExpirationTime, expirationTime.ToString() },
         };
 
         var job = JobBuilder.Create<EmailSenderJob>()

--- a/OutOfSchool/OutOfSchool.EmailSender/Services/IEmailSenderService.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/Services/IEmailSenderService.cs
@@ -5,5 +5,5 @@ namespace OutOfSchool.EmailSender.Services;
 
 public interface IEmailSenderService
 {
-    Task SendAsync(string email, string subject, (string html, string plain) content, DateTime? expirationTime = null);
+    Task SendAsync(string email, string subject, (string html, string plain) content, DateTimeOffset? expirationTime = null);
 }


### PR DESCRIPTION
In this PR I fixed following error with JobDataMap:
`Quartz.JobPersistenceException: Couldn't store job: JobDataMap values must be strings when the 'useProperties' property is set.  Key of offending value: ExpirationTime`