### PR TITLE
Kymachynskyi/ Fix workshop status and seats availability #2450

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.201
+          dotnet-version: 8.0.300
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
@@ -65,7 +65,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.201
+        dotnet-version: 8.0.300
 
     - name: Clean
       run: dotnet clean ./OutOfSchool/OutOfSchool.sln --configuration Release && dotnet nuget locals all --clear

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -2,12 +2,11 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
+using OutOfSchool.BusinessLogic.Util.CustomValidation;
+using OutOfSchool.BusinessLogic.Util.JsonTools;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Validators;
 using OutOfSchool.Services.Enums;
-using OutOfSchool.BusinessLogic.Util.CustomValidation;
-using OutOfSchool.BusinessLogic.Util.JsonTools;
-using OutOfSchool.Common.Extensions;
 
 namespace OutOfSchool.BusinessLogic.Models.Workshops;
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/IWorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/IWorkshopService.cs
@@ -33,9 +33,10 @@ public interface IWorkshopService
     /// Get entity by it's key.
     /// </summary>
     /// <param name="id">Key in the table.</param>
+    /// <param name="asNoTracking">If true, the entity is retrieved without tracking.</param>
     /// <returns>A <see cref="Task{TEntity}"/> representing the result of the asynchronous operation.
     /// The task result contains the entity that was found, or null.</returns>
-    Task<WorkshopDto> GetById(Guid id);
+    Task<WorkshopDto> GetById(Guid id, bool asNoTracking = false);
 
     /// <summary>
     /// Update existing entity in the database.

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -901,21 +901,27 @@ public class WorkshopService : IWorkshopService
         if (newAvailableSeats == uint.MaxValue
             && currentWorkshop.AvailableSeats == currentWorkshopTakenSeats)
         {
-            await UpdateStatus(new()
+            if (currentWorkshop.Status == WorkshopStatus.Closed)
             {
-                WorkshopId = currentWorkshop.Id,
-                Status = WorkshopStatus.Open,
-            }).ConfigureAwait(false);
+                await UpdateStatus(new()
+                {
+                    WorkshopId = currentWorkshop.Id,
+                    Status = WorkshopStatus.Open,
+                }).ConfigureAwait(false);
+            }
         }
 
         if (newAvailableSeats < uint.MaxValue
             && newAvailableSeats == currentWorkshopTakenSeats)
         {
-            await UpdateStatus(new()
+            if (currentWorkshop.Status == WorkshopStatus.Open)
             {
-                WorkshopId = currentWorkshop.Id,
-                Status = WorkshopStatus.Closed,
-            }).ConfigureAwait(false);
+                await UpdateStatus(new()
+                {
+                    WorkshopId = currentWorkshop.Id,
+                    Status = WorkshopStatus.Closed,
+                }).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -899,29 +899,25 @@ public class WorkshopService : IWorkshopService
         var currentWorkshopTakenSeats = currentWorkshop.Applications.TakenSeats();
 
         if (newAvailableSeats == uint.MaxValue
-            && currentWorkshop.AvailableSeats == currentWorkshopTakenSeats)
+            && currentWorkshop.AvailableSeats == currentWorkshopTakenSeats
+            && currentWorkshop.Status == WorkshopStatus.Closed)
         {
-            if (currentWorkshop.Status == WorkshopStatus.Closed)
+            await UpdateStatus(new()
             {
-                await UpdateStatus(new()
-                {
-                    WorkshopId = currentWorkshop.Id,
-                    Status = WorkshopStatus.Open,
-                }).ConfigureAwait(false);
-            }
+                WorkshopId = currentWorkshop.Id,
+                Status = WorkshopStatus.Open,
+            }).ConfigureAwait(false);
         }
 
         if (newAvailableSeats < uint.MaxValue
-            && newAvailableSeats == currentWorkshopTakenSeats)
+            && newAvailableSeats == currentWorkshopTakenSeats
+            && currentWorkshop.Status == WorkshopStatus.Open)
         {
-            if (currentWorkshop.Status == WorkshopStatus.Open)
+            await UpdateStatus(new()
             {
-                await UpdateStatus(new()
-                {
-                    WorkshopId = currentWorkshop.Id,
-                    Status = WorkshopStatus.Closed,
-                }).ConfigureAwait(false);
-            }
+                WorkshopId = currentWorkshop.Id,
+                Status = WorkshopStatus.Closed,
+            }).ConfigureAwait(false);
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -47,7 +47,6 @@ public class WorkshopService : IWorkshopService
     /// <param name="providerAdminRepository">Repository for provider admins.</param>
     /// <param name="averageRatingService">Average rating service.</param>
     /// <param name="providerRepository">Repository for providers.</param>
-
     public WorkshopService(
         IWorkshopRepository workshopRepository,
         IEntityRepositorySoftDeleted<long, DateTimeRange> dateTimeRangeRepository,

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -910,7 +910,7 @@ public class WorkshopService : IWorkshopService
         }
 
         if (newAvailableSeats < uint.MaxValue
-            && newAvailableSeats == currentWorkshopTakenSeats
+            && newAvailableSeats <= currentWorkshopTakenSeats
             && currentWorkshop.Status == WorkshopStatus.Open)
         {
             await UpdateStatus(new()

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
@@ -131,4 +131,13 @@ public interface IWorkshopServicesCombiner
     /// <param name="providerStatus">ProviderStatus of Provider to be changed.</param>
     /// <returns><see cref="IEnumerable{T}"/> of Workshops for the specified provider.</returns>
     Task<IEnumerable<ShortEntityDto>> UpdateProviderStatus(Guid providerId, ProviderStatus providerStatus);
+
+    /// <summary>
+    /// Checks if the given available seats value is valid for the specified workshop.
+    /// </summary>
+    /// <param name="availableSeats">The number of available seats to validate.</param>
+    /// <param name="workshopId">The unique Id of the workshop.</param>
+    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation.
+    /// The task result indicates whether the available seats value is valid.</returns>
+    Task<bool> IsAvailableSeatsValid(uint? availableSeats, Guid workshopId);
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
@@ -136,7 +136,8 @@ public interface IWorkshopServicesCombiner
     /// Checks if the given available seats value is valid for the specified workshop.
     /// </summary>
     /// <param name="availableSeats">The number of available seats to validate.</param>
-    /// <param name="workshop">The object representing the workshop.</param>
-    /// <returns>A boolean value indicating whether the available seats value is valid.</returns>
-    bool IsAvailableSeatsValid(uint? availableSeats, WorkshopDto workshop);
+    /// <param name="workshopId">The unique Id of the workshop.</param>
+    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation.
+    /// The task result indicates whether the available seats value is valid.</returns>
+    Task<bool> IsAvailableSeatsValid(uint? availableSeats, Guid workshopId);
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
@@ -136,8 +136,7 @@ public interface IWorkshopServicesCombiner
     /// Checks if the given available seats value is valid for the specified workshop.
     /// </summary>
     /// <param name="availableSeats">The number of available seats to validate.</param>
-    /// <param name="workshopId">The unique Id of the workshop.</param>
-    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation.
-    /// The task result indicates whether the available seats value is valid.</returns>
-    Task<bool> IsAvailableSeatsValid(uint? availableSeats, Guid workshopId);
+    /// <param name="workshop">The object representing the workshop.</param>
+    /// <returns>A boolean value indicating whether the available seats value is valid.</returns>
+    bool IsAvailableSeatsValid(uint? availableSeats, WorkshopDto workshop);
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
@@ -1,6 +1,7 @@
-﻿using OutOfSchool.Common.Enums;
+﻿using OutOfSchool.BusinessLogic.Common;
 using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.Workshops;
+using OutOfSchool.Common.Enums;
 
 namespace OutOfSchool.BusinessLogic.Services;
 
@@ -52,8 +53,13 @@ public interface IWorkshopServicesCombiner
     /// Update existing entity in the database.
     /// </summary>
     /// <param name="dto">Entity that will be to updated.</param>
-    /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="WorkshopBaseDto"/>.</returns>
-    Task<WorkshopBaseDto> Update(WorkshopBaseDto dto);
+    /// <returns>A <see cref="Task{TResult}"/> containing a <see cref="Result{WorkshopBaseDto}"/>
+    /// that indicates the success or failure of the operation.
+    /// If the operation succeeds, the <see cref="Result{WorkshopBaseDto}.Value"/> property
+    /// contains the updated <see cref="WorkshopBaseDto"/>.
+    /// If the operation fails, the <see cref="Result{WorkshopBaseDto}.OperationResult"/> property
+    /// contains error information.</returns>
+    Task<Result<WorkshopBaseDto>> Update(WorkshopBaseDto dto);
 
     /// <summary>
     /// Update status field for existing entity in the database.
@@ -136,9 +142,7 @@ public interface IWorkshopServicesCombiner
     /// Checks if the given available seats value is valid for the specified workshop.
     /// </summary>
     /// <param name="availableSeats">The number of available seats to validate.</param>
-    /// <param name="workshopId">The unique Id of the workshop.</param>
-    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation.
-    /// The task result indicates whether the available seats value is valid,
-    /// or null if workshop does not exist.</returns>
-    Task<bool?> IsAvailableSeatsValidForWorkshop(uint? availableSeats, Guid workshopId);
+    /// <param name="workshop">The workshop for which the available seats value is being validated.</param>
+    /// <returns> A boolean value indicating whether the available seats value is valid for the workshop.</returns>
+    bool IsAvailableSeatsValidForWorkshop(uint? availableSeats, WorkshopDto workshop);
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
@@ -138,6 +138,7 @@ public interface IWorkshopServicesCombiner
     /// <param name="availableSeats">The number of available seats to validate.</param>
     /// <param name="workshopId">The unique Id of the workshop.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation.
-    /// The task result indicates whether the available seats value is valid.</returns>
-    Task<bool> IsAvailableSeatsValid(uint? availableSeats, Guid workshopId);
+    /// The task result indicates whether the available seats value is valid,
+    /// or null if workshop does not exist.</returns>
+    Task<bool?> IsAvailableSeatsValidForWorkshop(uint? availableSeats, Guid workshopId);
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
@@ -43,9 +43,10 @@ public interface IWorkshopServicesCombiner
     /// Get entity by it's key.
     /// </summary>
     /// <param name="id">Key in the table.</param>
+    /// <param name="asNoTracking">If true, the entity is retrieved without tracking.</param>
     /// <returns>A <see cref="Task{TEntity}"/> representing the result of the asynchronous operation.
     /// The task result contains the entity that was found, or null.</returns>
-    Task<WorkshopDto> GetById(Guid id);
+    Task<WorkshopDto> GetById(Guid id, bool asNoTracking = false);
 
     /// <summary>
     /// Update existing entity in the database.

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombiner.cs
@@ -137,12 +137,4 @@ public interface IWorkshopServicesCombiner
     /// <param name="providerStatus">ProviderStatus of Provider to be changed.</param>
     /// <returns><see cref="IEnumerable{T}"/> of Workshops for the specified provider.</returns>
     Task<IEnumerable<ShortEntityDto>> UpdateProviderStatus(Guid providerId, ProviderStatus providerStatus);
-
-    /// <summary>
-    /// Checks if the given available seats value is valid for the specified workshop.
-    /// </summary>
-    /// <param name="availableSeats">The number of available seats to validate.</param>
-    /// <param name="workshop">The workshop for which the available seats value is being validated.</param>
-    /// <returns> A boolean value indicating whether the available seats value is valid for the workshop.</returns>
-    bool IsAvailableSeatsValidForWorkshop(uint? availableSeats, WorkshopDto workshop);
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombinerV2.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/IWorkshopServicesCombinerV2.cs
@@ -1,4 +1,5 @@
-﻿using OutOfSchool.BusinessLogic.Models.Workshops;
+﻿using OutOfSchool.BusinessLogic.Common;
+using OutOfSchool.BusinessLogic.Models.Workshops;
 
 namespace OutOfSchool.BusinessLogic.Services;
 
@@ -15,8 +16,13 @@ public interface IWorkshopServicesCombinerV2 : IWorkshopServicesCombiner
     /// Update existing entity in the database.
     /// </summary>
     /// <param name="dto">Entity that will be to updated.</param>
-    /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="WorkshopResultDto"/>.</returns>
-    new Task<WorkshopResultDto> Update(WorkshopV2Dto dto);
+    /// <returns>A <see cref="Task{TResult}"/> containing a <see cref="Result{WorkshopBaseDto}"/>
+    /// that indicates the success or failure of the operation.
+    /// If the operation succeeds, the <see cref="Result{WorkshopResultDto}.Value"/> property
+    /// contains the updated <see cref="WorkshopResultDto"/>.
+    /// If the operation fails, the <see cref="Result{WorkshopResultDto}.OperationResult"/> property
+    /// contains error information.</returns>
+    new Task<Result<WorkshopResultDto>> Update(WorkshopV2Dto dto);
 
     /// <summary>
     ///  Delete entity.

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
@@ -1,11 +1,11 @@
 ﻿using System.Linq.Expressions;
 using AutoMapper;
-using OutOfSchool.Common.Enums;
-using OutOfSchool.Services.Enums;
 using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.BusinessLogic.Services.Strategies.Interfaces;
+using OutOfSchool.Common.Enums;
+using OutOfSchool.Services.Enums;
 
 namespace OutOfSchool.BusinessLogic.Services;
 
@@ -257,6 +257,13 @@ public class WorkshopServicesCombiner : IWorkshopServicesCombiner
         }
 
         return shortWorkshops;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> IsAvailableSeatsValid(uint? availableSeats, Guid workshopId)
+    {
+        var workshop = await workshopService.GetById(workshopId, true).ConfigureAwait(false);
+        return availableSeats.GetMaxValueIfNullOrZero() >= workshop.TakenSeats;
     }
 
     private async Task<IEnumerable<string>> GetNotificationsRecipientIds(Guid objectId)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
@@ -260,8 +260,9 @@ public class WorkshopServicesCombiner : IWorkshopServicesCombiner
     }
 
     /// <inheritdoc/>
-    public bool IsAvailableSeatsValid(uint? availableSeats, WorkshopDto workshop)
+    public async Task<bool> IsAvailableSeatsValid(uint? availableSeats, Guid workshopId)
     {
+        var workshop = await workshopService.GetById(workshopId, true).ConfigureAwait(false);
         return availableSeats.GetMaxValueIfNullOrZero() >= workshop.TakenSeats;
     }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
@@ -260,9 +260,14 @@ public class WorkshopServicesCombiner : IWorkshopServicesCombiner
     }
 
     /// <inheritdoc/>
-    public async Task<bool> IsAvailableSeatsValid(uint? availableSeats, Guid workshopId)
+    public async Task<bool?> IsAvailableSeatsValidForWorkshop(uint? availableSeats, Guid workshopId)
     {
         var workshop = await workshopService.GetById(workshopId, true).ConfigureAwait(false);
+        if (workshop == null)
+        {
+            return null;
+        }
+
         return availableSeats.GetMaxValueIfNullOrZero() >= workshop.TakenSeats;
     }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
@@ -73,9 +73,9 @@ public class WorkshopServicesCombiner : IWorkshopServicesCombiner
     }
 
     /// <inheritdoc/>
-    public async Task<WorkshopDto> GetById(Guid id)
+    public async Task<WorkshopDto> GetById(Guid id, bool asNoTracking = false)
     {
-        var workshop = await workshopService.GetById(id).ConfigureAwait(false);
+        var workshop = await workshopService.GetById(id, asNoTracking).ConfigureAwait(false);
 
         return workshop;
     }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
