### PR TITLE
Added notification count sending to NotificationHub

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/NotificationService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/NotificationService.cs
@@ -56,7 +56,7 @@ public class NotificationService : INotificationService
 
         var notificationDtoReturn = mapper.Map<NotificationDto>(newNotification);
 
-        var unreadNotificationsCount = GetAmountOfNewUsersNotificationsAsync(notification.UserId);
+        var unreadNotificationsCount = await GetAmountOfNewUsersNotificationsAsync(notification.UserId);
 
         await notificationHub.Clients
             .Group(notification.UserId)
@@ -99,7 +99,7 @@ public class NotificationService : INotificationService
 
             logger.LogInformation("Notification with Id = {Id} was created successfully", newNotificationDto?.Id);
 
-            var unreadNotificationsCount = GetAmountOfNewUsersNotificationsAsync(notification.UserId);
+            var unreadNotificationsCount = await GetAmountOfNewUsersNotificationsAsync(notification.UserId);
 
             await notificationHub.Clients
                 .Group(notification.UserId)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/NotificationService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/NotificationService.cs
@@ -3,8 +3,8 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using OutOfSchool.Services.Enums;
 using OutOfSchool.BusinessLogic.Models.Notifications;
+using OutOfSchool.Services.Enums;
 
 namespace OutOfSchool.BusinessLogic.Services;
 
@@ -56,6 +56,13 @@ public class NotificationService : INotificationService
 
         var notificationDtoReturn = mapper.Map<NotificationDto>(newNotification);
 
+        var unreadNotificationsCount = GetAmountOfNewUsersNotificationsAsync(notification.UserId);
+
+        await notificationHub.Clients
+            .Group(notification.UserId)
+            .SendAsync("ReceiveNotification", JsonConvert.SerializeObject(new { unreadNotificationsCount, notificationDtoReturn }))
+            .ConfigureAwait(false);
+
         return notificationDtoReturn;
     }
 
@@ -92,10 +99,12 @@ public class NotificationService : INotificationService
 
             logger.LogInformation("Notification with Id = {Id} was created successfully", newNotificationDto?.Id);
 
+            var unreadNotificationsCount = GetAmountOfNewUsersNotificationsAsync(notification.UserId);
+
             await notificationHub.Clients
-                    .Group(userId)
-                    .SendAsync("ReceiveNotification", JsonConvert.SerializeObject(newNotificationDto))
-                    .ConfigureAwait(false);
+                .Group(notification.UserId)
+                .SendAsync("ReceiveNotification", JsonConvert.SerializeObject(new { unreadNotificationsCount, newNotificationDto }))
+                .ConfigureAwait(false);
 
             logger.LogInformation(
                 "Notification with Id = {Id} was sent to {UserId} successfully",

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/NotificationServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/NotificationServiceTests.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
+using Bogus;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
@@ -137,14 +139,11 @@ public class NotificationServiceTests
     }
 
     [Test]
