### PR TITLE
Fix date time parsing

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthServer.Tests/EmailSender/EmailSenderJobTests.cs
+++ b/OutOfSchool/OutOfSchool.AuthServer.Tests/EmailSender/EmailSenderJobTests.cs
@@ -86,7 +86,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddMinutes(-10).ToString() }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddMinutes(-10).ToString("dd.MM.yyyy HH:mm:ss zzz") }
             });
 
         // Act
@@ -111,7 +111,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString() }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString("dd.MM.yyyy HH:mm:ss zzz") }
             });
         _mockSendGridClient.Setup(client => client.SendEmailAsync(It.IsAny<SendGridMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Response(HttpStatusCode.OK, null, null));
@@ -138,7 +138,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString() }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString("dd.MM.yyyy HH:mm:ss zzz") }
             });
         _mockSendGridClient.Setup(client => client.SendEmailAsync(It.IsAny<SendGridMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Response(HttpStatusCode.TooManyRequests, null, null));
@@ -160,7 +160,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString() }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString("dd.MM.yyyy HH:mm:ss zzz") }
             });
         _mockSendGridClient.Setup(client => client.SendEmailAsync(It.IsAny<SendGridMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Response(HttpStatusCode.BadRequest, null, null));

--- a/OutOfSchool/OutOfSchool.AuthServer.Tests/EmailSender/EmailSenderJobTests.cs
+++ b/OutOfSchool/OutOfSchool.AuthServer.Tests/EmailSender/EmailSenderJobTests.cs
@@ -19,6 +19,7 @@ namespace OutOfSchool.AuthServer.Tests.EmailSender;
 [TestFixture]
 public class EmailSenderJobTests
 {
+    private const string DateTimeStringFormat = "dd.MM.yyyy HH:mm:ss zzz";
     private Mock<IOptions<EmailOptions>> _mockEmailOptions;
     private Mock<ILogger<EmailSenderJob>> _mockLogger;
     private Mock<ISendGridClient> _mockSendGridClient;
@@ -86,7 +87,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddMinutes(-10).ToString("dd.MM.yyyy HH:mm:ss zzz") }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddMinutes(-10).ToString(DateTimeStringFormat) }
             });
 
         // Act
@@ -111,7 +112,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString("dd.MM.yyyy HH:mm:ss zzz") }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString(DateTimeStringFormat) }
             });
         _mockSendGridClient.Setup(client => client.SendEmailAsync(It.IsAny<SendGridMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Response(HttpStatusCode.OK, null, null));
@@ -138,7 +139,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString("dd.MM.yyyy HH:mm:ss zzz") }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString(DateTimeStringFormat) }
             });
         _mockSendGridClient.Setup(client => client.SendEmailAsync(It.IsAny<SendGridMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Response(HttpStatusCode.TooManyRequests, null, null));
@@ -160,7 +161,7 @@ public class EmailSenderJobTests
                 { EmailSenderStringConstants.Subject, "Test Email" },
                 { EmailSenderStringConstants.HtmlContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("<html><body><h1>Hello</h1></body></html>")) },
                 { EmailSenderStringConstants.PlainContent, Convert.ToBase64String(Encoding.ASCII.GetBytes("Hello")) },
-                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString("dd.MM.yyyy HH:mm:ss zzz") }
+                { EmailSenderStringConstants.ExpirationTime, DateTimeOffset.Now.AddDays(1).ToString(DateTimeStringFormat) }
             });
         _mockSendGridClient.Setup(client => client.SendEmailAsync(It.IsAny<SendGridMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Response(HttpStatusCode.BadRequest, null, null));

--- a/OutOfSchool/OutOfSchool.EmailSender/EmailSenderStringConstants.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/EmailSenderStringConstants.cs
@@ -7,4 +7,5 @@ public static class EmailSenderStringConstants
     public const string HtmlContent = "HtmlContent";
     public const string PlainContent = "PlainContent";
     public const string ExpirationTime = "ExpirationTime";
+    public const string DateTimeStringFormat = "dd.MM.yyyy HH:mm:ss zzz";
 }