@@ -278,7 +278,12 @@ public class WorkshopServicesCombiner : IWorkshopServicesCombiner
         return shortWorkshops;
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Checks if the given available seats value is valid for the specified workshop.
+    /// </summary>
+    /// <param name="availableSeats">The number of available seats to validate.</param>
+    /// <param name="workshop">The workshop for which the available seats value is being validated.</param>
+    /// <returns> A boolean value indicating whether the available seats value is valid for the workshop.</returns>
     public bool IsAvailableSeatsValidForWorkshop(uint? availableSeats, WorkshopDto workshop)
     {
         return availableSeats.GetMaxValueIfNullOrZero() >= workshop.TakenSeats;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopServicesCombiner.cs
@@ -260,9 +260,8 @@ public class WorkshopServicesCombiner : IWorkshopServicesCombiner
     }
 
     /// <inheritdoc/>
-    public async Task<bool> IsAvailableSeatsValid(uint? availableSeats, Guid workshopId)
+    public bool IsAvailableSeatsValid(uint? availableSeats, WorkshopDto workshop)
     {
-        var workshop = await workshopService.GetById(workshopId, true).ConfigureAwait(false);
         return availableSeats.GetMaxValueIfNullOrZero() >= workshop.TakenSeats;
     }
 

--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.AspNetCore.Http.HttpResults;
-using static System.Runtime.InteropServices.JavaScript.JSType;
-
-namespace OutOfSchool.Common;
+﻿namespace OutOfSchool.Common;
 
 public static class Constants
 {
@@ -55,6 +52,8 @@ public static class Constants
 
     public const string InvalidAvailableSeatsForWorkshopErrorMessage =
         "The number of available seats must be equal or greater than the number of taken seats.";
+
+    public const string UnknownErrorDuringUpdateMessage = "Unknown error occurred during update.";
 
     /// <summary>
     /// Longest possible length of provider founder.

--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -1,4 +1,7 @@
-﻿namespace OutOfSchool.Common;
+﻿using Microsoft.AspNetCore.Http.HttpResults;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace OutOfSchool.Common;
 
 public static class Constants
 {
@@ -47,6 +50,11 @@ public static class Constants
     public const string PathToChatHub = "/hubs/chat";
 
     public const string PathToNotificationHub = "/hubs/notification";
+
+    public const string WorkshopNotFoundErrorMessage = "Workshop not found.";
+
+    public const string InvalidAvailableSeatsForWorkshopErrorMessage =
+        "The number of available seats must be equal or greater than the number of taken seats.";
 
     /// <summary>
     /// Longest possible length of provider founder.

--- a/OutOfSchool/OutOfSchool.Common/Enums/PayRateType.cs
+++ b/OutOfSchool/OutOfSchool.Common/Enums/PayRateType.cs
@@ -1,12 +1,12 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+﻿using System.Text.Json.Serialization;
 
 namespace OutOfSchool.Common.Enums;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PayRateType
 {
-    Classes = 1,
+    None,
+    Classes,
     Month,
     Day,
     Year,

--- a/OutOfSchool/OutOfSchool.Common/Extensions/UintExtensions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Extensions/UintExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace OutOfSchool.Common.Extensions;
+
+public static class UintExtensions
+{
+    public static uint GetMaxValueIfNullOrZero(this uint? value)
+        => value is 0 or null ? uint.MaxValue : (uint)value;
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/IWorkshopRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/IWorkshopRepository.cs
@@ -8,7 +8,14 @@ namespace OutOfSchool.Services.Repository;
 
 public interface IWorkshopRepository : IEntityRepositorySoftDeleted<Guid, Workshop>
 {
-    Task<Workshop> GetWithNavigations(Guid id);
+    /// <summary>
+    /// Retrieves a workshop entity by its Id, including related navigation properties.
+    /// </summary>
+    /// <param name="id">The unique identifier of the workshop.</param>
+    /// <param name="asNoTracking">If true, the entity is retrieved without tracking changes.</param>
+    /// <returns>A <see cref="Task{Workshop}"/> representing the result of the asynchronous operation.
+    /// The task result contains the workshop entity with its navigation properties loaded, or null if not found.</returns>
+    Task<Workshop> GetWithNavigations(Guid id, bool asNoTracking = false);
 
     Task<IEnumerable<Workshop>> GetByIds(IEnumerable<Guid> ids);
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/WorkshopRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/WorkshopRepository.cs
@@ -31,14 +31,21 @@ public class WorkshopRepository : SensitiveEntityRepositorySoftDeleted<Workshop>
         await db.SaveChangesAsync();
     }
 
-    public async Task<Workshop> GetWithNavigations(Guid id)
+    /// <inheritdoc/>
+    public async Task<Workshop> GetWithNavigations(Guid id, bool asNoTracking = false)
     {
-        return await db.Workshops
+        IQueryable<Workshop> query = db.Workshops
             .Include(ws => ws.Address)
             .Include(ws => ws.Teachers)
             .Include(ws => ws.DateTimeRanges)
-            .Include(ws => ws.Images)
-            .SingleOrDefaultAsync(ws => ws.Id == id && !ws.IsDeleted);
+            .Include(ws => ws.Images);
+
+        if (asNoTracking)
+        {
+            query = query.AsNoTracking();
+        }
+
+        return await query.SingleOrDefaultAsync(ws => ws.Id == id && !ws.IsDeleted);
     }
 
     public async Task<IEnumerable<Workshop>> GetByIds(IEnumerable<Guid> ids)

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ApplicationControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ApplicationControllerTests.cs
@@ -246,7 +246,7 @@ public class ApplicationControllerTests
     {
         // Arrange
         httpContext.Setup(c => c.User.IsInRole("provider")).Returns(true);
-        workshopService.Setup(s => s.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(workshopDto);
+        workshopService.Setup(s => s.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshopDto);
         providerService.Setup(s => s.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
         List<ApplicationDto> app = applications.ToList();
         applicationService.Setup(s => s.GetAllByWorkshop(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ApplicationFilter>()))
@@ -299,7 +299,7 @@ public class ApplicationControllerTests
         httpContext.Setup(c => c.User.IsInRole("provider")).Returns(true);
 
         providerService.Setup(s => s.GetByUserId(userId, It.IsAny<bool>())).ReturnsAsync(newProvider);
-        workshopService.Setup(s => s.GetById(id, false)).ReturnsAsync(newWorkshop);
+        workshopService.Setup(s => s.GetById(id, It.IsAny<bool>())).ReturnsAsync(newWorkshop);
         providerService.Setup(s => s.GetById(id)).ReturnsAsync(newProvider);
         List<ApplicationDto> app1 = applications.Where(a => a.Workshop.ProviderId == id).ToList();
         applicationService.Setup(s => s.GetAllByProvider(id, filter))
@@ -329,7 +329,7 @@ public class ApplicationControllerTests
         httpContext.Setup(c => c.User.IsInRole("provider")).Returns(true);
 
         providerService.Setup(s => s.GetByUserId(userId, It.IsAny<bool>())).ReturnsAsync(newProvider);
-        workshopService.Setup(s => s.GetById(id, false)).ReturnsAsync(newWorkshop);
+        workshopService.Setup(s => s.GetById(id, It.IsAny<bool>())).ReturnsAsync(newWorkshop);
         providerService.Setup(s => s.GetById(id)).ReturnsAsync(newProvider);
         List<ApplicationDto> app1 = applications.Where(a => a.Workshop.ProviderId == id).ToList();
         applicationService.Setup(s => s.GetAllByProvider(id, filter))
@@ -355,7 +355,7 @@ public class ApplicationControllerTests
 
         httpContext.Setup(c => c.User.IsInRole("provider")).Returns(true);
 
-        workshopService.Setup(s => s.GetById(id, false)).ReturnsAsync(new WorkshopDto());
+        workshopService.Setup(s => s.GetById(id, It.IsAny<bool>())).ReturnsAsync(new WorkshopDto());
         applicationService.Setup(s => s.GetAllByWorkshop(id, It.IsAny<Guid>(), filter))
             .ThrowsAsync(new UnauthorizedAccessException());
 
@@ -405,7 +405,7 @@ public class ApplicationControllerTests
         };
 
         var workshop = new WorkshopDto();
-        workshopService.Setup(s => s.GetById(app.WorkshopId, false)).ReturnsAsync(workshop);
+        workshopService.Setup(s => s.GetById(app.WorkshopId, It.IsAny<bool>())).ReturnsAsync(workshop);
 
         blockedProviderParentService.Setup(s => s.IsBlocked(app.ParentId, workshop.ProviderId))
         .ReturnsAsync(false);
@@ -468,7 +468,7 @@ public class ApplicationControllerTests
 
         var workshop = new WorkshopDto();
 
-        workshopService.Setup(s => s.GetById(workshopId, false)).ReturnsAsync(workshop);
+        workshopService.Setup(s => s.GetById(workshopId, It.IsAny<bool>())).ReturnsAsync(workshop);
 
         blockedProviderParentService.Setup(s => s.IsBlocked(blockedParentId, workshop.ProviderId))
             .ReturnsAsync(true);
@@ -497,7 +497,7 @@ public class ApplicationControllerTests
             WorkshopId = nonExistentWorkshopId,
         };
 
-        workshopService.Setup(s => s.GetById(nonExistentWorkshopId, false)).ReturnsAsync((WorkshopDto)null);
+        workshopService.Setup(s => s.GetById(nonExistentWorkshopId, It.IsAny<bool>())).ReturnsAsync((WorkshopDto)null);
 
         // Act
         var result = await controller.Create(applicationWithNonExistentWorkshop).ConfigureAwait(false) as BadRequestObjectResult;
@@ -525,7 +525,7 @@ public class ApplicationControllerTests
             ParentId = anotherParent.Id,
         };
 
-        workshopService.Setup(s => s.GetById(applicationCreate.WorkshopId, false)).ReturnsAsync(new WorkshopDto()); 
+        workshopService.Setup(s => s.GetById(applicationCreate.WorkshopId, It.IsAny<bool>())).ReturnsAsync(new WorkshopDto()); 
 
         blockedProviderParentService.Setup(s => s.IsBlocked(applicationCreate.ParentId, It.IsAny<Guid>())).ReturnsAsync(false);
 
@@ -562,7 +562,7 @@ public class ApplicationControllerTests
         };
 
         applicationService.Setup(s => s.Update(It.IsAny<ApplicationUpdate>(), It.IsAny<Guid>())).ReturnsAsync(applications.First());
-        workshopService.Setup(s => s.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(new WorkshopDto());
+        workshopService.Setup(s => s.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(new WorkshopDto());
 
         // Act
         var result = await controller.Update(shortApplication).ConfigureAwait(false);
@@ -605,7 +605,7 @@ public class ApplicationControllerTests
 
         applicationService.Setup(s => s.Update(shortApplication, It.IsAny<Guid>()))
             .ThrowsAsync(new UnauthorizedAccessException());
-        workshopService.Setup(s => s.GetById(shortApplication.WorkshopId, false)).ReturnsAsync(new WorkshopDto());
+        workshopService.Setup(s => s.GetById(shortApplication.WorkshopId, It.IsAny<bool>())).ReturnsAsync(new WorkshopDto());
 
         // Act & Assert
         Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await controller.Update(shortApplication));

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ApplicationControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ApplicationControllerTests.cs
@@ -246,7 +246,7 @@ public class ApplicationControllerTests
     {
         // Arrange
         httpContext.Setup(c => c.User.IsInRole("provider")).Returns(true);
-        workshopService.Setup(s => s.GetById(It.IsAny<Guid>())).ReturnsAsync(workshopDto);
+        workshopService.Setup(s => s.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(workshopDto);
         providerService.Setup(s => s.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
         List<ApplicationDto> app = applications.ToList();
         applicationService.Setup(s => s.GetAllByWorkshop(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ApplicationFilter>()))
@@ -299,7 +299,7 @@ public class ApplicationControllerTests
         httpContext.Setup(c => c.User.IsInRole("provider")).Returns(true);
 
         providerService.Setup(s => s.GetByUserId(userId, It.IsAny<bool>())).ReturnsAsync(newProvider);
-        workshopService.Setup(s => s.GetById(id)).ReturnsAsync(newWorkshop);
+        workshopService.Setup(s => s.GetById(id, false)).ReturnsAsync(newWorkshop);
         providerService.Setup(s => s.GetById(id)).ReturnsAsync(newProvider);
         List<ApplicationDto> app1 = applications.Where(a => a.Workshop.ProviderId == id).ToList();
         applicationService.Setup(s => s.GetAllByProvider(id, filter))
@@ -329,7 +329,7 @@ public class ApplicationControllerTests
         httpContext.Setup(c => c.User.IsInRole("provider")).Returns(true);
 
         providerService.Setup(s => s.GetByUserId(userId, It.IsAny<bool>())).ReturnsAsync(newProvider);
-        workshopService.Setup(s => s.GetById(id)).ReturnsAsync(newWorkshop);
+        workshopService.Setup(s => s.GetById(id, false)).ReturnsAsync(newWorkshop);
         providerService.Setup(s => s.GetById(id)).ReturnsAsync(newProvider);
         List<ApplicationDto> app1 = applications.Where(a => a.Workshop.ProviderId == id).ToList();
         applicationService.Setup(s => s.GetAllByProvider(id, filter))
@@ -355,7 +355,7 @@ public class ApplicationControllerTests
 
         httpContext.Setup(c => c.User.IsInRole("provider")).Returns(true);
 
-        workshopService.Setup(s => s.GetById(id)).ReturnsAsync(new WorkshopDto());
+        workshopService.Setup(s => s.GetById(id, false)).ReturnsAsync(new WorkshopDto());
         applicationService.Setup(s => s.GetAllByWorkshop(id, It.IsAny<Guid>(), filter))
             .ThrowsAsync(new UnauthorizedAccessException());
 
@@ -405,7 +405,7 @@ public class ApplicationControllerTests
         };
 
         var workshop = new WorkshopDto();
-        workshopService.Setup(s => s.GetById(app.WorkshopId)).ReturnsAsync(workshop);
+        workshopService.Setup(s => s.GetById(app.WorkshopId, false)).ReturnsAsync(workshop);
 
         blockedProviderParentService.Setup(s => s.IsBlocked(app.ParentId, workshop.ProviderId))
         .ReturnsAsync(false);
@@ -468,7 +468,7 @@ public class ApplicationControllerTests
 
         var workshop = new WorkshopDto();
 
-        workshopService.Setup(s => s.GetById(workshopId)).ReturnsAsync(workshop);
+        workshopService.Setup(s => s.GetById(workshopId, false)).ReturnsAsync(workshop);
 
         blockedProviderParentService.Setup(s => s.IsBlocked(blockedParentId, workshop.ProviderId))
             .ReturnsAsync(true);
@@ -497,7 +497,7 @@ public class ApplicationControllerTests
             WorkshopId = nonExistentWorkshopId,
         };
 
-        workshopService.Setup(s => s.GetById(nonExistentWorkshopId)).ReturnsAsync((WorkshopDto)null);
+        workshopService.Setup(s => s.GetById(nonExistentWorkshopId, false)).ReturnsAsync((WorkshopDto)null);
 
         // Act
         var result = await controller.Create(applicationWithNonExistentWorkshop).ConfigureAwait(false) as BadRequestObjectResult;
@@ -525,7 +525,7 @@ public class ApplicationControllerTests
             ParentId = anotherParent.Id,
         };
 
-        workshopService.Setup(s => s.GetById(applicationCreate.WorkshopId)).ReturnsAsync(new WorkshopDto()); 
+        workshopService.Setup(s => s.GetById(applicationCreate.WorkshopId, false)).ReturnsAsync(new WorkshopDto()); 
 
         blockedProviderParentService.Setup(s => s.IsBlocked(applicationCreate.ParentId, It.IsAny<Guid>())).ReturnsAsync(false);
 
@@ -562,7 +562,7 @@ public class ApplicationControllerTests
         };
 
         applicationService.Setup(s => s.Update(It.IsAny<ApplicationUpdate>(), It.IsAny<Guid>())).ReturnsAsync(applications.First());
-        workshopService.Setup(s => s.GetById(It.IsAny<Guid>())).ReturnsAsync(new WorkshopDto());
+        workshopService.Setup(s => s.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(new WorkshopDto());
 
         // Act
         var result = await controller.Update(shortApplication).ConfigureAwait(false);
@@ -605,7 +605,7 @@ public class ApplicationControllerTests
 
         applicationService.Setup(s => s.Update(shortApplication, It.IsAny<Guid>()))
             .ThrowsAsync(new UnauthorizedAccessException());
-        workshopService.Setup(s => s.GetById(shortApplication.WorkshopId)).ReturnsAsync(new WorkshopDto());
+        workshopService.Setup(s => s.GetById(shortApplication.WorkshopId, false)).ReturnsAsync(new WorkshopDto());
 
         // Act & Assert
         Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await controller.Update(shortApplication));

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -533,7 +533,6 @@ public class WorkshopControllerTests
         workshopUpdateDto.ProviderId = provider.Id;
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshop);
         workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<WorkshopDto>())).Returns(false);
 
         // Act
