### PR TITLE
Nakoneshniuk/fixed total amount workshops returned

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -670,7 +670,10 @@ public class WorkshopService : IWorkshopService, ISensitiveWorkshopsService
             .ToListAsync()
             .ConfigureAwait(false);
 
-        var workshopsCount = workshops.Count;
+        var workshopsCount = await workshopRepository
+            .Count(predicate)
+            .ConfigureAwait(false);
+
         logger.LogInformation("Retrieved {WorkshopsCount} matching recods by filter for admins.", workshopsCount);
 
         var workshopsDTO = mapper.Map<List<WorkshopDto>>(workshops);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -655,11 +655,38 @@ public class WorkshopService : IWorkshopService, ISensitiveWorkshopsService
 
         if (filter == null)
         {
-            logger.LogDebug("Method {MethodName} started with null filter. Applying default {Filter}", nameof(FetchByFilterForAdmins), nameof(WorkshopFilterAdministration));
+            logger.LogDebug(
+                "Method {MethodName} started with null filter. Applying default {Filter}",
+                nameof(FetchByFilterForAdmins),
+                nameof(WorkshopFilterAdministration));
+
             filter = new WorkshopFilterAdministration();
         }
 
-        var predicate = await PredicateBuildForAdminds(filter);
+        var (adminInstitutionId, catottgIdAdmin) = await GetAdminInstitutionAndCatottgIds();
+
+        IEnumerable<long> allowedSettlementIdsForAdmin = Enumerable.Empty<long>();
+        IEnumerable<long> subSettlementsIdsByFilter = Enumerable.Empty<long>();
+
+        if (catottgIdAdmin > 0)
+        {
+            allowedSettlementIdsForAdmin = await codeficatorService
+                .GetAllChildrenIdsByParentIdAsync(catottgIdAdmin)
+                .ConfigureAwait(false);
+        }
+
+        if (filter.CATOTTGId > 0)
+        {
+            subSettlementsIdsByFilter = await codeficatorService
+                .GetAllChildrenIdsByParentIdAsync(filter.CATOTTGId)
+                .ConfigureAwait(false);
+        }
+
+        var predicate = PredicateBuildForAdminds(
+            filter,
+            adminInstitutionId,
+            allowedSettlementIdsForAdmin,
+            subSettlementsIdsByFilter);
 
         var workshops = await workshopRepository.Get(
                 skip: filter.From,
@@ -674,41 +701,80 @@ public class WorkshopService : IWorkshopService, ISensitiveWorkshopsService
             .Count(predicate)
             .ConfigureAwait(false);
 
-        logger.LogInformation("Retrieved {WorkshopsCount} matching recods by filter for admins.", workshopsCount);
+        logger.LogInformation("Retrieved {WorkshopsCount} matching records by filter for admins.", workshopsCount);
 
         var workshopsDTO = mapper.Map<List<WorkshopDto>>(workshops);
 
-        var result = new SearchResult<WorkshopDto>()
+        return new SearchResult<WorkshopDto>()
         {
             TotalAmount = workshopsCount,
             Entities = workshopsDTO,
         };
-
-        return result;
     }
 
