### PR TITLE
Return explicit target framework for executable projects

### DIFF
--- a/OutOfSchool/OutOfSchool.AdminInitializer/OutOfSchool.AdminInitializer.csproj
+++ b/OutOfSchool/OutOfSchool.AdminInitializer/OutOfSchool.AdminInitializer.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <UserSecretsId>dd058b3f-d89a-4456-a6df-2f32568b56ea</UserSecretsId>
-  </PropertyGroup>
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/OutOfSchool.AuthorizationServer.csproj
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/OutOfSchool.AuthorizationServer.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
         <CodeAnalysisRuleSet>..\StyleCopAnalyzersRules.ruleset</CodeAnalysisRuleSet>
         <UserSecretsId>23768b69-757e-4a20-894f-dcf7181971ca</UserSecretsId>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
         <UserSecretsId>1ac220b0-4848-4d5c-b0d9-b64657bd3b04</UserSecretsId>
     </PropertyGroup>
     <PropertyGroup>


### PR DESCRIPTION
Paketo buildpack runs a scan to determine needed runtime before running MSBuild and fails to detect the setting in `Directory.Build.props`, so reverting the change for 3 executable projects.