-    public async Task Create_RecipientsIdsValid_CreatesSpecificNumberOfTimes()
+    public async Task Create_RecipientsIdsValid_CreatesSpecificNumberOfTimesAndSendNotifications()
     {
         // Arrange
-        IEnumerable<string> recipientsIds = new List<string>()
-            {
-                Guid.NewGuid().ToString(),
-                Guid.NewGuid().ToString(),
-            };
+        var faker = new Faker();
+        var recipientsIds = faker.Make(faker.Random.Int(1, 10), () => Guid.NewGuid().ToString());
 
         var notificationsConfig = new NotificationsConfig
         {
@@ -157,20 +156,84 @@ public class NotificationServiceTests
         mockClients.Setup(clients => clients.Group(It.IsAny<string>())).Returns(mockClientProxy.Object);
         notificationHub.Setup(x => x.Clients).Returns(() => mockClients.Object);
 
+        var unreadNotifications = new Faker<Notification>().GenerateBetween(0, faker.Random.Number(10));
+        notificationRepositoryMock
+            .Setup(x => x.GetByFilter(It.IsAny<Expression<Func<Notification, bool>>>(), It.IsAny<string>()))
+            .Returns(Task.FromResult(unreadNotifications.AsEnumerable()));
+        notificationRepositoryMock.Setup(x => x.Create(It.IsAny<Notification>())).Returns<Notification>(Task.FromResult);
+
         // Act
         await notificationService.Create(
             It.IsAny<NotificationType>(),
             It.IsAny<NotificationAction>(),
             It.IsAny<Guid>(),
-            recipientsIds).ConfigureAwait(false);
+            recipientsIds)
+            .ConfigureAwait(false);
 
         // Assert
         notificationRepositoryMock.Verify(x => x.Create(It.IsAny<Notification>()), Times.Exactly(recipientsIds.Count()));
-        notificationHub.Verify(x => x.Clients.Group(It.IsAny<string>()), Times.Exactly(recipientsIds.Count()));
         foreach (var recipientId in recipientsIds)
         {
             notificationHub.Verify(x => x.Clients.Group(recipientId), Times.Once);
         }
+
+        var countOfUnread = $"unreadNotificationsCount\":{unreadNotifications.Count}";
+        mockClientProxy.Verify(
+            x => x.SendCoreAsync(
+                "ReceiveNotification",
+                It.Is<object[]>(
+                    arg => arg.Length > 0
+                        && arg[0].ToString().Contains(countOfUnread)
+                        && recipientsIds.Any(id => arg[0].ToString().Contains(id))),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(recipientsIds.Count));
+    }
+
+    [Test]
+    public async Task Create_NotificationDtoValid_CreatesNotificationAndSend()
+    {
+        // Arrange
+        var faker = new Faker();
+        var notificationId = Guid.NewGuid();
+        var notificationDto = new NotificationDto()
+        {
+            Id = notificationId,
+        };
+
+        var notificationsConfig = new NotificationsConfig
+        {
+            Enabled = true,
+        };
+
+        notificationsConfigMock.Setup(x => x.Value).Returns(notificationsConfig);
+        var mockClients = new Mock<IHubClients>();
+        var mockClientProxy = new Mock<IClientProxy>();
+        mockClients.Setup(clients => clients.Group(It.IsAny<string>())).Returns(mockClientProxy.Object);
+        notificationHub.Setup(x => x.Clients).Returns(() => mockClients.Object);
+
+        var unreadNotifications = new Faker<Notification>().GenerateBetween(0, faker.Random.Number(10));
+        notificationRepositoryMock
+            .Setup(x => x.GetByFilter(It.IsAny<Expression<Func<Notification, bool>>>(), It.IsAny<string>()))
+            .Returns(Task.FromResult(unreadNotifications.AsEnumerable()));
+        notificationRepositoryMock.Setup(x => x.Create(It.IsAny<Notification>())).ReturnsAsync(new Notification() { Id = notificationId });
+
+        // Act
+        await notificationService.Create(notificationDto)
+            .ConfigureAwait(false);
+
+        // Assert
+        notificationRepositoryMock.Verify(x => x.Create(It.IsAny<Notification>()), Times.Once);
+
+        var countOfUnread = $"unreadNotificationsCount\":{unreadNotifications.Count}";
+        mockClientProxy.Verify(
+            x => x.SendCoreAsync(
+                "ReceiveNotification",
+                It.Is<object[]>(
+                    arg => arg.Length > 0
+                        && arg[0].ToString().Contains(countOfUnread)
+                        && arg[0].ToString().Contains(notificationDto.Id.ToString())),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     #endregion


### PR DESCRIPTION
Follow-up for (https://github.com/ita-social-projects/OoS-Frontend/issues/2294)
Goal for this PR is to update notification count using WebSocket through SignalR.

Example of sent data:
```
{
   "type":1,
   "target":"ReceiveNotification",
   "arguments":[
      "{\"unreadNotificationsCount\":2,\"newNotificationDto\":{\"Id\":\"08dc79c9-f420-4795-85ce-534b46c12bef\",\"UserId\":\"string\",\"Data\":{\"additionalProp1\":\"string\",\"additionalProp2\":\"string\",\"additionalProp3\":\"string\"},\"Type\":\"Application\",\"Action\":\"Unknown\",\"CreatedDateTime\":\"2024-05-21T19:12:27.0712675+00:00\",\"ReadDateTime\":null,\"ObjectId\":\"3fa85f64-5717-4562-b3fc-2c963f66afa6\"}}"
   ]
}
  ```