### PR TITLE
yavoda/add endpoint for competitive selection description

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
@@ -143,12 +144,19 @@ public class WorkshopControllerTests
         workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshop);
 
         // Act
-        var result = await controller.GetCompetitiveSelectionDescription(workshop.Id) as OkObjectResult;
+        var result = await controller.GetCompetitiveSelectionDescription(workshop.Id);
 
         // Assert
         workshopServiceMoq.VerifyAll();
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.StatusCode, Is.EqualTo(Ok));
+
+        result.Should()
+            .NotBeNull();
+
+        result.Should()
+            .BeOfType<OkObjectResult>()
+            .Which.StatusCode
+            .Should()
+            .Be(StatusCodes.Status200OK);
     }
 
     [Test]
@@ -158,12 +166,19 @@ public class WorkshopControllerTests
         workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync((WorkshopDto)null);
 
         // Act
-        var result = await controller.GetCompetitiveSelectionDescription(workshop.Id) as NoContentResult;
+        var result = await controller.GetCompetitiveSelectionDescription(workshop.Id);
 
         // Assert
         workshopServiceMoq.VerifyAll();
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.StatusCode, Is.EqualTo(NoContent));
+
+        result.Should()
+            .NotBeNull();
+
+        result.Should()
+            .BeOfType<NoContentResult>()
+            .Which.StatusCode
+            .Should()
+            .Be(StatusCodes.Status204NoContent);
     }
 
     [TestCase(null)]
@@ -177,23 +192,36 @@ public class WorkshopControllerTests
         workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshopWithoutCSD);
 
         // Act
-        var result = await controller.GetCompetitiveSelectionDescription(workshop.Id) as NoContentResult;
+        var result = await controller.GetCompetitiveSelectionDescription(workshop.Id);
 
         // Assert
         workshopServiceMoq.VerifyAll();
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.StatusCode, Is.EqualTo(NoContent));
+
+        result.Should()
+            .NotBeNull();
+
+        result.Should()
+            .BeOfType<NoContentResult>()
+            .Which.StatusCode
+            .Should()
+            .Be(StatusCodes.Status204NoContent);
     }
 
     [Test]
     public async Task GetCompetitiveSelectionDescription_EmptyId_ReturnsBadRequest()
     {
         // Act
-        var result = await controller.GetCompetitiveSelectionDescription(Guid.Empty) as BadRequestObjectResult;
+        var result = await controller.GetCompetitiveSelectionDescription(Guid.Empty);
 
         // Assert
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.StatusCode, Is.EqualTo(BadRequest));
+        result.Should()
+            .NotBeNull();
+
+        result.Should()
+            .BeOfType<BadRequestObjectResult>()
+            .Which.StatusCode
+            .Should()
+            .Be(StatusCodes.Status400BadRequest);
     }
         #endregion
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -135,6 +135,68 @@ public class WorkshopControllerTests
     }
     #endregion
 
+    #region GetCompetitiveSelectionDescription
+    [Test]
+    public async Task GetCompetitiveSelectionDescription_WhenIdIsValid_ShouldReturnOkResultObject()
+    {
+        // Arrange
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshop);
+
+        // Act
+        var result = await controller.GetCompetitiveSelectionDescription(workshop.Id) as OkObjectResult;
+
+        // Assert
+        workshopServiceMoq.VerifyAll();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(Ok));
+    }
+
+    [Test]
+    public async Task GetCompetitiveSelectionDescription_WhenThereIsNoWorkshopWithId_ShouldReturnNoContent()
+    {
+        // Arrange
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync((WorkshopDto)null);
+
+        // Act
+        var result = await controller.GetCompetitiveSelectionDescription(workshop.Id) as NoContentResult;
+
+        // Assert
+        workshopServiceMoq.VerifyAll();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(NoContent));
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public async Task GetCompetitiveSelectionDescription_WhenCompetitiveSelectionDescriptionIsNullOrEmpty_ShouldReturnNoContent(string competitiveSelectionDescription)
+    {
+        // Arrange
+        var workshopWithoutCSD = WorkshopDtoGenerator.Generate();
+        workshopWithoutCSD.CompetitiveSelectionDescription = competitiveSelectionDescription;
+
+        workshopServiceMoq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>())).ReturnsAsync(workshopWithoutCSD);
+
+        // Act
+        var result = await controller.GetCompetitiveSelectionDescription(workshop.Id) as NoContentResult;
+
+        // Assert
+        workshopServiceMoq.VerifyAll();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(NoContent));
+    }
+
+    [Test]
+    public async Task GetCompetitiveSelectionDescription_EmptyId_ReturnsBadRequest()
+    {
+        // Act
+        var result = await controller.GetCompetitiveSelectionDescription(Guid.Empty) as BadRequestObjectResult;
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(BadRequest));
+    }
+        #endregion
+
     #region GetByProviderId
     [Test]
     public async Task GetByProviderId_WhenThereAreWorkshops_ShouldReturnOkResultObject()

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -200,6 +200,35 @@ public class WorkshopController : ControllerBase
     }
 
     /// <summary>
+    /// Gets the competitive selection description of the specified workshop.
+    /// </summary>
+    /// <param name="id">Id of the workshop to get the competitive selection description for.</param>
+    /// <returns>A string description of the competitive selection for the workshop specified by id.</returns>
+    [AllowAnonymous]
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+
+    public async Task<IActionResult> GetCompetitiveSelectionDescription(Guid id)
+    {
+        if (id == Guid.Empty)
+        {
+            return BadRequest("Workshop id is empty.");
+        }
+
+        var workshop = await combinedWorkshopService.GetById(id).ConfigureAwait(false);
+
+        if (workshop is null || string.IsNullOrEmpty(workshop.CompetitiveSelectionDescription))
+        {
+            return NoContent();
+        }
+
+        return Ok(workshop.CompetitiveSelectionDescription);
+    }
+
+    /// <summary>
     /// Get workshops that matches filter's parameters.
     /// </summary>
     /// <param name="filter">Entity that represents searching parameters.</param>


### PR DESCRIPTION
Related issue #2561 (frontend)
[https://github.com/ita-social-projects/OoS-Frontend/issues/2561](url)
## Summary of change

1. Added GetCompetitiveSelectionDescription action to WorkshopController
2. Added unit tests for this action