@@ -541,27 +540,7 @@ public class WorkshopControllerTests
 
         // Assert
         providerServiceMoq.VerifyAll();
-        workshopServiceMoq.VerifyAll();
-        Assert.IsNotNull(result);
-        Assert.AreEqual(BadRequest, result.StatusCode);
-    }
-
-    [Test]
-    public async Task UpdateWorkshop_WhenWorkshopEntityNotExist_ShouldReturnBadRequestObjectResult()
-    {
-        // Arrange
-        workshopUpdateDto.ProviderId = provider.Id;
-        var workshopDto = null as WorkshopDto;
-        providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
-        providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshopDto);
-
-        // Act
-        var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;
-
-        // Assert
-        providerServiceMoq.VerifyAll();
-        workshopServiceMoq.VerifyAll();
+        workshopServiceMoq.Verify(x => x.Update(It.IsAny<WorkshopBaseDto>()), Times.Never);
         Assert.IsNotNull(result);
         Assert.AreEqual(BadRequest, result.StatusCode);
     }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -481,7 +481,8 @@ public class WorkshopControllerTests
         workshopUpdateDto.ProviderId = provider.Id;
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<Guid>())).ReturnsAsync(true);
+        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<WorkshopDto>())).Returns(true);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshop);
         workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto)).ReturnsAsync(workshopUpdateDto);
 
         // Act
@@ -532,7 +533,7 @@ public class WorkshopControllerTests
         workshopUpdateDto.ProviderId = provider.Id;
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<Guid>())).ReturnsAsync(false);
+        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<WorkshopDto>())).Returns(false);
 
         // Act
         var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -481,8 +481,7 @@ public class WorkshopControllerTests
         workshopUpdateDto.ProviderId = provider.Id;
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<WorkshopDto>())).Returns(true);
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshop);
+        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<Guid>())).ReturnsAsync(true);
         workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto)).ReturnsAsync(workshopUpdateDto);
 
         // Act
@@ -533,7 +532,7 @@ public class WorkshopControllerTests
         workshopUpdateDto.ProviderId = provider.Id;
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<WorkshopDto>())).Returns(false);
+        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<Guid>())).ReturnsAsync(false);
 
         // Act
         var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -483,8 +483,6 @@ public class WorkshopControllerTests
         providerServiceMoq.Setup(x => x.IsBlocked(provider.Id)).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(userId, It.IsAny<bool>()))
             .ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(It.IsAny<uint?>(), workshop))
-            .Returns(true);
         workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto))
             .ReturnsAsync(Result<WorkshopBaseDto>.Success(workshopUpdateDto));
 
@@ -500,12 +498,6 @@ public class WorkshopControllerTests
     public async Task UpdateWorkshop_WhenModelIsInvalid_ShouldReturnBadRequestObjectResult()
     {
         // Arrange
-        //workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto))
-        //    .ReturnsAsync(Result<WorkshopBaseDto>.Failed(new OperationError
-        //    {
-        //        Code = HttpStatusCode.BadRequest.ToString(),
-        //        Description = "Workshop not found.",
-        //    }));
         controller.ModelState.AddModelError("CreateWorkshop", "Invalid model state.");
 
         // Act
@@ -534,50 +526,6 @@ public class WorkshopControllerTests
         Assert.IsNotNull(result);
         Assert.AreEqual(Forbidden, result.StatusCode);
     }
-
-    //[Test]
-    //public async Task UpdateWorkshop_WhenWorkshopDoesntExist_ShouldReturnBadRequestObjectResult()
-    //{
-    //    // Arrange
-    //    workshopUpdateDto.ProviderId = provider.Id;
-    //    providerServiceMoq.Setup(x => x.IsBlocked(provider.Id)).ReturnsAsync(false);
-    //    providerServiceMoq.Setup(x => x.GetByUserId(userId, It.IsAny<bool>()))
-    //        .ReturnsAsync(provider);
-    //    bool? validationResult = null;
-    //    workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(
-    //        It.IsAny<uint?>(), workshop)).Returns(validationResult);
-
-    //    // Act
-    //    var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;
-
-    //    // Assert
-    //    providerServiceMoq.VerifyAll();
-    //    workshopServiceMoq.Verify(x => x.Update(It.IsAny<WorkshopBaseDto>()), Times.Never);
-    //    Assert.IsNotNull(result);
-    //    Assert.AreEqual(BadRequest, result.StatusCode);
-    //}
-
-    //[Test]
-    //public async Task UpdateWorkshop_WhenDtoAvailableSeatsIsInvalid_ShouldReturnBadRequestObjectResult()
-    //{
-    //    // Arrange
-    //    workshopUpdateDto.ProviderId = provider.Id;
-    //    providerServiceMoq.Setup(x => x.IsBlocked(provider.Id)).ReturnsAsync(false);
-    //    providerServiceMoq.Setup(x => x.GetByUserId(userId, It.IsAny<bool>()))
-    //        .ReturnsAsync(provider);
-    //    bool? validationResult = false;
-    //    workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(
-    //        It.IsAny<uint?>(), workshopUpdateDto.Id)).ReturnsAsync(validationResult);
-
-    //    // Act
-    //    var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;
-
-    //    // Assert
-    //    providerServiceMoq.VerifyAll();
-    //    workshopServiceMoq.Verify(x => x.Update(It.IsAny<WorkshopBaseDto>()), Times.Never);
-    //    Assert.IsNotNull(result);
-    //    Assert.AreEqual(BadRequest, result.StatusCode);
-    //}
 
     [Test]
     public async Task UpdateWorkshop_WhenDtoIsNull_ShouldReturnBadRequestObjectResult()

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using OutOfSchool.BusinessLogic;
+using OutOfSchool.BusinessLogic.Common;
 using OutOfSchool.BusinessLogic.Config;
 using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.Providers;
@@ -482,9 +483,10 @@ public class WorkshopControllerTests
         providerServiceMoq.Setup(x => x.IsBlocked(provider.Id)).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(userId, It.IsAny<bool>()))
             .ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(It.IsAny<uint?>(), workshopUpdateDto.Id))
-            .ReturnsAsync(true);
-        workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto)).ReturnsAsync(workshopUpdateDto);
+        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(It.IsAny<uint?>(), workshop))
+            .Returns(true);
+        workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto))
+            .ReturnsAsync(Result<WorkshopBaseDto>.Success(workshopUpdateDto));
 
         // Act
         var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as OkObjectResult;
@@ -498,7 +500,12 @@ public class WorkshopControllerTests
     public async Task UpdateWorkshop_WhenModelIsInvalid_ShouldReturnBadRequestObjectResult()
     {
         // Arrange
-        workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto)).ReturnsAsync(workshopUpdateDto);
+        //workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto))
+        //    .ReturnsAsync(Result<WorkshopBaseDto>.Failed(new OperationError
+        //    {
+        //        Code = HttpStatusCode.BadRequest.ToString(),
+        //        Description = "Workshop not found.",
+        //    }));
         controller.ModelState.AddModelError("CreateWorkshop", "Invalid model state.");
 
         // Act
@@ -528,49 +535,49 @@ public class WorkshopControllerTests
         Assert.AreEqual(Forbidden, result.StatusCode);
     }
 
-    [Test]
-    public async Task UpdateWorkshop_WhenWorkshopDoesntExist_ShouldReturnBadRequestObjectResult()
-    {
-        // Arrange
-        workshopUpdateDto.ProviderId = provider.Id;
-        providerServiceMoq.Setup(x => x.IsBlocked(provider.Id)).ReturnsAsync(false);
-        providerServiceMoq.Setup(x => x.GetByUserId(userId, It.IsAny<bool>()))
-            .ReturnsAsync(provider);
-        bool? validationResult = null;
-        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(
-            It.IsAny<uint?>(), workshopUpdateDto.Id)).ReturnsAsync(validationResult);
+    //[Test]
+    //public async Task UpdateWorkshop_WhenWorkshopDoesntExist_ShouldReturnBadRequestObjectResult()
+    //{
+    //    // Arrange
+    //    workshopUpdateDto.ProviderId = provider.Id;
+    //    providerServiceMoq.Setup(x => x.IsBlocked(provider.Id)).ReturnsAsync(false);
+    //    providerServiceMoq.Setup(x => x.GetByUserId(userId, It.IsAny<bool>()))
+    //        .ReturnsAsync(provider);
+    //    bool? validationResult = null;
+    //    workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(
+    //        It.IsAny<uint?>(), workshop)).Returns(validationResult);
 
-        // Act
-        var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;
+    //    // Act
+    //    var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;
 
-        // Assert
-        providerServiceMoq.VerifyAll();
-        workshopServiceMoq.Verify(x => x.Update(It.IsAny<WorkshopBaseDto>()), Times.Never);
-        Assert.IsNotNull(result);
-        Assert.AreEqual(BadRequest, result.StatusCode);
-    }
+    //    // Assert
+    //    providerServiceMoq.VerifyAll();
+    //    workshopServiceMoq.Verify(x => x.Update(It.IsAny<WorkshopBaseDto>()), Times.Never);
+    //    Assert.IsNotNull(result);
+    //    Assert.AreEqual(BadRequest, result.StatusCode);
+    //}
 
-    [Test]
-    public async Task UpdateWorkshop_WhenDtoAvailableSeatsIsInvalid_ShouldReturnBadRequestObjectResult()
-    {
-        // Arrange
-        workshopUpdateDto.ProviderId = provider.Id;
-        providerServiceMoq.Setup(x => x.IsBlocked(provider.Id)).ReturnsAsync(false);
-        providerServiceMoq.Setup(x => x.GetByUserId(userId, It.IsAny<bool>()))
-            .ReturnsAsync(provider);
-        bool? validationResult = false;
-        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(
-            It.IsAny<uint?>(), workshopUpdateDto.Id)).ReturnsAsync(validationResult);
+    //[Test]
+    //public async Task UpdateWorkshop_WhenDtoAvailableSeatsIsInvalid_ShouldReturnBadRequestObjectResult()
+    //{
+    //    // Arrange
+    //    workshopUpdateDto.ProviderId = provider.Id;
+    //    providerServiceMoq.Setup(x => x.IsBlocked(provider.Id)).ReturnsAsync(false);
+    //    providerServiceMoq.Setup(x => x.GetByUserId(userId, It.IsAny<bool>()))
+    //        .ReturnsAsync(provider);
+    //    bool? validationResult = false;
+    //    workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(
+    //        It.IsAny<uint?>(), workshopUpdateDto.Id)).ReturnsAsync(validationResult);
 
-        // Act
-        var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;
+    //    // Act
+    //    var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;
 
-        // Assert
-        providerServiceMoq.VerifyAll();
-        workshopServiceMoq.Verify(x => x.Update(It.IsAny<WorkshopBaseDto>()), Times.Never);
-        Assert.IsNotNull(result);
-        Assert.AreEqual(BadRequest, result.StatusCode);
-    }
+    //    // Assert
+    //    providerServiceMoq.VerifyAll();
+    //    workshopServiceMoq.Verify(x => x.Update(It.IsAny<WorkshopBaseDto>()), Times.Never);
+    //    Assert.IsNotNull(result);
+    //    Assert.AreEqual(BadRequest, result.StatusCode);
+    //}
 
     [Test]
     public async Task UpdateWorkshop_WhenDtoIsNull_ShouldReturnBadRequestObjectResult()

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -480,8 +480,10 @@ public class WorkshopControllerTests
         // Arrange
         workshopUpdateDto.ProviderId = provider.Id;
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
-        providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<Guid>())).ReturnsAsync(true);
+        providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(provider);
+        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(It.IsAny<uint?>(), It.IsAny<Guid>()))
+            .ReturnsAsync(true);
         workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto)).ReturnsAsync(workshopUpdateDto);
 
         // Act
@@ -531,8 +533,10 @@ public class WorkshopControllerTests
         // Arrange
         workshopUpdateDto.ProviderId = provider.Id;
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
-        providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<Guid>())).ReturnsAsync(false);
+        providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(provider);
+        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(
+            It.IsAny<uint?>(), It.IsAny<Guid>())).ReturnsAsync(false);
 
         // Act
         var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -533,6 +533,7 @@ public class WorkshopControllerTests
         workshopUpdateDto.ProviderId = provider.Id;
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshop);
         workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<WorkshopDto>())).Returns(false);
 
         // Act
@@ -540,7 +541,27 @@ public class WorkshopControllerTests
 
         // Assert
         providerServiceMoq.VerifyAll();
-        workshopServiceMoq.Verify(x => x.Update(It.IsAny<WorkshopBaseDto>()), Times.Never);
+        workshopServiceMoq.VerifyAll();
+        Assert.IsNotNull(result);
+        Assert.AreEqual(BadRequest, result.StatusCode);
+    }
+
+    [Test]
+    public async Task UpdateWorkshop_WhenWorkshopEntityNotExist_ShouldReturnBadRequestObjectResult()
+    {
+        // Arrange
+        workshopUpdateDto.ProviderId = provider.Id;
+        var workshopDto = null as WorkshopDto;
+        providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
+        providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshopDto);
+
+        // Act
+        var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;
+
+        // Assert
+        providerServiceMoq.VerifyAll();
+        workshopServiceMoq.VerifyAll();
         Assert.IsNotNull(result);
         Assert.AreEqual(BadRequest, result.StatusCode);
     }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -571,6 +571,20 @@ public class WorkshopControllerTests
         Assert.IsNotNull(result);
         Assert.AreEqual(BadRequest, result.StatusCode);
     }
