### PR TITLE
Kymachynskyi/ Fix the unblocking of the institution by the admin #1458

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Providers/ProviderBlockDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Providers/ProviderBlockDto.cs
@@ -15,7 +15,7 @@ public class ProviderBlockDto
     [DataType(DataType.PhoneNumber)]
     [CustomPhoneNumber(ErrorMessage = Constants.PhoneErrorMessage)]
     [DisplayFormat(DataFormatString = Constants.PhoneNumberFormat)]
-    [RequiredIf("IsBlocked", true, ErrorMessage = "PhoneNumber is required")]
+    [RequiredIf(nameof(IsBlocked), true, ErrorMessage = "PhoneNumber is required")]
     public string BlockPhoneNumber { get; set; } = string.Empty;
 
     [MaxLength(500)]

--- a/OutOfSchool/OutOfSchool.Common/Validators/CustomPhoneNumberAttribute.cs
+++ b/OutOfSchool/OutOfSchool.Common/Validators/CustomPhoneNumberAttribute.cs
@@ -36,6 +36,11 @@ public class CustomPhoneNumberAttribute : DataTypeAttribute
             return false;
         }
 
+        if (phoneNumber.Length == 0)
+        {
+            return true;
+        }
+
         var phoneNumberSpan = phoneNumber.AsSpan();
 
         if (phoneNumberSpan is not ['+', .. var possibleDigits])

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Validators/CustomPhoneNumberAttributeTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Validators/CustomPhoneNumberAttributeTests.cs
@@ -35,7 +35,7 @@ public class CustomPhoneNumberAttributeTests
     }
 
     [Test]
-    public void IsValid_WhenPhoneNumberIsEmpty_ShouldReturnFalse()
+    public void IsValid_WhenPhoneNumberIsEmpty_ShouldReturnTrue()
     {
         // Arrange
         var phoneNumber = string.Empty;
@@ -45,7 +45,7 @@ public class CustomPhoneNumberAttributeTests
         var isValid = customPhoneNumberAttribute.IsValid(phoneNumber);
 
         // Assert
-        Assert.IsFalse(isValid);
+        Assert.IsTrue(isValid);
     }
 
     [Test]


### PR DESCRIPTION
The `ProviderBlockDto` is responsible for transferring data used to block or unblock an institution. The `BlockPhoneNumber` property is required to block an institution, but it is not used to unblock one.

During the unblocking process, the `BlockPhoneNumber` property, which is initialized with the value `string.Empty`, fails validation as the `CustomPhoneNumber` validation attribute does not check if `BlockPhoneNumber` equals `string.Empty`. This failure in validation renders it impossible to unblock the institution.