### PR TITLE
BugFix[1560]/Added single record to logs instead many in case deletion of the provider admin

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthCommon/Services/ProviderAdminService.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Services/ProviderAdminService.cs
@@ -376,19 +376,14 @@ public class ProviderAdminService : IProviderAdminService
                     return CreateResponseDto(HttpStatusCode.InternalServerError);
                 }
 
-                var oldPropertiesValues = GetTrackedUserProperties(user);
-
-                foreach (var oldProperty in oldPropertiesValues)
-                {
-                    await providerAdminChangesLogService.SaveChangesLogAsync(
+                await providerAdminChangesLogService.SaveChangesLogAsync(
                         providerAdmin,
                         userId,
                         OperationType.Delete,
-                        oldProperty.Key,
-                        oldProperty.Value,
+                        string.Empty,
+                        string.Empty,
                         string.Empty)
                     .ConfigureAwait(false);
-                }
 
                 await transaction.CommitAsync();
 


### PR DESCRIPTION
bugfix #1560 
Removed foreach and added single record to logs in case deletion of the provider admin
Fields "was" and "Became" will be empty