+
+    [Test]
+    public async Task UpdateWorkshop_WhenDtoIsNull_ShouldReturnBadRequestObjectResult()
+    {
+        // Arrange
+        WorkshopBaseDto workshopBaseDto = null;
+
+        // Act
+        var result = await controller.Update(workshopBaseDto).ConfigureAwait(false) as ObjectResult;
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(BadRequest, result.StatusCode);
+    }
     #endregion
 
     #region UpdateStatus

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -481,7 +481,7 @@ public class WorkshopControllerTests
         workshopUpdateDto.ProviderId = provider.Id;
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), true)).ReturnsAsync(new WorkshopDto());
+        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<Guid>())).ReturnsAsync(true);
         workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto)).ReturnsAsync(workshopUpdateDto);
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -105,7 +105,7 @@ public class WorkshopControllerTests
     public async Task GetWorkshopById_WhenIdIsValid_ShouldReturnOkResultObject()
     {
         // Arrange
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(workshop);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshop);
 
         // Act
         var result = await controller.GetById(workshop.Id).ConfigureAwait(false) as OkObjectResult;
@@ -120,7 +120,7 @@ public class WorkshopControllerTests
     public async Task GetWorkshopById_WhenThereIsNoWorkshopWithId_ShouldReturnNoContent()
     {
         // Arrange
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), false)).ReturnsAsync((WorkshopDto)null);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync((WorkshopDto)null);
 
         // Act
         var result = await controller.GetById(workshop.Id).ConfigureAwait(false) as NoContentResult;
@@ -537,7 +537,7 @@ public class WorkshopControllerTests
 
         var updateRequest = WithWorkshopStatusDto(workshop.Id, WorkshopStatus.Open);
 
-        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId, false))
+        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId, It.IsAny<bool>()))
             .ReturnsAsync(workshop);
         workshopServiceMoq.Setup(x => x.UpdateStatus(updateRequest))
             .ReturnsAsync(updateRequest);
@@ -559,7 +559,7 @@ public class WorkshopControllerTests
 
         var updateRequest = WithWorkshopStatusDto(nonExistentId, WorkshopStatus.Open);
 
-        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId, false))
+        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId, It.IsAny<bool>()))
             .ReturnsAsync(null as WorkshopDto);
 
         // Act
@@ -580,7 +580,7 @@ public class WorkshopControllerTests
         workshop.ProviderOwnership = OwnershipType.Common;
 
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId, false))
+        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId, It.IsAny<bool>()))
             .ReturnsAsync(workshop);
         workshopServiceMoq.Setup(x => x.UpdateStatus(updateRequest)).
             ThrowsAsync(new ArgumentException(It.IsAny<string>()));
@@ -599,7 +599,7 @@ public class WorkshopControllerTests
         // Arrange
         var workShopStatusDto = WithWorkshopStatusDto(workshop.Id, WorkshopStatus.Open);
         var notAuthorProvider = new ProviderDto() { Id = It.IsAny<Guid>(), UserId = userId };
-        workshopServiceMoq.Setup(x => x.GetById(workShopStatusDto.WorkshopId, false))
+        workshopServiceMoq.Setup(x => x.GetById(workShopStatusDto.WorkshopId, It.IsAny<bool>()))
             .ReturnsAsync(workshop);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(notAuthorProvider);
 
@@ -620,7 +620,7 @@ public class WorkshopControllerTests
     {
         // Arrange
         workshop.ProviderId = provider.Id;
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(workshop);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshop);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
         workshopServiceMoq.Setup(x => x.Delete(workshop.Id)).Returns(Task.CompletedTask);
@@ -640,7 +640,7 @@ public class WorkshopControllerTests
     public async Task DeleteWorkshop_WhenThereIsNoWorkshopWithId_ShouldNoContentResult()
     {
         // Arrange
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(() => null);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(() => null);
 
         // Act
         var result = await controller.Delete(workshop.Id) as NoContentResult;
@@ -656,7 +656,7 @@ public class WorkshopControllerTests
     public async Task DeleteWorkshop_WhenIdProviderHasNoRights_ShouldReturn403ObjectResult()
     {
         // Arrange
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(workshop);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshop);
         var notAuthorProvider = new ProviderDto() { Id = It.IsAny<Guid>(), UserId = userId };
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(notAuthorProvider);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -524,6 +524,25 @@ public class WorkshopControllerTests
         Assert.IsNotNull(result);
         Assert.AreEqual(Forbidden, result.StatusCode);
     }
+
+    [Test]
+    public async Task UpdateWorkshop_WhenDtoAvailableSeatsIsInvalid_ShouldReturnBadRequestObjectResult()
+    {
+        // Arrange
+        workshopUpdateDto.ProviderId = provider.Id;
+        providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
+        providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
+        workshopServiceMoq.Setup(x => x.IsAvailableSeatsValid(It.IsAny<uint?>(), It.IsAny<Guid>())).ReturnsAsync(false);
+
+        // Act
+        var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;
+
+        // Assert
+        providerServiceMoq.VerifyAll();
+        workshopServiceMoq.Verify(x => x.Update(It.IsAny<WorkshopBaseDto>()), Times.Never);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(BadRequest, result.StatusCode);
+    }
     #endregion
 
     #region UpdateStatus

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -105,7 +105,7 @@ public class WorkshopControllerTests
     public async Task GetWorkshopById_WhenIdIsValid_ShouldReturnOkResultObject()
     {
         // Arrange
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>())).ReturnsAsync(workshop);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(workshop);
 
         // Act
         var result = await controller.GetById(workshop.Id).ConfigureAwait(false) as OkObjectResult;
@@ -120,7 +120,7 @@ public class WorkshopControllerTests
     public async Task GetWorkshopById_WhenThereIsNoWorkshopWithId_ShouldReturnNoContent()
     {
         // Arrange
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>())).ReturnsAsync((WorkshopDto)null);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), false)).ReturnsAsync((WorkshopDto)null);
 
         // Act
         var result = await controller.GetById(workshop.Id).ConfigureAwait(false) as NoContentResult;
@@ -481,6 +481,7 @@ public class WorkshopControllerTests
         workshopUpdateDto.ProviderId = provider.Id;
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), true)).ReturnsAsync(new WorkshopDto());
         workshopServiceMoq.Setup(x => x.Update(workshopUpdateDto)).ReturnsAsync(workshopUpdateDto);
 
         // Act
@@ -536,7 +537,7 @@ public class WorkshopControllerTests
 
         var updateRequest = WithWorkshopStatusDto(workshop.Id, WorkshopStatus.Open);
 
-        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId))
+        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId, false))
             .ReturnsAsync(workshop);
         workshopServiceMoq.Setup(x => x.UpdateStatus(updateRequest))
             .ReturnsAsync(updateRequest);
@@ -558,7 +559,7 @@ public class WorkshopControllerTests
 
         var updateRequest = WithWorkshopStatusDto(nonExistentId, WorkshopStatus.Open);
 
-        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId))
+        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId, false))
             .ReturnsAsync(null as WorkshopDto);
 
         // Act
@@ -579,7 +580,7 @@ public class WorkshopControllerTests
         workshop.ProviderOwnership = OwnershipType.Common;
 
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
-        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId))
+        workshopServiceMoq.Setup(x => x.GetById(updateRequest.WorkshopId, false))
             .ReturnsAsync(workshop);
         workshopServiceMoq.Setup(x => x.UpdateStatus(updateRequest)).
             ThrowsAsync(new ArgumentException(It.IsAny<string>()));
@@ -598,7 +599,7 @@ public class WorkshopControllerTests
         // Arrange
         var workShopStatusDto = WithWorkshopStatusDto(workshop.Id, WorkshopStatus.Open);
         var notAuthorProvider = new ProviderDto() { Id = It.IsAny<Guid>(), UserId = userId };
-        workshopServiceMoq.Setup(x => x.GetById(workShopStatusDto.WorkshopId))
+        workshopServiceMoq.Setup(x => x.GetById(workShopStatusDto.WorkshopId, false))
             .ReturnsAsync(workshop);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(notAuthorProvider);
 
@@ -619,7 +620,7 @@ public class WorkshopControllerTests
     {
         // Arrange
         workshop.ProviderId = provider.Id;
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>())).ReturnsAsync(workshop);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(workshop);
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(provider);
         providerServiceMoq.Setup(x => x.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
         workshopServiceMoq.Setup(x => x.Delete(workshop.Id)).Returns(Task.CompletedTask);
@@ -639,7 +640,7 @@ public class WorkshopControllerTests
     public async Task DeleteWorkshop_WhenThereIsNoWorkshopWithId_ShouldNoContentResult()
     {
         // Arrange
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>())).ReturnsAsync(() => null);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(() => null);
 
         // Act
         var result = await controller.Delete(workshop.Id) as NoContentResult;
@@ -655,7 +656,7 @@ public class WorkshopControllerTests
     public async Task DeleteWorkshop_WhenIdProviderHasNoRights_ShouldReturn403ObjectResult()
     {
         // Arrange
-        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>())).ReturnsAsync(workshop);
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), false)).ReturnsAsync(workshop);
         var notAuthorProvider = new ProviderDto() { Id = It.IsAny<Guid>(), UserId = userId };
         providerServiceMoq.Setup(x => x.GetByUserId(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(notAuthorProvider);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -558,8 +558,9 @@ public class WorkshopControllerTests
         providerServiceMoq.Setup(x => x.IsBlocked(provider.Id)).ReturnsAsync(false);
         providerServiceMoq.Setup(x => x.GetByUserId(userId, It.IsAny<bool>()))
             .ReturnsAsync(provider);
+        bool? validationResult = false;
         workshopServiceMoq.Setup(x => x.IsAvailableSeatsValidForWorkshop(
-            It.IsAny<uint?>(), workshopUpdateDto.Id)).ReturnsAsync(false);
+            It.IsAny<uint?>(), workshopUpdateDto.Id)).ReturnsAsync(validationResult);
 
         // Act
         var result = await controller.Update(workshopUpdateDto).ConfigureAwait(false) as ObjectResult;

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
@@ -231,7 +231,7 @@ public class ApplicationServiceTests
 
         currentUserServiceMock.Setup(x => x.UserHasRights(It.IsAny<ParentRights>())).Returns(() => Task.FromResult(true));
 
-        workshopServiceCombinerMock.Setup(x => x.GetById(application.WorkshopId, false)).Returns(Task.FromResult(new WorkshopDto()));
+        workshopServiceCombinerMock.Setup(x => x.GetById(application.WorkshopId, It.IsAny<bool>())).Returns(Task.FromResult(new WorkshopDto()));
 
         var applications = new List<Application>
         {
@@ -593,7 +593,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), It.IsAny<bool>()))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -677,7 +677,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), It.IsAny<bool>()))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -755,7 +755,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), It.IsAny<bool>()))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -818,7 +818,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), It.IsAny<bool>()))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -881,7 +881,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), It.IsAny<bool>()))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -963,7 +963,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), It.IsAny<bool>()))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -1028,7 +1028,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), It.IsAny<bool>()))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -1083,7 +1083,7 @@ public class ApplicationServiceTests
                 It.IsAny<Expression<Func<Application, bool>>>(),
                 It.IsAny<string>()))
             .Returns(Task.FromResult<IEnumerable<Application>>(new List<Application> {application}));
-        workshopServiceCombinerMock.Setup(x => x.GetById(application.WorkshopId, false)).ReturnsAsync(workshopMock);
+        workshopServiceCombinerMock.Setup(x => x.GetById(application.WorkshopId, It.IsAny<bool>())).ReturnsAsync(workshopMock);
     }
 
     private void SetupGetAll(List<Application> apps)

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
@@ -231,7 +231,7 @@ public class ApplicationServiceTests
 
         currentUserServiceMock.Setup(x => x.UserHasRights(It.IsAny<ParentRights>())).Returns(() => Task.FromResult(true));
 
-        workshopServiceCombinerMock.Setup(x => x.GetById(application.WorkshopId)).Returns(Task.FromResult(new WorkshopDto()));
+        workshopServiceCombinerMock.Setup(x => x.GetById(application.WorkshopId, false)).Returns(Task.FromResult(new WorkshopDto()));
 
         var applications = new List<Application>
         {
@@ -593,7 +593,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId)))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -677,7 +677,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId)))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -755,7 +755,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId)))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -818,7 +818,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId)))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -881,7 +881,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId)))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -963,7 +963,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId)))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -1028,7 +1028,7 @@ public class ApplicationServiceTests
         };
 
         workshopServiceCombinerMock.Setup(c =>
-                c.GetById(It.Is<Guid>(i => i == update.WorkshopId)))
+                c.GetById(It.Is<Guid>(i => i == update.WorkshopId), false))
             .ReturnsAsync(new WorkshopDto()
             {
                 Id = update.WorkshopId,
@@ -1083,7 +1083,7 @@ public class ApplicationServiceTests
                 It.IsAny<Expression<Func<Application, bool>>>(),
                 It.IsAny<string>()))
             .Returns(Task.FromResult<IEnumerable<Application>>(new List<Application> {application}));
-        workshopServiceCombinerMock.Setup(x => x.GetById(application.WorkshopId)).ReturnsAsync(workshopMock);
+        workshopServiceCombinerMock.Setup(x => x.GetById(application.WorkshopId, false)).ReturnsAsync(workshopMock);
     }
 
     private void SetupGetAll(List<Application> apps)

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -559,7 +559,7 @@ public class ChatRoomWorkshopServiceTests
         var expectedEmptyList = new List<ChatRoomWorkshopDtoWithLastMessage>();
 
         roomWithSpecialModelRepositoryMock
-            .Setup(x => x.GetByParentIdAsync(invalidParentId, false))
+            .Setup(x => x.GetByParentIdAsync(invalidParentId, It.IsAny<bool>()))
             .Returns(Task.FromResult(new List<ChatRoomWorkshopForChatList>()));
 
         // Act
@@ -580,7 +580,7 @@ public class ChatRoomWorkshopServiceTests
         var expectedEmptyList = new List<ChatRoomWorkshopDtoWithLastMessage>();
 
         roomWithSpecialModelRepositoryMock
-            .Setup(x => x.GetByWorkshopIdsAsync(It.IsAny<IEnumerable<Guid>>(), true))
+            .Setup(x => x.GetByWorkshopIdsAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<bool>()))
             .Returns(Task.FromResult(new List<ChatRoomWorkshopForChatList>()));
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -241,7 +241,7 @@ public class ChatRoomWorkshopServiceTests
         {
             new ChatRoomWorkshopForChatList() { Id = Guid.NewGuid(), ParentId = existingParentId },
         };
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(existingParentId, It.IsAny<bool>())).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(existingParentId, default)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByParentIdAsync(existingParentId).ConfigureAwait(false);
@@ -259,7 +259,7 @@ public class ChatRoomWorkshopServiceTests
         var notExistingParentId = Guid.NewGuid();
         var validRooms = new List<ChatRoomWorkshopForChatList>();
 
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(notExistingParentId, It.IsAny<bool>())).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(notExistingParentId, default)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByParentIdAsync(notExistingParentId).ConfigureAwait(false);
@@ -281,7 +281,7 @@ public class ChatRoomWorkshopServiceTests
         {
             new ChatRoomWorkshopForChatList() { Id = Guid.NewGuid(), Workshop = new WorkshopInfoForChatList() { Id = Guid.NewGuid(), ProviderId = existingProviderId } },
         };
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByProviderIdAsync(existingProviderId, It.IsAny<bool>())).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByProviderIdAsync(existingProviderId, true)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByProviderIdAsync(existingProviderId).ConfigureAwait(false);
@@ -299,7 +299,7 @@ public class ChatRoomWorkshopServiceTests
         var notExistingProviderId = Guid.NewGuid();
         var validRooms = new List<ChatRoomWorkshopForChatList>();
 
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByProviderIdAsync(notExistingProviderId, It.IsAny<bool>())).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByProviderIdAsync(notExistingProviderId, true)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByProviderIdAsync(notExistingProviderId).ConfigureAwait(false);
@@ -322,7 +322,7 @@ public class ChatRoomWorkshopServiceTests
         {
             new ChatRoomWorkshopForChatList() { Id = Guid.NewGuid(), WorkshopId = existingWorkshopId, Workshop = new WorkshopInfoForChatList() { Id = existingWorkshopId } },
         };
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(existingWorkshopId, It.IsAny<bool>())).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(existingWorkshopId, default)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByWorkshopIdAsync(existingWorkshopId).ConfigureAwait(false);
@@ -341,7 +341,7 @@ public class ChatRoomWorkshopServiceTests
         var notExistingWorkshopId = Guid.NewGuid();
         var validRooms = new List<ChatRoomWorkshopForChatList>();
 
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(notExistingWorkshopId, It.IsAny<bool>())).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(notExistingWorkshopId, default)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByWorkshopIdAsync(notExistingWorkshopId).ConfigureAwait(false);
@@ -499,7 +499,7 @@ public class ChatRoomWorkshopServiceTests
         var expectedCount = chatRooms.Count(r => r.NotReadByCurrentUserMessagesCount > 0);
 
         roomWithSpecialModelRepositoryMock