--- a/OutOfSchool/OutOfSchool.EmailSender/Quartz/EmailSenderJob.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/Quartz/EmailSenderJob.cs
@@ -55,7 +55,7 @@ public class EmailSenderJob : IJob
             var plainContent = dataMap.GetString(EmailSenderStringConstants.PlainContent);
             var expirationTime = DateTimeOffset.ParseExact(
                 dataMap.GetString(EmailSenderStringConstants.ExpirationTime),
-                "dd.MM.yyyy HH:mm:ss zzz",
+                EmailSenderStringConstants.DateTimeStringFormat,
                 CultureInfo.InvariantCulture);
 
             if (expirationTime < DateTimeOffset.Now)

--- a/OutOfSchool/OutOfSchool.EmailSender/Quartz/EmailSenderJob.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/Quartz/EmailSenderJob.cs
@@ -53,7 +53,10 @@ public class EmailSenderJob : IJob
             var subject = dataMap.GetString(EmailSenderStringConstants.Subject);
             var htmlContent = dataMap.GetString(EmailSenderStringConstants.HtmlContent);
             var plainContent = dataMap.GetString(EmailSenderStringConstants.PlainContent);
-            var expirationTime = DateTimeOffset.Parse(dataMap.GetString(EmailSenderStringConstants.ExpirationTime), CultureInfo.CurrentCulture);
+            var expirationTime = DateTimeOffset.ParseExact(
+                dataMap.GetString(EmailSenderStringConstants.ExpirationTime),
+                "dd.MM.yyyy HH:mm:ss zzz",
+                CultureInfo.InvariantCulture);
 
             if (expirationTime < DateTimeOffset.Now)
             {

--- a/OutOfSchool/OutOfSchool.EmailSender/Services/EmailSenderService.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/Services/EmailSenderService.cs
@@ -29,7 +29,7 @@ public class EmailSenderService : IEmailSenderService
             { EmailSenderStringConstants.Subject, subject },
             { EmailSenderStringConstants.HtmlContent, EncodeToBase64(content.html) },
             { EmailSenderStringConstants.PlainContent, EncodeToBase64(content.plain) },
-            { EmailSenderStringConstants.ExpirationTime, expirationTime.ToString() },
+            { EmailSenderStringConstants.ExpirationTime, ((DateTimeOffset)expirationTime).ToString("dd.MM.yyyy HH:mm:ss zzz") },
         };
 
         var scheduler = await schedulerFactory.GetScheduler();

--- a/OutOfSchool/OutOfSchool.EmailSender/Services/EmailSenderService.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/Services/EmailSenderService.cs
@@ -29,7 +29,7 @@ public class EmailSenderService : IEmailSenderService
             { EmailSenderStringConstants.Subject, subject },
             { EmailSenderStringConstants.HtmlContent, EncodeToBase64(content.html) },
             { EmailSenderStringConstants.PlainContent, EncodeToBase64(content.plain) },
-            { EmailSenderStringConstants.ExpirationTime, ((DateTimeOffset)expirationTime).ToString("dd.MM.yyyy HH:mm:ss zzz") },
+            { EmailSenderStringConstants.ExpirationTime, ((DateTimeOffset)expirationTime).ToString(EmailSenderStringConstants.DateTimeStringFormat) },
         };
 
         var scheduler = await schedulerFactory.GetScheduler();


### PR DESCRIPTION
Possible fix for issue with date time parsing in EmailSenderJob.
Exception:
String '31.12.9999 23:59:59 +00:00' was not recognized as a valid DateTime.
Exception of type 'Quartz.JobExecutionException' was thrown в OutOfSchool.EmailSender
at OutOfSchool.EmailSender.Quartz.EmailSenderJob.Execute(IJobExecutionContext context) in /workspace/OutOfSchool/OutOfSchool.EmailSender/Quartz/EmailSenderJob.cs:line 101
   at Quartz.Core.JobRunShell.Run(CancellationToken cancellationToken)