-    private async Task<Expression<Func<Workshop, bool>>> PredicateBuildForAdminds(WorkshopFilterAdministration filter)
+    private async Task<(Guid InstitutionId, long CatottgId)> GetAdminInstitutionAndCatottgIds()
     {
-        var predicate = PredicateBuilder.True<Workshop>();
-
-        // TODO: add condition for united territorial community admin
         if (currentUserService.IsMinistryAdmin())
         {
-            var predicateForMinAdmin = await PredicateForRoleMinistryAdmin()
+            var userId = currentUserService.UserId;
+            var ministryAdmin = await ministryAdminService
+                .GetByUserId(userId)
                 .ConfigureAwait(false);
-            predicate = predicate.And(predicateForMinAdmin);
+
+            return (ministryAdmin.InstitutionId, 0);
         }
         else if (currentUserService.IsRegionAdmin())
         {
-            var predicateForRegionAdmin = await PredicateForRoleRegionAdmin()
+            var userId = currentUserService.UserId;
+            var regionAdmin = await regionAdminService
+                .GetByUserId(userId)
                 .ConfigureAwait(false);
-            predicate = predicate.And(predicateForRegionAdmin);
+
+            if (regionAdmin == null)
+            {
+                var errorMsg = $"Region admin with the specified ID: {userId} not found";
+                logger.LogError(errorMsg);
+                throw new InvalidOperationException(errorMsg);
+            }
+
+            return (regionAdmin.InstitutionId, regionAdmin.CATOTTGId);
+        }
+
+        return (Guid.Empty, 0);
+    }
+
+    private Expression<Func<Workshop, bool>> PredicateBuildForAdminds(
+        WorkshopFilterAdministration filter,
+        Guid adminInstitutionId,
+        IEnumerable<long> allowedSettlementIdsForAdmin,
+        IEnumerable<long> subSettlementFilterIds)
+    {
+        var predicate = PredicateBuilder.True<Workshop>();
+
+        if (adminInstitutionId != Guid.Empty)
+        {
+            predicate = predicate.And(x => x.InstitutionHierarchy.InstitutionId == adminInstitutionId);
+        }
+
+        if (filter.InstitutionId != Guid.Empty)
+        {
+            predicate = predicate.And(x => x.InstitutionHierarchy.InstitutionId == filter.InstitutionId);
+        }
+
+        if (allowedSettlementIdsForAdmin != null && allowedSettlementIdsForAdmin.Any())
+        {
+            predicate = predicate.And(x => allowedSettlementIdsForAdmin.Contains(x.Address.CATOTTGId));
+        }
+
+        if (subSettlementFilterIds != null && subSettlementFilterIds.Any())
+        {
+            predicate = predicate.And(x => subSettlementFilterIds.Contains(x.Address.CATOTTGId));
         }
 
         if (!string.IsNullOrWhiteSpace(filter.SearchString))
         {
             // Split the search string by commas and spaces, remove any empty entries, and trim whitespace from each element.
-            var searchTerms = filter.SearchString.Split(new char[] {' ', ','}, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var searchTerms = filter.SearchString.Split(new char[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
             logger.LogDebug("Received terms from search string: {Words}", searchTerms);
 
@@ -728,62 +794,6 @@ public class WorkshopService : IWorkshopService, ISensitiveWorkshopsService
                 predicate = predicate.And(tempPredicate);
             }
         }
-
-        if (filter.InstitutionId != Guid.Empty)
-        {
-            predicate = predicate.And(x => x.InstitutionHierarchy.InstitutionId == filter.InstitutionId);
-        }
-
-        if (filter.CATOTTGId > 0)
-        {
-            var subSettlementsIds = await codeficatorService
-                .GetAllChildrenIdsByParentIdAsync(filter.CATOTTGId)
-                .ConfigureAwait(false);
-
-            predicate = predicate.And(x => subSettlementsIds.Contains(x.Address.CATOTTGId));
-        }
-
-        return predicate;
-    }
-
-    private async Task<Expression<Func<Workshop, bool>>> PredicateForRoleMinistryAdmin()
-    {
-        var predicate = PredicateBuilder.True<Workshop>();
-        var userId = currentUserService.UserId;
-        var ministryAdmin = await ministryAdminService
-            .GetByUserId(userId)
-            .ConfigureAwait(false);
-
-        predicate = predicate.And(x => x.InstitutionHierarchy.InstitutionId == ministryAdmin.InstitutionId);
-
-        return predicate;
-    }
-
-    private async Task<Expression<Func<Workshop, bool>>> PredicateForRoleRegionAdmin()
-    {
-        var userId = currentUserService.UserId;
-        var regionAdmin = await regionAdminService
-                .GetByUserId(userId)
-                .ConfigureAwait(false);
-
-        if (regionAdmin == null)
-        {
-            var errorMsg = $"Region admin with the specified ID: {userId} not found";
-            logger.LogError(errorMsg);
-            throw new InvalidOperationException(errorMsg);
-        }
-
-        var predicate = PredicateBuilder.True<Workshop>();
-        var institutionId = regionAdmin.InstitutionId;
-        var catottgId = regionAdmin.CATOTTGId;
-
-        predicate = predicate.And(x => x.InstitutionHierarchy.InstitutionId == institutionId);
-
-        var subSettlementsIds = await codeficatorService
-            .GetAllChildrenIdsByParentIdAsync(catottgId)
-            .ConfigureAwait(false);
-
-        predicate = predicate.And(x => subSettlementsIds.Contains(x.Address.CATOTTGId));
 
         return predicate;
     }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceDBTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceDBTests.cs
@@ -83,18 +83,20 @@ public class SensitiveWorkshopsServiceDBTests
     }
 
     [Test]
-    public async Task FetchByFilterForAdmins_FilterIsNull_ShouldBuildPredicateAndReturnDefaultAmountOfEntities()
+    public async Task FetchByFilterForAdmins_FilterIsNull_ShouldReturnDefaultAmountEntities()
     {
         // Arrange
+        var workshopDtos = await MapWorkshopsToDtos();
         var filter = new WorkshopFilterAdministration();
-        var workshopDtos = (await MapWorkshopsToDtos())
-            .Take(filter.Size)
-            .ToList();
+        var entities = workshopDtos.
+            Skip(filter.From).
+            Take(filter.Size).
+            ToList();
 
         var expectedResult = new SearchResult<WorkshopDto>()
         {
             TotalAmount = workshopDtos.Count,
-            Entities = workshopDtos,
+            Entities = entities,
         };
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceDBTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceDBTests.cs
@@ -212,9 +212,8 @@ public class SensitiveWorkshopsServiceDBTests
         var workshopDto = await MapWorkshopsToDtos();
         var userId = Guid.NewGuid().ToString();
         var expectedList = new List<WorkshopDto>() { workshopDto[2], workshopDto[3], workshopDto[4] };
-        var admin = new RegionAdminDto() { CATOTTGId = 4};
+        var admin = new RegionAdminDto() { CATOTTGId = 4, InstitutionId = Guid.Parse("4c865c12-e99a-456b-82b1-7a7c3a2d6935") };
         SetupRegionAdminRole(userId, admin);
-        TestContext.WriteLine(workshopDto);
 
         // Act
         var result = await sensitiveWorkshopService.FetchByFilterForAdmins()
@@ -271,6 +270,75 @@ public class SensitiveWorkshopsServiceDBTests
 
         result.Entities.Should()
             .BeEquivalentTo(expectedList);
+    }
+
+    [Test]
+    public async Task FetchByFilterForAdmins_RoleMinistryAdminFilterByInvalidInstitutionId_ShouldReturnEmptyList()
+    {
+        // Arrange
+        await MapWorkshopsToDtos();
+        var expectedList = new List<WorkshopDto>();
+        var userId = Guid.NewGuid().ToString();
+        var ministryAdmin = new MinistryAdminDto()
+        {
+            Id = userId,
+            InstitutionId = Guid.Parse("d85a3f07-8d7b-45b1-871d-23c5f4e34b92"),
+        };
+
+        SetupMinistryAdminRole(userId, ministryAdmin);
+
+        var filter = new WorkshopFilterAdministration()
+        {
+            InstitutionId = Guid.Parse("4c865c12-e99a-456b-82b1-7a7c3a2d6935"),
+        };
+
+        var expectedResult = new SearchResult<WorkshopDto>()
+        {
+            TotalAmount = expectedList.Count,
+            Entities = expectedList,
+        };
+
+        // Act
+        var result = await sensitiveWorkshopService.FetchByFilterForAdmins(filter)
+            .ConfigureAwait(false);
+
+        result.Should()
+            .BeEquivalentTo(expectedResult);
+    }
+
+    [Test]
+    public async Task FetchByFilterForAdmins_RoleRegionAdminFilterByInvalidInstitutionId_ShouldReturnEmptyList()
+    {
+        // Arrange
+        await MapWorkshopsToDtos();
+        var expectedList = new List<WorkshopDto>();
+        var userId = Guid.NewGuid().ToString();
+
+        var regionAdmin = new RegionAdminDto()
+        {
+            Id = userId,
+            InstitutionId = Guid.Parse("d85a3f07-8d7b-45b1-871d-23c5f4e34b92"),
+        };
+
+        SetupRegionAdminRole(userId, regionAdmin);
+
+        var filter = new WorkshopFilterAdministration()
+        {
+            InstitutionId = Guid.Parse("4c865c12-e99a-456b-82b1-7a7c3a2d6935"),
+        };
+
+        var expectedResult = new SearchResult<WorkshopDto>()
+        {
+            TotalAmount = expectedList.Count,
+            Entities = expectedList,
+        };
+
+        // Act
+        var result = await sensitiveWorkshopService.FetchByFilterForAdmins(filter)
+            .ConfigureAwait(false);
+
+        result.Should()
+            .BeEquivalentTo(expectedResult);
     }
 
     private void Seed()

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceTests.cs
@@ -212,6 +212,10 @@ public class SensitiveWorkshopsServiceTests
     private void SetUpWorkshopsRepository(List<Workshop> workshopsReturned, WorkshopFilterAdministration filter = null)
     {
         workshopRepository.Setup(
+            x => x.Count(It.IsAny<Expression<Func<Workshop, bool>>>()))
+            .ReturnsAsync(workshopsReturned.Count);
+
+        workshopRepository.Setup(
                 w => w.Get(
                     It.Is<int>(x => x == filter.From),
                     It.Is<int>(x => x == filter.Size),


### PR DESCRIPTION
### Summary of Changes:
- Fixed the filtering behavior by `InstitutionId` when the user has the `regionadmin` or `ministryadmin` role. 
- Now, if the `InstitutionId` in the filter differs from the `InstitutionId` associated with the user's role, an empty list is returned instead of the full list of workshops belonging to the  role.
- Fixed the `totalAmount` value, which now correctly reflects the total number of workshops found by the filter.

### Testing:
- Added tests to verify that an empty list is returned when the `InstitutionId` in the filter does not match the user's role.