-            .Setup(x => x.GetByParentIdAsync(parentId, It.IsAny<bool>()))
+            .Setup(x => x.GetByParentIdAsync(parentId, default))
             .ReturnsAsync(chatRooms);
 
         // Act
@@ -525,7 +525,7 @@ public class ChatRoomWorkshopServiceTests
         var expectedCount = chatRooms.Count(r => r.NotReadByCurrentUserMessagesCount > 0);
 
         roomWithSpecialModelRepositoryMock
-            .Setup(x => x.GetByProviderIdAsync(providerId, It.IsAny<bool>()))
+            .Setup(x => x.GetByProviderIdAsync(providerId, true))
             .ReturnsAsync(chatRooms);
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -241,7 +241,7 @@ public class ChatRoomWorkshopServiceTests
         {
             new ChatRoomWorkshopForChatList() { Id = Guid.NewGuid(), ParentId = existingParentId },
         };
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(existingParentId, default)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(existingParentId, It.IsAny<bool>())).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByParentIdAsync(existingParentId).ConfigureAwait(false);
@@ -259,7 +259,7 @@ public class ChatRoomWorkshopServiceTests
         var notExistingParentId = Guid.NewGuid();
         var validRooms = new List<ChatRoomWorkshopForChatList>();
 
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(notExistingParentId, default)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(notExistingParentId, It.IsAny<bool>())).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByParentIdAsync(notExistingParentId).ConfigureAwait(false);
@@ -281,7 +281,7 @@ public class ChatRoomWorkshopServiceTests
         {
             new ChatRoomWorkshopForChatList() { Id = Guid.NewGuid(), Workshop = new WorkshopInfoForChatList() { Id = Guid.NewGuid(), ProviderId = existingProviderId } },
         };
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByProviderIdAsync(existingProviderId, true)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByProviderIdAsync(existingProviderId, It.IsAny<bool>())).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByProviderIdAsync(existingProviderId).ConfigureAwait(false);
@@ -299,7 +299,7 @@ public class ChatRoomWorkshopServiceTests
         var notExistingProviderId = Guid.NewGuid();
         var validRooms = new List<ChatRoomWorkshopForChatList>();
 
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByProviderIdAsync(notExistingProviderId, true)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByProviderIdAsync(notExistingProviderId, It.IsAny<bool>())).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByProviderIdAsync(notExistingProviderId).ConfigureAwait(false);
@@ -322,7 +322,7 @@ public class ChatRoomWorkshopServiceTests
         {
             new ChatRoomWorkshopForChatList() { Id = Guid.NewGuid(), WorkshopId = existingWorkshopId, Workshop = new WorkshopInfoForChatList() { Id = existingWorkshopId } },
         };
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(existingWorkshopId, default)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(existingWorkshopId, It.IsAny<bool>())).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByWorkshopIdAsync(existingWorkshopId).ConfigureAwait(false);
@@ -341,7 +341,7 @@ public class ChatRoomWorkshopServiceTests
         var notExistingWorkshopId = Guid.NewGuid();
         var validRooms = new List<ChatRoomWorkshopForChatList>();
 
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(notExistingWorkshopId, default)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(notExistingWorkshopId, It.IsAny<bool>())).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByWorkshopIdAsync(notExistingWorkshopId).ConfigureAwait(false);
@@ -499,7 +499,7 @@ public class ChatRoomWorkshopServiceTests
         var expectedCount = chatRooms.Count(r => r.NotReadByCurrentUserMessagesCount > 0);
 
         roomWithSpecialModelRepositoryMock
-            .Setup(x => x.GetByParentIdAsync(parentId, default))
+            .Setup(x => x.GetByParentIdAsync(parentId, It.IsAny<bool>()))
             .ReturnsAsync(chatRooms);
 
         // Act
@@ -525,7 +525,7 @@ public class ChatRoomWorkshopServiceTests
         var expectedCount = chatRooms.Count(r => r.NotReadByCurrentUserMessagesCount > 0);
 
         roomWithSpecialModelRepositoryMock
-            .Setup(x => x.GetByProviderIdAsync(providerId, true))
+            .Setup(x => x.GetByProviderIdAsync(providerId, It.IsAny<bool>()))
             .ReturnsAsync(chatRooms);
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -241,7 +241,7 @@ public class ChatRoomWorkshopServiceTests
         {
             new ChatRoomWorkshopForChatList() { Id = Guid.NewGuid(), ParentId = existingParentId },
         };
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(existingParentId, false)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(existingParentId, default)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByParentIdAsync(existingParentId).ConfigureAwait(false);
@@ -259,7 +259,7 @@ public class ChatRoomWorkshopServiceTests
         var notExistingParentId = Guid.NewGuid();
         var validRooms = new List<ChatRoomWorkshopForChatList>();
 
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(notExistingParentId, false)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(notExistingParentId, default)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByParentIdAsync(notExistingParentId).ConfigureAwait(false);
@@ -322,7 +322,7 @@ public class ChatRoomWorkshopServiceTests
         {
             new ChatRoomWorkshopForChatList() { Id = Guid.NewGuid(), WorkshopId = existingWorkshopId, Workshop = new WorkshopInfoForChatList() { Id = existingWorkshopId } },
         };
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(existingWorkshopId, true)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(existingWorkshopId, default)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByWorkshopIdAsync(existingWorkshopId).ConfigureAwait(false);
@@ -341,7 +341,7 @@ public class ChatRoomWorkshopServiceTests
         var notExistingWorkshopId = Guid.NewGuid();
         var validRooms = new List<ChatRoomWorkshopForChatList>();
 
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(notExistingWorkshopId, true)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(notExistingWorkshopId, default)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByWorkshopIdAsync(notExistingWorkshopId).ConfigureAwait(false);
@@ -499,7 +499,7 @@ public class ChatRoomWorkshopServiceTests
         var expectedCount = chatRooms.Count(r => r.NotReadByCurrentUserMessagesCount > 0);
 
         roomWithSpecialModelRepositoryMock
-            .Setup(x => x.GetByParentIdAsync(parentId, false))
+            .Setup(x => x.GetByParentIdAsync(parentId, default))
             .ReturnsAsync(chatRooms);
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -559,7 +559,7 @@ public class ChatRoomWorkshopServiceTests
         var expectedEmptyList = new List<ChatRoomWorkshopDtoWithLastMessage>();
 
         roomWithSpecialModelRepositoryMock
-            .Setup(x => x.GetByParentIdAsync(invalidParentId, It.IsAny<bool>()))
+            .Setup(x => x.GetByParentIdAsync(invalidParentId, false))
             .Returns(Task.FromResult(new List<ChatRoomWorkshopForChatList>()));
 
         // Act
@@ -580,7 +580,7 @@ public class ChatRoomWorkshopServiceTests
         var expectedEmptyList = new List<ChatRoomWorkshopDtoWithLastMessage>();
 
         roomWithSpecialModelRepositoryMock
-            .Setup(x => x.GetByWorkshopIdsAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<bool>()))
+            .Setup(x => x.GetByWorkshopIdsAsync(It.IsAny<IEnumerable<Guid>>(), true))
             .Returns(Task.FromResult(new List<ChatRoomWorkshopForChatList>()));
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -241,7 +241,7 @@ public class ChatRoomWorkshopServiceTests
         {
             new ChatRoomWorkshopForChatList() { Id = Guid.NewGuid(), ParentId = existingParentId },
         };
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(existingParentId, default)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(existingParentId, false)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByParentIdAsync(existingParentId).ConfigureAwait(false);
@@ -259,7 +259,7 @@ public class ChatRoomWorkshopServiceTests
         var notExistingParentId = Guid.NewGuid();
         var validRooms = new List<ChatRoomWorkshopForChatList>();
 
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(notExistingParentId, default)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByParentIdAsync(notExistingParentId, false)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByParentIdAsync(notExistingParentId).ConfigureAwait(false);
@@ -322,7 +322,7 @@ public class ChatRoomWorkshopServiceTests
         {
             new ChatRoomWorkshopForChatList() { Id = Guid.NewGuid(), WorkshopId = existingWorkshopId, Workshop = new WorkshopInfoForChatList() { Id = existingWorkshopId } },
         };
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(existingWorkshopId, default)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(existingWorkshopId, true)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByWorkshopIdAsync(existingWorkshopId).ConfigureAwait(false);
@@ -341,7 +341,7 @@ public class ChatRoomWorkshopServiceTests
         var notExistingWorkshopId = Guid.NewGuid();
         var validRooms = new List<ChatRoomWorkshopForChatList>();
 
-        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(notExistingWorkshopId, default)).ReturnsAsync(validRooms);
+        roomWithSpecialModelRepositoryMock.Setup(x => x.GetByWorkshopIdAsync(notExistingWorkshopId, true)).ReturnsAsync(validRooms);
 
         // Act
         var result = await roomService.GetByWorkshopIdAsync(notExistingWorkshopId).ConfigureAwait(false);
@@ -499,7 +499,7 @@ public class ChatRoomWorkshopServiceTests
         var expectedCount = chatRooms.Count(r => r.NotReadByCurrentUserMessagesCount > 0);
 
         roomWithSpecialModelRepositoryMock
-            .Setup(x => x.GetByParentIdAsync(parentId, default))
+            .Setup(x => x.GetByParentIdAsync(parentId, false))
             .ReturnsAsync(chatRooms);
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -93,7 +93,7 @@ public class ChatRoomWorkshopServiceTests
         loggerMock = new Mock<ILogger<ChatRoomWorkshopService>>();
         mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         workshopServiceMock = new Mock<IWorkshopService>();
-        workshopServiceMock.Setup(x => x.GetById(It.IsAny<Guid>())).ReturnsAsync(new WorkshopDto() { ProviderId = Guid.Empty });
+        workshopServiceMock.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(new WorkshopDto() { ProviderId = Guid.Empty });
         blockedProviderParentServiceMock = new Mock<IBlockedProviderParentService>();
         blockedProviderParentServiceMock.Setup(x => x.IsBlocked(It.IsAny<Guid>(), It.IsAny<Guid>())).ReturnsAsync(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -122,7 +122,7 @@ public class ChatRoomWorkshopServiceTests
 
         // Assert
         Assert.IsInstanceOf<ChatRoomWorkshopDto>(result);
-        Assert.AreNotEqual(0, roomCount);
+        Assert.AreNotEqual(default(int), roomCount);
         Assert.AreEqual(roomCount, dbContext.ChatRoomWorkshops.Count());
         Assert.AreEqual(dbContext.ChatRoomWorkshops.Where(x => x.ParentId == parentId && x.WorkshopId == workshopId).FirstOrDefault()?.Id, result.Id);
     }
@@ -141,7 +141,7 @@ public class ChatRoomWorkshopServiceTests
         // Assert
         Assert.IsInstanceOf<ChatRoomWorkshopDto>(result);
         Assert.AreEqual(roomCount + 1, dbContext.ChatRoomWorkshops.Count());
-        Assert.AreNotEqual(0, result.Id);
+        Assert.AreNotEqual(default(int), result.Id);
         Assert.AreEqual(dbContext.ChatRoomWorkshops.LastOrDefault()?.Id, result.Id);
     }
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChatRoomWorkshopServiceTests.cs
@@ -122,7 +122,7 @@ public class ChatRoomWorkshopServiceTests
 
         // Assert
         Assert.IsInstanceOf<ChatRoomWorkshopDto>(result);
-        Assert.AreNotEqual(default(int), roomCount);
+        Assert.AreNotEqual(0, roomCount);
         Assert.AreEqual(roomCount, dbContext.ChatRoomWorkshops.Count());
         Assert.AreEqual(dbContext.ChatRoomWorkshops.Where(x => x.ParentId == parentId && x.WorkshopId == workshopId).FirstOrDefault()?.Id, result.Id);
     }
@@ -141,7 +141,7 @@ public class ChatRoomWorkshopServiceTests
         // Assert
         Assert.IsInstanceOf<ChatRoomWorkshopDto>(result);
         Assert.AreEqual(roomCount + 1, dbContext.ChatRoomWorkshops.Count());
-        Assert.AreNotEqual(default(int), result.Id);
+        Assert.AreNotEqual(0, result.Id);
         Assert.AreEqual(dbContext.ChatRoomWorkshops.LastOrDefault()?.Id, result.Id);
     }
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/ChatRoomWorkshopServiceWithDBTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/ChatRoomWorkshopServiceWithDBTests.cs
@@ -95,7 +95,7 @@ public class ChatRoomWorkshopServiceWithDBTests
         loggerMock = new Mock<ILogger<ChatRoomWorkshopService>>();
         mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
         workshopServiceMock = new Mock<IWorkshopService>();
-        workshopServiceMock.Setup(x => x.GetById(It.IsAny<Guid>())).ReturnsAsync(new WorkshopDto() { ProviderId = Guid.Empty });
+        workshopServiceMock.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(new WorkshopDto() { ProviderId = Guid.Empty });
         blockedProviderParentServiceMock = new Mock<IBlockedProviderParentService>();
         blockedProviderParentServiceMock.Setup(x => x.IsBlocked(It.IsAny<Guid>(), It.IsAny<Guid>())).ReturnsAsync(false);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopRepositoryTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopRepositoryTests.cs
@@ -92,8 +92,9 @@ public class WorkshopRepositoryTests
         Assert.IsEmpty(images);
     }
 
-    [Test]
-    public async Task GetWithNavigations_WhenGetValidEntity_ReturnValue()
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task GetWithNavigations_WhenGetValidEntity_ReturnValue(bool asNoTracking)
     {
         // Arrange
         using var context = GetContext();
@@ -101,14 +102,15 @@ public class WorkshopRepositoryTests
         var workshop = context.Workshops.First();
 
         // Act
-        var expectedWorkshop = await workshopRepository.GetWithNavigations(workshop.Id);
+        var expectedWorkshop = await workshopRepository.GetWithNavigations(workshop.Id, asNoTracking);
 
         // Assert
         Assert.IsNotNull(expectedWorkshop);
     }
 
