### PR TITLE
Removed the unnecessary Antiforgery token validation

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Controllers/TokenController.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Controllers/TokenController.cs
@@ -275,7 +275,7 @@ public class TokenController : Controller
 
     [ActionName(nameof(Logout))]
     [HttpPost("~/connect/logout")]
-    [ValidateAntiForgeryToken]
+    [IgnoreAntiforgeryToken]
     public async Task<IActionResult> DoLogout()
     {
         // logger.LogDebug($"{path} started. User(id): {userId}.");


### PR DESCRIPTION
Removed the Antiforgery token validation as it is unnecessary in the case of logging out. 
Prior to this there was a problem where the UI logout confirmation would log the user out in any case, actually before the confirmation results where accepted. 