-    [Test]
-    public async Task GetWithNavigations_WhenGetValidEntity_ReturnEmpty()
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task GetWithNavigations_WhenGetValidEntity_ReturnEmpty(bool asNoTracking)
     {
         // Arrange
         using var context = GetContext();
@@ -117,7 +119,7 @@ public class WorkshopRepositoryTests
 
         // Act
         await workshopRepository.Delete(workshop);
-        var expectedWorkshop = await workshopRepository.GetWithNavigations(workshop.Id);
+        var expectedWorkshop = await workshopRepository.GetWithNavigations(workshop.Id, asNoTracking);
 
         // Assert
         Assert.IsNull(expectedWorkshop);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -700,7 +700,7 @@ public class WorkshopServiceTests
             .ReturnsAsync(workshop);
         workshopRepository
             .Setup(
-                w => w.GetWithNavigations(workshopId, false))
+                w => w.GetWithNavigations(workshopId, It.IsAny<bool>()))
             .ReturnsAsync(workshop);
         mapperMock.Setup(m => m.Map<WorkshopDto>(workshop)).Returns(new WorkshopDto() { Id = workshop.Id });
         averageRatingServiceMock.Setup(r => r.GetByEntityIdAsync(workshopId)).ReturnsAsync(new AverageRatingDto() { EntityId = workshop.Id });
@@ -754,7 +754,7 @@ public class WorkshopServiceTests
     private void SetupUpdate(Workshop workshop)
     {
         workshopRepository.Setup(w => w.GetById(It.IsAny<Guid>())).ReturnsAsync(workshop);
-        workshopRepository.Setup(w => w.GetWithNavigations(It.IsAny<Guid>(), false)).ReturnsAsync(workshop);
+        workshopRepository.Setup(w => w.GetWithNavigations(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshop);
         workshopRepository.Setup(w => w.UnitOfWork.CompleteAsync()).ReturnsAsync(It.IsAny<int>());
         mapperMock.Setup(m => m.Map<WorkshopBaseDto>(workshop))
             .Returns(mapper.Map<WorkshopBaseDto>(workshop));

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -406,8 +406,9 @@ public class WorkshopServiceTests
         WorkshopBaseDto workshopBaseDto = null;
 
         // Act and Assert
-        Func<Task> act = () => workshopService.Update(workshopBaseDto);
-        await act.Should().ThrowAsync<ArgumentNullException>();
+        await workshopService
+            .Awaiting(m => m.Update(workshopBaseDto))
+            .Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Test]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -186,7 +186,8 @@ public class WorkshopServiceTests
     {
         // Arrange
         var id = new Guid("b94f1989-c4e7-4878-ac86-21c4a402fb43");
-        SetupGetById(WithWorkshop(id));
+        var workshop = WorkshopGenerator.Generate().WithId(id).WithAddress();
+        SetupGetById(workshop);
 
         // Act
         var result = await workshopService.GetById(id).ConfigureAwait(false);
@@ -200,7 +201,8 @@ public class WorkshopServiceTests
     {
         // Arrange
         var id = new Guid("2a9fcc6d-6c7d-4711-849d-aa8991337185");
-        SetupGetById(WithWorkshop(id));
+        var workshop = WorkshopGenerator.Generate().WithId(id).WithAddress();
+        SetupGetById(workshop);
 
         // Act
         var result = await workshopService.GetById(It.IsAny<Guid>()).ConfigureAwait(false);
@@ -354,8 +356,7 @@ public class WorkshopServiceTests
     public async Task Update_WhenEntityIsValid_ShouldReturnUpdatedEntity([Random(2, 5, 1)] int teachersInWorkshop)
     {
         // Arrange
-        var id = new Guid("ca2cc30c-419c-4b00-a344-b23f0cbf18d8");
-        var changedFirstEntity = WithWorkshop(id);
+        var changedFirstEntity = WorkshopGenerator.Generate().WithApplications().WithAddress();
         var teachers = TeachersGenerator.Generate(teachersInWorkshop).WithWorkshop(changedFirstEntity);
         var provider = ProvidersGenerator.Generate();
         changedFirstEntity.Teachers = teachers;
@@ -368,6 +369,7 @@ public class WorkshopServiceTests
         var result = await workshopService.Update(mapper.Map<WorkshopBaseDto>(changedFirstEntity)).ConfigureAwait(false);
 
         // Assert
+        result.Should().NotBeNull();
         result.Teachers.Should().BeEquivalentTo(expectedTeachers);
         result.AvailableSeats.Should().Be(uint.MaxValue);
     }
@@ -376,8 +378,7 @@ public class WorkshopServiceTests
     public async Task Update_WhenEntityIsValidAvaliableSeatsIsNull_ShouldReturnUpdatedEntity([Random(2, 5, 1)] int teachersInWorkshop)
     {
         // Arrange
-        var id = new Guid("ca2cc30c-419c-4b00-a344-b23f0cbf18d8");
-        var changedFirstEntity = WithWorkshop(id);
+        var changedFirstEntity = WorkshopGenerator.Generate().WithApplications().WithAddress();
         var teachers = TeachersGenerator.Generate(teachersInWorkshop).WithWorkshop(changedFirstEntity);
         var provider = ProvidersGenerator.Generate();
         changedFirstEntity.Teachers = teachers;
@@ -393,20 +394,20 @@ public class WorkshopServiceTests
         var result = await workshopService.Update(changeFirstEntityDto).ConfigureAwait(false);
 
         // Assert
+        result.Should().NotBeNull();
         result.Teachers.Should().BeEquivalentTo(expectedTeachers);
         result.AvailableSeats.Should().Be(uint.MaxValue);
     }
 
     [Test]
-    public void Update_WhenClassIdIsInvalid_ShouldThrowArgumentOutOfRangeException()
+    public async Task Update_WhenDtoIsNull_ShouldThrowArgumentNullException()
     {
         // Arrange
-        var id = new Guid("f1b73d56-ce9f-47fc-85fe-94bf72ebd3e4");
-        var changedEntity = WithWorkshop(id);
-        SetupUpdate(changedEntity);
+        WorkshopBaseDto workshopBaseDto = null;
 
         // Act and Assert
-        workshopService.Invoking(w => w.Update(mapper.Map<WorkshopBaseDto>(changedEntity))).Should().ThrowAsync<ArgumentException>();
+        Func<Task> act = () => workshopService.Update(workshopBaseDto);
+        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Test]
@@ -415,8 +416,7 @@ public class WorkshopServiceTests
     public async Task Update_WhenTeachersWereDeletedBefore_ShouldReturnUpdatedEntity(int teachersInWorkshop, bool isDeleted)
     {
         // Arrange
-        var id = new Guid("ca2cc30c-419c-4b00-a344-b23f0cbf18d8");
-        var changedFirstEntity = WithWorkshop(id);
+        var changedFirstEntity = WorkshopGenerator.Generate().WithApplications().WithAddress();
         var teachers = TeachersGenerator.Generate(teachersInWorkshop).WithWorkshop(changedFirstEntity).WithIsDeleted(true);
         teachers.AddRange(TeachersGenerator.Generate(teachersInWorkshop).WithWorkshop(changedFirstEntity).WithIsDeleted(isDeleted));
         var provider = ProvidersGenerator.Generate();
@@ -492,11 +492,11 @@ public class WorkshopServiceTests
     public async Task Delete_WhenEntityWithIdExists_ShouldTryToDelete()
     {
         // Arrange
-        var id = Guid.NewGuid();
-        SetupDelete(WithWorkshop(id));
+        var workshop = WorkshopGenerator.Generate();
+        SetupDelete(workshop);
 
         // Act
-        await workshopService.Delete(id).ConfigureAwait(false);
+        await workshopService.Delete(workshop.Id).ConfigureAwait(false);
 
         // Assert
         workshopRepository.Verify(w => w.Delete(It.IsAny<Workshop>()), Times.Once);
@@ -613,76 +613,6 @@ public class WorkshopServiceTests
     {
         return RatingsGenerator.GetAverageRatings(workshopGuids);
     }
-
-    private static Workshop WithWorkshop(Guid id) => new Workshop()
-    {
-        Id = id,
-        Title = "ChangedTitle",
-        Phone = "1111111111",
-        Price = 1000,
-        WithDisabilityOptions = true,
-        ProviderTitle = "ProviderTitle",
-        DisabilityOptionsDesc = "Desc1",
-        Website = "website1",
-        Instagram = "insta1",
-        Facebook = "facebook1",
-        Email = "email1@gmail.com",
-        MaxAge = 10,
-        MinAge = 4,
-        ProviderOwnership = OwnershipType.Private,
-        Status = WorkshopStatus.Open,
-        CoverImageId = "image1",
-        ProviderId = new Guid("65eb933f-6502-4e89-a7cb-65901e51d119"),
-        InstitutionHierarchyId = new Guid("8f91783d-a68f-41fa-9ded-d879f187a94e"),
-        AddressId = 55,
-        Address = new Address
-        {
-            Id = 55,
-            CATOTTGId = 4970,
-            Street = "Street55",
-            BuildingNumber = "BuildingNumber55",
-            Latitude = 10,
-            Longitude = 10,
-        },
-        WorkshopDescriptionItems = new[]
-        {
-            new WorkshopDescriptionItem()
-            {
-                Id = Guid.NewGuid(),
-                SectionName = "Workshop description heading 1",
-                Description = "Workshop description text 1",
-            },
-        },
-        DateTimeRanges = new List<DateTimeRange>()
-        {
-            new DateTimeRange
-            {
-                Id = It.IsAny<long>(),
-                EndTime = It.IsAny<TimeSpan>(),
-                StartTime = It.IsAny<TimeSpan>(),
-                Workdays = default,
-            },
-        },
-        Teachers = new List<Teacher>(),
-        //{
-        //    new Teacher
-        //    {
-        //        Id = Guid.NewGuid(),
-        //        FirstName = "Alex",
-        //        LastName = "Brown",
-        //        MiddleName = "SomeMiddleName",
-        //        Description = "Description",
-        //        DateOfBirth = DateTime.Parse("2000-01-01"),
-        //        WorkshopId = new Guid("5e519d63-0cdd-48a8-81da-6365aa5ad8c3"),
-        //    },
-        //},
-    };
-
-    private Workshop WithNullWorkshopEntity()
-    {
-        return null;
-    }
-
     #endregion
 
     #region Setup
@@ -770,7 +700,7 @@ public class WorkshopServiceTests
             .ReturnsAsync(workshop);
         workshopRepository
             .Setup(
-                w => w.GetWithNavigations(workshopId))
+                w => w.GetWithNavigations(workshopId, false))
             .ReturnsAsync(workshop);
         mapperMock.Setup(m => m.Map<WorkshopDto>(workshop)).Returns(new WorkshopDto() { Id = workshop.Id });
         averageRatingServiceMock.Setup(r => r.GetByEntityIdAsync(workshopId)).ReturnsAsync(new AverageRatingDto() { EntityId = workshop.Id });
@@ -824,7 +754,7 @@ public class WorkshopServiceTests
     private void SetupUpdate(Workshop workshop)
     {
         workshopRepository.Setup(w => w.GetById(It.IsAny<Guid>())).ReturnsAsync(workshop);
-        workshopRepository.Setup(w => w.GetWithNavigations(It.IsAny<Guid>())).ReturnsAsync(workshop);
+        workshopRepository.Setup(w => w.GetWithNavigations(It.IsAny<Guid>(), false)).ReturnsAsync(workshop);
         workshopRepository.Setup(w => w.UnitOfWork.CompleteAsync()).ReturnsAsync(It.IsAny<int>());
         mapperMock.Setup(m => m.Map<WorkshopBaseDto>(workshop))
             .Returns(mapper.Map<WorkshopBaseDto>(workshop));

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -190,7 +190,7 @@ public class WorkshopServiceTests
         SetupGetById(workshop);
 
         // Act
-        var result = await workshopService.GetById(id).ConfigureAwait(false);
+        var result = await workshopService.GetById(id, false).ConfigureAwait(false);
 
         // Assert
         result.Should().BeEquivalentTo(ExpectedWorkshopGetByIdSuccess(id));
@@ -205,7 +205,7 @@ public class WorkshopServiceTests
         SetupGetById(workshop);
 
         // Act
-        var result = await workshopService.GetById(It.IsAny<Guid>()).ConfigureAwait(false);
+        var result = await workshopService.GetById(It.IsAny<Guid>(), false).ConfigureAwait(false);
 
         // Assert
         result.Should().BeNull();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -847,14 +847,8 @@ public class WorkshopServiceTests
             .WithChild(ChildGenerator.Generate());
         for (int i = 0; i < allApplications; i++)
         {
-            if (i < approvedApplications)
-            {
-                applications[i].Status = ApplicationStatus.Approved;
-            }
-            else
-            {
-                applications[i].Status = ApplicationStatus.Rejected;
-            }
+            applications[i].Status = i < approvedApplications
+                ? ApplicationStatus.Approved : ApplicationStatus.Rejected;
         }
 
         return applications;

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -269,21 +269,17 @@ public class WorkshopServicesCombinerTests
     [TestCase(uint.MaxValue, 3U, true)]
     [TestCase(null, 3U, true)]
     [TestCase(4U, 6U, false)]
-    public async Task IsAvailableSeatsValid_WithExistIdAndValidAvailableSeats_ShouldReturnExpectedResult(
+    public void IsAvailableSeatsValid_WithExistIdAndValidAvailableSeats_ShouldReturnExpectedResult(
         uint? availableSeats, uint takenSeats, bool expectedResult)
     {
         // Arrange
-        var id = Guid.NewGuid();
         var workshopDto = WorkshopDtoGenerator.Generate();
-        workshopDto.Id = id;
         workshopDto.TakenSeats = takenSeats;
-        workshopService.Setup(x => x.GetById(id, true)).ReturnsAsync(workshopDto);
 
         // Assert
-        var result = await service.IsAvailableSeatsValid(availableSeats, id).ConfigureAwait(false);
+        var result = service.IsAvailableSeatsValid(availableSeats, workshopDto);
 
         // Act
         Assert.AreEqual(expectedResult, result);
-        workshopService.Verify(x => x.GetById(id, true), Times.Once);
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -115,7 +115,7 @@ public class WorkshopServicesCombinerTests
         var workshopDtoWithTitle = mapper.Map<WorkshopStatusWithTitleDto>(workshopStatusDto);
         workshopDtoWithTitle.Title = workshop.Title;
 
-        workshopService.Setup(x => x.GetById(workshopDto.Id, false)).ReturnsAsync(workshopDto);
+        workshopService.Setup(x => x.GetById(workshopDto.Id, It.IsAny<bool>())).ReturnsAsync(workshopDto);
         workshopService.Setup(x => x.UpdateStatus(workshopStatusDto)).ReturnsAsync(workshopDtoWithTitle);
 
         favoriteRepository.Setup(x => x.Get(
@@ -194,7 +194,7 @@ public class WorkshopServicesCombinerTests
 
         var workshop = WorkshopGenerator.Generate();
 
-        workshopService.Setup(x => x.GetById(workshop.Id, false)).ReturnsAsync(mapper.Map<WorkshopDto>(workshop));
+        workshopService.Setup(x => x.GetById(workshop.Id, It.IsAny<bool>())).ReturnsAsync(mapper.Map<WorkshopDto>(workshop));
         favoriteRepository.Setup(x => x.Get(
                 It.IsAny<int>(),
                 It.IsAny<int>(),

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -269,17 +269,21 @@ public class WorkshopServicesCombinerTests
     [TestCase(uint.MaxValue, 3U, true)]
     [TestCase(null, 3U, true)]
     [TestCase(4U, 6U, false)]
-    public void IsAvailableSeatsValid_WithExistIdAndValidAvailableSeats_ShouldReturnExpectedResult(
+    public async Task IsAvailableSeatsValid_WithExistIdAndValidAvailableSeats_ShouldReturnExpectedResult(
         uint? availableSeats, uint takenSeats, bool expectedResult)
     {
         // Arrange
+        var id = Guid.NewGuid();
         var workshopDto = WorkshopDtoGenerator.Generate();
+        workshopDto.Id = id;
         workshopDto.TakenSeats = takenSeats;
+        workshopService.Setup(x => x.GetById(id, true)).ReturnsAsync(workshopDto);
 
         // Assert
-        var result = service.IsAvailableSeatsValid(availableSeats, workshopDto);
+        var result = await service.IsAvailableSeatsValid(availableSeats, id).ConfigureAwait(false);
 
         // Act
         Assert.AreEqual(expectedResult, result);
+        workshopService.Verify(x => x.GetById(id, true), Times.Once);
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -74,6 +74,7 @@ public class WorkshopServicesCombinerTests
         // Arrange
         var id = Guid.NewGuid();
         var workshopDto = WorkshopDtoGenerator.Generate();
+        workshopDto.Id = id;
         workshopService.Setup(x => x.GetById(id, asNoTracking)).ReturnsAsync(workshopDto);
 
         // Assert
@@ -260,5 +261,29 @@ public class WorkshopServicesCombinerTests
                 It.Is<Dictionary<string, string>>(c => c.ContainsKey(titleKey) && c[titleKey] == workshop.Title),
                 null),
             Times.Once);
+    }
+
+    [Test]
+    [TestCase(3U, 3U, true)]
+    [TestCase(5U, 3U, true)]
+    [TestCase(uint.MaxValue, 3U, true)]
+    [TestCase(null, 3U, true)]
+    [TestCase(4U, 6U, false)]
+    public async Task IsAvailableSeatsValid_WithExistIdAndValidAvailableSeats_ShouldReturnExpectedResult(
+        uint? availableSeats, uint takenSeats, bool expectedResult)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var workshopDto = WorkshopDtoGenerator.Generate();
+        workshopDto.Id = id;
+        workshopDto.TakenSeats = takenSeats;
+        workshopService.Setup(x => x.GetById(id, true)).ReturnsAsync(workshopDto);
+
+        // Assert
+        var result = await service.IsAvailableSeatsValid(availableSeats, id).ConfigureAwait(false);
+
+        // Act
+        Assert.AreEqual(expectedResult, result);
+        workshopService.Verify(x => x.GetById(id, true), Times.Once);
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -4,7 +4,6 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using AutoMapper;
 using Moq;
-using Nest;
 using NUnit.Framework;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.BusinessLogic.Services;

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -115,7 +115,7 @@ public class WorkshopServicesCombinerTests
         var workshopDtoWithTitle = mapper.Map<WorkshopStatusWithTitleDto>(workshopStatusDto);
         workshopDtoWithTitle.Title = workshop.Title;
 
-        workshopService.Setup(x => x.GetById(workshopDto.Id)).ReturnsAsync(workshopDto);
+        workshopService.Setup(x => x.GetById(workshopDto.Id, false)).ReturnsAsync(workshopDto);
         workshopService.Setup(x => x.UpdateStatus(workshopStatusDto)).ReturnsAsync(workshopDtoWithTitle);
 
         favoriteRepository.Setup(x => x.Get(
@@ -194,7 +194,7 @@ public class WorkshopServicesCombinerTests
 
         var workshop = WorkshopGenerator.Generate();
 
-        workshopService.Setup(x => x.GetById(workshop.Id)).ReturnsAsync(mapper.Map<WorkshopDto>(workshop));
+        workshopService.Setup(x => x.GetById(workshop.Id, false)).ReturnsAsync(mapper.Map<WorkshopDto>(workshop));
         favoriteRepository.Setup(x => x.Get(
                 It.IsAny<int>(),
                 It.IsAny<int>(),

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -67,6 +67,42 @@ public class WorkshopServicesCombinerTests
     }
 
     [Test]
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task GetById_WithValidId_ShouldReturnDto(bool asNoTracking)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var workshopDto = WorkshopDtoGenerator.Generate();
+        workshopService.Setup(x => x.GetById(id, asNoTracking)).ReturnsAsync(workshopDto);
+
+        // Assert
+        var result = await service.GetById(id, asNoTracking).ConfigureAwait(false);
+
+        // Act
+        Assert.IsNotNull(result);
+        Assert.AreEqual(workshopDto, result);
+    }
+
+    [Test]
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task GetById_WithNotExistId_ShouldReturnNull(bool asNoTracking)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var workshopDto = null as WorkshopDto;
+        workshopService.Setup(x => x.GetById(id, asNoTracking)).ReturnsAsync(workshopDto);
+
+        // Assert
+        var result = await service.GetById(id, asNoTracking).ConfigureAwait(false);
+
+        // Act
+        Assert.IsNull(result);
+        workshopService.Verify(x => x.GetById(id, asNoTracking), Times.Once);
+    }
+
+    [Test]
     public async Task UpdateStatus_WhenDtoIsNull_ThrowsArgumentNullException()
     {
         // Arrange

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -280,7 +280,8 @@ public class WorkshopServicesCombinerTests
         workshopService.Setup(x => x.GetById(id, true)).ReturnsAsync(workshopDto);
 
         // Assert
-        var result = await service.IsAvailableSeatsValid(availableSeats, id).ConfigureAwait(false);
+        var result = await service.IsAvailableSeatsValidForWorkshop(
+            availableSeats, id).ConfigureAwait(false);
 
         // Act
         Assert.AreEqual(expectedResult, result);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using AutoMapper;
 using Moq;
+using Nest;
 using NUnit.Framework;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.BusinessLogic.Services;
@@ -269,7 +270,7 @@ public class WorkshopServicesCombinerTests
     [TestCase(uint.MaxValue, 3U, true)]
     [TestCase(null, 3U, true)]
     [TestCase(4U, 6U, false)]
-    public async Task IsAvailableSeatsValid_WithExistIdAndValidAvailableSeats_ShouldReturnExpectedResult(
+    public async Task IsAvailableSeatsValidForWorkshop_WithExistIdAndValidAvailableSeats_ShouldReturnExpectedResult(
         uint? availableSeats, uint takenSeats, bool expectedResult)
     {
         // Arrange
@@ -279,12 +280,29 @@ public class WorkshopServicesCombinerTests
         workshopDto.TakenSeats = takenSeats;
         workshopService.Setup(x => x.GetById(id, true)).ReturnsAsync(workshopDto);
 
-        // Assert
+        // Act
         var result = await service.IsAvailableSeatsValidForWorkshop(
             availableSeats, id).ConfigureAwait(false);
 
-        // Act
+        // Assert
         Assert.AreEqual(expectedResult, result);
+        workshopService.Verify(x => x.GetById(id, true), Times.Once);
+    }
+
+    [Test]
+    public async Task IsAvailableSeatsValidForWorkshop_WithNotExistingWorkshop_ShouldReturnNull()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        workshopService.Setup(x => x.GetById(id, true))
+            .ReturnsAsync(null as WorkshopDto);
+
+        // Act
+        var result = await service.IsAvailableSeatsValidForWorkshop(
+            It.IsAny<uint>(), id).ConfigureAwait(false);
+
+        // Assert
+        Assert.IsNull(result);
         workshopService.Verify(x => x.GetById(id, true), Times.Once);
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -269,7 +269,7 @@ public class WorkshopServicesCombinerTests
     [TestCase(uint.MaxValue, 3U, true)]
     [TestCase(null, 3U, true)]
     [TestCase(4U, 6U, false)]
-    public async Task IsAvailableSeatsValidForWorkshop_WithExistIdAndValidAvailableSeats_ShouldReturnExpectedResult(
+    public void IsAvailableSeatsValidForWorkshop_ReturnsExpectedResult(
         uint? availableSeats, uint takenSeats, bool expectedResult)
     {
         // Arrange
@@ -277,31 +277,11 @@ public class WorkshopServicesCombinerTests
         var workshopDto = WorkshopDtoGenerator.Generate();
         workshopDto.Id = id;
         workshopDto.TakenSeats = takenSeats;
-        workshopService.Setup(x => x.GetById(id, true)).ReturnsAsync(workshopDto);
 
         // Act
-        var result = await service.IsAvailableSeatsValidForWorkshop(
-            availableSeats, id).ConfigureAwait(false);
+        var result = service.IsAvailableSeatsValidForWorkshop(availableSeats, workshopDto);
 
         // Assert
         Assert.AreEqual(expectedResult, result);
-        workshopService.Verify(x => x.GetById(id, true), Times.Once);
-    }
-
-    [Test]
-    public async Task IsAvailableSeatsValidForWorkshop_WithNotExistingWorkshop_ShouldReturnNull()
-    {
-        // Arrange
-        var id = Guid.NewGuid();
-        workshopService.Setup(x => x.GetById(id, true))
-            .ReturnsAsync(null as WorkshopDto);
-
-        // Act
-        var result = await service.IsAvailableSeatsValidForWorkshop(
-            It.IsAny<uint>(), id).ConfigureAwait(false);
-
-        // Assert
-        Assert.IsNull(result);
-        workshopService.Verify(x => x.GetById(id, true), Times.Once);
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -262,26 +262,4 @@ public class WorkshopServicesCombinerTests
                 null),
             Times.Once);
     }
-
-    [Test]
-    [TestCase(3U, 3U, true)]
-    [TestCase(5U, 3U, true)]
-    [TestCase(uint.MaxValue, 3U, true)]
-    [TestCase(null, 3U, true)]
-    [TestCase(4U, 6U, false)]
-    public void IsAvailableSeatsValidForWorkshop_ReturnsExpectedResult(
-        uint? availableSeats, uint takenSeats, bool expectedResult)
-    {
-        // Arrange
-        var id = Guid.NewGuid();
-        var workshopDto = WorkshopDtoGenerator.Generate();
-        workshopDto.Id = id;
-        workshopDto.TakenSeats = takenSeats;
-
-        // Act
-        var result = service.IsAvailableSeatsValidForWorkshop(availableSeats, workshopDto);
-
-        // Assert
-        Assert.AreEqual(expectedResult, result);
-    }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Net;
 using System.Threading.Tasks;
 using AutoMapper;
 using Moq;
@@ -10,6 +12,7 @@ using OutOfSchool.BusinessLogic.Services;
 using OutOfSchool.BusinessLogic.Services.Strategies.Interfaces;
 using OutOfSchool.BusinessLogic.Util;
 using OutOfSchool.BusinessLogic.Util.Mapping;
+using OutOfSchool.Common;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.ElasticsearchData;
 using OutOfSchool.ElasticsearchData.Models;
@@ -77,10 +80,10 @@ public class WorkshopServicesCombinerTests
         workshopDto.Id = id;
         workshopService.Setup(x => x.GetById(id, asNoTracking)).ReturnsAsync(workshopDto);
 
-        // Assert
+        // Act
         var result = await service.GetById(id, asNoTracking).ConfigureAwait(false);
 
-        // Act
+        // Assert
         Assert.IsNotNull(result);
         Assert.AreEqual(workshopDto, result);
     }
@@ -95,12 +98,82 @@ public class WorkshopServicesCombinerTests
         var workshopDto = null as WorkshopDto;
         workshopService.Setup(x => x.GetById(id, asNoTracking)).ReturnsAsync(workshopDto);
 
-        // Assert
+        // Act
         var result = await service.GetById(id, asNoTracking).ConfigureAwait(false);
 
-        // Act
+        // Assert
         Assert.IsNull(result);
         workshopService.Verify(x => x.GetById(id, asNoTracking), Times.Once);
+    }
+
+    [Test]
+    public async Task Update_WithValidDto_ShouldReturnSucceededResult()
+    {
+        // Arrange
+        var currentWorkshopDto = WorkshopDtoGenerator.Generate();
+        currentWorkshopDto.TakenSeats = 4;
+        var newWorkshopBaseDto = WorkshopBaseDtoGenerator.Generate();
+        newWorkshopBaseDto.AvailableSeats = 10;
+        workshopService.Setup(x => x.GetById(newWorkshopBaseDto.Id, true))
+            .ReturnsAsync(currentWorkshopDto);
+        workshopService.Setup(x => x.Update(newWorkshopBaseDto)).ReturnsAsync(newWorkshopBaseDto);
+
+        // Act
+        var result = await service.Update(newWorkshopBaseDto).ConfigureAwait(false);
+
+        // Assert
+        workshopService.VerifyAll();
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(newWorkshopBaseDto, result.Value);
+    }
+
+    [Test]
+    public async Task Update_WithNotExistWorkshop_ShouldReturnBadRequestResult()
+    {
+        // Arrange
+        var currentWorkshopDto = null as WorkshopDto;
+        var newWorkshopBaseDto = WorkshopBaseDtoGenerator.Generate();
+        workshopService.Setup(x => x.GetById(newWorkshopBaseDto.Id, true))
+            .ReturnsAsync(currentWorkshopDto);
+
+        // Act
+        var result = await service.Update(newWorkshopBaseDto).ConfigureAwait(false);
+        var firstError = result.OperationResult.Errors.FirstOrDefault();
+
+        // Assert
+        workshopService.VerifyAll();
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(result.OperationResult);
+        Assert.IsNotNull(firstError, "Expected an error, but no errors were found.");
+        Assert.AreEqual(HttpStatusCode.BadRequest.ToString(), firstError.Code);
+        Assert.AreEqual(Constants.WorkshopNotFoundErrorMessage, firstError.Description);
+    }
+
+    [Test]
+    public async Task Update_WithInvalidAvailableSeats_ShouldReturnBadRequestResult()
+    {
+        // Arrange
+        var currentWorkshopDto = WorkshopDtoGenerator.Generate();
+        currentWorkshopDto.TakenSeats = 5;
+        var newWorkshopBaseDto = WorkshopBaseDtoGenerator.Generate();
+        newWorkshopBaseDto.AvailableSeats = 3;
+        workshopService.Setup(x => x.GetById(newWorkshopBaseDto.Id, true))
+            .ReturnsAsync(currentWorkshopDto);
+
+        // Act
+        var result = await service.Update(newWorkshopBaseDto).ConfigureAwait(false);
+        var firstError = result.OperationResult.Errors.FirstOrDefault();
+
+        // Assert
+        workshopService.VerifyAll();
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(result.OperationResult);
+        Assert.IsNotNull(firstError, "Expected an error, but no errors were found.");
+        Assert.AreEqual(HttpStatusCode.BadRequest.ToString(), firstError.Code);
+        Assert.AreEqual(Constants.InvalidAvailableSeatsForWorkshopErrorMessage, firstError.Description);
     }
 
     [Test]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerV2Tests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerV2Tests.cs
@@ -1,0 +1,142 @@
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using AutoMapper;
+using Moq;
+using NUnit.Framework;
+using OutOfSchool.BusinessLogic.Models.Workshops;
+using OutOfSchool.BusinessLogic.Services;
+using OutOfSchool.BusinessLogic.Services.Strategies.Interfaces;
+using OutOfSchool.Common;
+using OutOfSchool.ElasticsearchData;
+using OutOfSchool.ElasticsearchData.Models;
+using OutOfSchool.Services.Enums;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Services.Repository;
+using OutOfSchool.Tests.Common.TestDataGenerators;
+
+namespace OutOfSchool.WebApi.Tests.Services;
+
+public class WorkshopServicesCombinerV2Tests
+{
+    private Mock<IWorkshopService> workshopService;
+    private Mock<IElasticsearchSynchronizationService> elasticsearchSynchronizationService;
+
+    private IWorkshopServicesCombinerV2 service;
+
+    [SetUp]
+    public void SetUp()
+    {
+        workshopService = new Mock<IWorkshopService>();
+        elasticsearchSynchronizationService = new Mock<IElasticsearchSynchronizationService>();
+        var notificationService = new Mock<INotificationService>();
+        var favoriteRepository = new Mock<IEntityRepositorySoftDeleted<long, Favorite>>();
+        var applicationRepository = new Mock<IApplicationRepository>();
+        var workshopStrategy = new Mock<IWorkshopStrategy>();
+        var currentUserServicse = new Mock<ICurrentUserService>();
+        var ministryAdminService = new Mock<IMinistryAdminService>();
+        var regionAdminService = new Mock<IRegionAdminService>();
+        var codeficatorService = new Mock<ICodeficatorService>();
+        var esProvider = new Mock<IElasticsearchProvider<WorkshopES, WorkshopFilterES>>();
+        var mapper = new Mock<IMapper>();
+
+        service = new WorkshopServicesCombinerV2(
+            workshopService.Object,
+            elasticsearchSynchronizationService.Object,
+            notificationService.Object,
+            favoriteRepository.Object,
+            applicationRepository.Object,
+            workshopStrategy.Object,
+            currentUserServicse.Object,
+            ministryAdminService.Object,
+            regionAdminService.Object,
+            codeficatorService.Object,
+            esProvider.Object,
+            mapper.Object);
+    }
+
+    [Test]
+    public async Task Update_WithValidDto_ShouldReturnSucceededResult()
+    {
+        // Arrange
+        var currentWorkshopDto = WorkshopDtoGenerator.Generate();
+        currentWorkshopDto.TakenSeats = 4;
+        var newWorkshopV2Dto = WorkshopV2DtoGenerator.Generate();
+        newWorkshopV2Dto.Id = currentWorkshopDto.Id;
+        newWorkshopV2Dto.AvailableSeats = 8;
+        var workshopResultDto = new WorkshopResultDto()
+        {
+            Workshop = newWorkshopV2Dto,
+        };
+
+        workshopService.Setup(x => x.GetById(newWorkshopV2Dto.Id, true))
+            .ReturnsAsync(currentWorkshopDto);
+        workshopService.Setup(x => x.UpdateV2(newWorkshopV2Dto))
+            .ReturnsAsync(workshopResultDto);
+        elasticsearchSynchronizationService.Setup(
+            x => x.AddNewRecordToElasticsearchSynchronizationTable(
+                ElasticsearchSyncEntity.Workshop,
+                workshopResultDto.Workshop.Id,
+                ElasticsearchSyncOperation.Update))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await service.Update(newWorkshopV2Dto).ConfigureAwait(false);
+
+        // Assert
+        workshopService.VerifyAll();
+        elasticsearchSynchronizationService.VerifyAll();
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(workshopResultDto, result.Value);
+    }
+
+    [Test]
+    public async Task Update_WithNotExistWorkshop_ShouldReturnBadRequestResult()
+    {
+        // Arrange
+        var currentWorkshopDto = null as WorkshopDto;
+        var newWorkshopV2Dto = WorkshopV2DtoGenerator.Generate();
+
+        workshopService.Setup(x => x.GetById(newWorkshopV2Dto.Id, true))
+            .ReturnsAsync(currentWorkshopDto);
+
+        // Act
+        var result = await service.Update(newWorkshopV2Dto).ConfigureAwait(false);
+        var firstError = result.OperationResult.Errors.FirstOrDefault();
+
+        // Assert
+        workshopService.VerifyAll();
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(firstError, "Expected an error, but no errors were found.");
+        Assert.AreEqual(HttpStatusCode.BadRequest.ToString(), firstError.Code);
+        Assert.AreEqual(Constants.WorkshopNotFoundErrorMessage, firstError.Description);
+    }
+
+    [Test]
+    public async Task Update_WithInvalidAvailableSeats_ShouldReturnBadRequestResult()
+    {
+        // Arrange
+        var currentWorkshopDto = WorkshopDtoGenerator.Generate();
+        currentWorkshopDto.TakenSeats = 7;
+        var newWorkshopV2Dto = WorkshopV2DtoGenerator.Generate();
+        newWorkshopV2Dto.Id = currentWorkshopDto.Id;
+        newWorkshopV2Dto.AvailableSeats = 5;
+
+        workshopService.Setup(x => x.GetById(newWorkshopV2Dto.Id, true))
+            .ReturnsAsync(currentWorkshopDto);
+
+        // Act
+        var result = await service.Update(newWorkshopV2Dto).ConfigureAwait(false);
+        var firstError = result.OperationResult.Errors.FirstOrDefault();
+
+        // Assert
+        workshopService.VerifyAll();
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(firstError, "Expected an error, but no errors were found.");
+        Assert.AreEqual(HttpStatusCode.BadRequest.ToString(), firstError.Code);
+        Assert.AreEqual(Constants.InvalidAvailableSeatsForWorkshopErrorMessage, firstError.Description);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -361,20 +361,14 @@ public class WorkshopController : ControllerBase
             return StatusCode(403, "Forbidden to update workshops, which are not related to you");
         }
 
-        var result = await combinedWorkshopService.IsAvailableSeatsValidForWorkshop(
-            dto.AvailableSeats, dto.Id).ConfigureAwait(false);
+        var result = await combinedWorkshopService.Update(dto).ConfigureAwait(false);
 
-        if (result is null)
+        if (!result.Succeeded)
         {
-            return BadRequest("The workshop does not exist.");
+            return BadRequest(result.OperationResult.Errors.FirstOrDefault().Description);
         }
 
-        if (result == false)
-        {
-            return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
-        }
-
-        return Ok(await combinedWorkshopService.Update(dto).ConfigureAwait(false));
+        return Ok(result.Value);
     }
 
     /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -365,7 +365,9 @@ public class WorkshopController : ControllerBase
 
         if (!result.Succeeded)
         {
-            return BadRequest(result.OperationResult.Errors.FirstOrDefault().Description);
+            var errors = result.OperationResult?.Errors;
+            return BadRequest(errors?.FirstOrDefault()?.Description
+                ?? Constants.UnknownErrorDuringUpdateMessage);
         }
 
         return Ok(result.Value);

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -369,7 +369,7 @@ public class WorkshopController : ControllerBase
             return BadRequest("The workshop does not exist.");
         }
 
-        if ((bool)!result)
+        if (result == false)
         {
             return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -361,14 +361,7 @@ public class WorkshopController : ControllerBase
             return StatusCode(403, "Forbidden to update workshops, which are not related to you");
         }
 
-        var workshop = await combinedWorkshopService.GetById(dto.Id, true).ConfigureAwait(false);
-
-        if (workshop is null)
-        {
-            return BadRequest("Workshop does not exist.");
-        }
-
-        if (!combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, workshop))
+        if (!await combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, dto.Id))
         {
             return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -365,8 +365,7 @@ public class WorkshopController : ControllerBase
 
         if (!result.Succeeded)
         {
-            var errors = result.OperationResult?.Errors;
-            return BadRequest(errors?.FirstOrDefault()?.Description
+            return BadRequest(result.OperationResult.Errors.FirstOrDefault()?.Description
                 ?? Constants.UnknownErrorDuringUpdateMessage);
         }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -361,7 +361,15 @@ public class WorkshopController : ControllerBase
             return StatusCode(403, "Forbidden to update workshops, which are not related to you");
         }
 
-        if (!await combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, dto.Id))
+        var result = await combinedWorkshopService.IsAvailableSeatsValidForWorkshop(
+            dto.AvailableSeats, dto.Id).ConfigureAwait(false);
+
+        if (result is null)
+        {
+            return BadRequest("The workshop does not exist.");
+        }
+
+        if ((bool)!result)
         {
             return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -361,7 +361,14 @@ public class WorkshopController : ControllerBase
             return StatusCode(403, "Forbidden to update workshops, which are not related to you");
         }
 
-        if (!await combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, dto.Id))
+        var workshop = await combinedWorkshopService.GetById(dto.Id, true).ConfigureAwait(false);
+
+        if (workshop is null)
+        {
+            return BadRequest("Workshop does not exist.");
+        }
+
+        if (!combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, workshop))
         {
             return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -361,6 +361,11 @@ public class WorkshopController : ControllerBase
             return StatusCode(403, "Forbidden to update workshops, which are not related to you");
         }
 
+        if (!await IsAvailableSeatsValid(dto.AvailableSeats, dto.Id))
+        {
+            return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
+        }
+
         return Ok(await combinedWorkshopService.Update(dto).ConfigureAwait(false));
     }
 
@@ -513,5 +518,11 @@ public class WorkshopController : ControllerBase
             providerId;
 
         return await providerService.IsBlocked(providerId).ConfigureAwait(false) ?? false;
+    }
+
+    private async Task<bool> IsAvailableSeatsValid(uint? availableSeats, Guid workshopId)
+    {
+        var workshop = await combinedWorkshopService.GetById(workshopId, true).ConfigureAwait(false);
+        return availableSeats.GetMaxValueIfNullOrZero() >= workshop.TakenSeats;
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -361,7 +361,7 @@ public class WorkshopController : ControllerBase
             return StatusCode(403, "Forbidden to update workshops, which are not related to you");
         }
 
-        if (!await IsAvailableSeatsValid(dto.AvailableSeats, dto.Id))
+        if (!await combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, dto.Id))
         {
             return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
         }
@@ -518,11 +518,5 @@ public class WorkshopController : ControllerBase
             providerId;
 
         return await providerService.IsBlocked(providerId).ConfigureAwait(false) ?? false;
-    }
-
-    private async Task<bool> IsAvailableSeatsValid(uint? availableSeats, Guid workshopId)
-    {
-        var workshop = await combinedWorkshopService.GetById(workshopId, true).ConfigureAwait(false);
-        return availableSeats.GetMaxValueIfNullOrZero() >= workshop.TakenSeats;
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
@@ -200,13 +200,25 @@ public class WorkshopController : ControllerBase
     [Consumes("multipart/form-data")]
     public async Task<IActionResult> Update([FromForm] WorkshopV2Dto dto)
     {
+        if (dto == null)
+        {
+            return BadRequest("Workshop is null.");
+        }
+
         var userHasRights = await IsUserProvidersOwner(dto.ProviderId).ConfigureAwait(false);
         if (!userHasRights)
         {
             return StatusCode(StatusCodes.Status403Forbidden, "Forbidden to update workshops for another providers.");
         }
 
-        if (!await combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, dto.Id))
+        var workshop = await combinedWorkshopService.GetById(dto.Id, true).ConfigureAwait(false);
+
+        if (workshop is null)
+        {
+            return BadRequest("Workshop does not exist.");
+        }
+
+        if (!combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, workshop))
         {
             return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
@@ -214,7 +214,7 @@ public class WorkshopController : ControllerBase
             return BadRequest("The workshop does not exist.");
         }
 
-        if ((bool)!result)
+        if (result == false)
         {
             return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
@@ -212,7 +212,9 @@ public class WorkshopController : ControllerBase
 
             if (!updatingResult.Succeeded)
             {
-                return BadRequest(updatingResult.OperationResult.Errors.FirstOrDefault().Description);
+                var errors = updatingResult.OperationResult?.Errors;
+                return BadRequest(errors?.FirstOrDefault()?.Description
+                    ?? Constants.UnknownErrorDuringUpdateMessage);
             }
 
             return Ok(CreateUpdateResponse(updatingResult.Value));

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
@@ -206,7 +206,15 @@ public class WorkshopController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Forbidden to update workshops for another providers.");
         }
 
-        if (!await combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, dto.Id))
+        var result = await combinedWorkshopService.IsAvailableSeatsValidForWorkshop(
+            dto.AvailableSeats, dto.Id).ConfigureAwait(false);
+
+        if (result is null)
+        {
+            return BadRequest("The workshop does not exist.");
+        }
+
+        if ((bool)!result)
         {
             return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
         }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
@@ -206,6 +206,11 @@ public class WorkshopController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Forbidden to update workshops for another providers.");
         }
 
+        if (!await combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, dto.Id))
+        {
+            return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
+        }
+
         try
         {
             var updatingResult = await combinedWorkshopService.Update(dto).ConfigureAwait(false);

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
@@ -212,8 +212,7 @@ public class WorkshopController : ControllerBase
 
             if (!updatingResult.Succeeded)
             {
-                var errors = updatingResult.OperationResult?.Errors;
-                return BadRequest(errors?.FirstOrDefault()?.Description
+                return BadRequest(updatingResult.OperationResult.Errors.FirstOrDefault()?.Description
                     ?? Constants.UnknownErrorDuringUpdateMessage);
             }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
@@ -206,24 +206,16 @@ public class WorkshopController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Forbidden to update workshops for another providers.");
         }
 
-        var result = await combinedWorkshopService.IsAvailableSeatsValidForWorkshop(
-            dto.AvailableSeats, dto.Id).ConfigureAwait(false);
-
-        if (result is null)
-        {
-            return BadRequest("The workshop does not exist.");
-        }
-
-        if (result == false)
-        {
-            return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
-        }
-
         try
         {
             var updatingResult = await combinedWorkshopService.Update(dto).ConfigureAwait(false);
 
-            return Ok(CreateUpdateResponse(updatingResult));
+            if (!updatingResult.Succeeded)
+            {
+                return BadRequest(updatingResult.OperationResult.Errors.FirstOrDefault().Description);
+            }
+
+            return Ok(CreateUpdateResponse(updatingResult.Value));
         }
         catch (ArgumentException e)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
@@ -200,25 +200,13 @@ public class WorkshopController : ControllerBase
     [Consumes("multipart/form-data")]
     public async Task<IActionResult> Update([FromForm] WorkshopV2Dto dto)
     {
-        if (dto == null)
-        {
-            return BadRequest("Workshop is null.");
-        }
-
         var userHasRights = await IsUserProvidersOwner(dto.ProviderId).ConfigureAwait(false);
         if (!userHasRights)
         {
             return StatusCode(StatusCodes.Status403Forbidden, "Forbidden to update workshops for another providers.");
         }
 
-        var workshop = await combinedWorkshopService.GetById(dto.Id, true).ConfigureAwait(false);
-
-        if (workshop is null)
-        {
-            return BadRequest("Workshop does not exist.");
-        }
-
-        if (!combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, workshop))
+        if (!await combinedWorkshopService.IsAvailableSeatsValid(dto.AvailableSeats, dto.Id))
         {
             return BadRequest("The number of available seats must be equal or greater than the number of taken seats");
         }

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/OutOfSchool.Tests.Common.csproj
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/OutOfSchool.Tests.Common.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
 	<PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/WorkshopGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/WorkshopGenerator.cs
@@ -34,6 +34,12 @@ public static class WorkshopGenerator
 
     public static List<Workshop> Generate(int count) => faker.Generate(count);
 
+    public static Workshop WithId(this Workshop workshop, Guid id)
+    {
+        workshop.Id = id;
+        return workshop;
+    }
+
     public static Workshop WithProvider(this Workshop workshop, Provider provider = null)
     {
         provider ??= ProvidersGenerator.Generate();


### PR DESCRIPTION
- Add check if a new value of workshop `AvailableSeats` is equal to or greater than the workshop's `TakenSeats` value.
- Set the workshop's status to open when the workshop is updated to unlimited seats by the workshops admin.
- Set the workshop's status to closed when the workshop is updated to limited seats and `AvailableSeats` equal to `TakenSeats`.
- A workshop's admin may suspend recruitment of children to the workshop with unlimited seats.
