### PR TITLE
Business Entity Configuration

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -95,7 +95,7 @@ public class WorkshopBaseDto : IValidatableObject
     public string InstitutionHierarchy { get; set; }
 
     public List<long> DirectionIds { get; set; }
-    
+
     [ModelBinder(BinderType = typeof(JsonModelBinder))]
     public IEnumerable<string> Keywords { get; set; } = default;
 
@@ -120,6 +120,10 @@ public class WorkshopBaseDto : IValidatableObject
 
     [EnumDataType(typeof(ProviderLicenseStatus), ErrorMessage = Constants.EnumErrorMessage)]
     public ProviderLicenseStatus ProviderLicenseStatus { get; set; } = ProviderLicenseStatus.NotProvided;
+
+    public DateOnly ActiveFrom { get; set; }
+
+    public DateOnly ActiveTo { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CurrentUserAccessor.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CurrentUserAccessor.cs
@@ -15,17 +15,17 @@ public class CurrentUserAccessor : ICurrentUser
         this.user = user;
     }
 
-    public string UserId => user?.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub) ?? string.Empty;
+    public string UserId => GettingUserProperties.GetUserId(user) ?? string.Empty;
 
-    public string UserRole => GettingUserProperties.GetUserRole(user);
+    public string UserRole => GettingUserProperties.GetUserRole(user) ?? string.Empty;
 
-    public string UserSubRole => GettingUserProperties.GetUserSubrole(user);
+    public string UserSubRole => GettingUserProperties.GetUserSubrole(user) ?? string.Empty;
 
     public bool IsInRole(string role) => user?.IsInRole(role) ?? false;
 
     public bool IsAuthenticated => user?.Identity?.IsAuthenticated ?? false;
 
-    public bool HasClaim(string type, Func<string, bool>? valueComparer) =>
+    public bool HasClaim(string type, Func<string, bool>? valueComparer = null) =>
         user?.Identities
             .Any(identity =>
                 identity.HasClaim(claim =>

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CurrentUserAccessor.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CurrentUserAccessor.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+using System.Security.Claims;
+using OutOfSchool.BusinessLogic.Common;
+using OutOfSchool.Common.Models;
+
+namespace OutOfSchool.BusinessLogic.Services;
+
+public class CurrentUserAccessor : ICurrentUser
+{
+    private readonly ClaimsPrincipal? user;
+
+    public CurrentUserAccessor(ClaimsPrincipal? user)
+    {
+        this.user = user;
+    }
+
+    public string UserId => user?.GetUserPropertyByClaimType(IdentityResourceClaimsTypes.Sub) ?? string.Empty;
+
+    public string UserRole => GettingUserProperties.GetUserRole(user);
+
+    public string UserSubRole => GettingUserProperties.GetUserSubrole(user);
+
+    public bool IsInRole(string role) => user?.IsInRole(role) ?? false;
+
+    public bool IsAuthenticated => user?.Identity?.IsAuthenticated ?? false;
+
+    public bool HasClaim(string type, Func<string, bool>? valueComparer) =>
+        user?.Identities
+            .Any(identity =>
+                identity.HasClaim(claim =>
+                    string.Equals(
+                        claim.Type,
+                        type,
+                        StringComparison.OrdinalIgnoreCase) && (valueComparer?.Invoke(claim.Value) ?? true))) ?? false;
+}

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ICurrentUserService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ICurrentUserService.cs
@@ -6,14 +6,8 @@ namespace OutOfSchool.BusinessLogic.Services;
 /// <summary>
 /// Defines interface for checking right to access entities in logic.
 /// </summary>
-public interface ICurrentUserService
+public interface ICurrentUserService : ICurrentUser
 {
-    /// <summary>
-    /// Gets current logged in UserId or empty string in other case.
-    /// </summary>
-    /// <returns>A <see cref="string"/> id of current logged in user.</returns>
-    public string UserId { get; }
-
     /// <summary>
     /// Gets current logged in UserRole or empty string in other case.
     /// </summary>

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ICurrentUserService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ICurrentUserService.cs
@@ -9,18 +9,6 @@ namespace OutOfSchool.BusinessLogic.Services;
 public interface ICurrentUserService : ICurrentUser
 {
     /// <summary>
-    /// Gets current logged in UserRole or empty string in other case.
-    /// </summary>
-    /// <returns>A <see cref="string"/> id of current logged in user.</returns>
-    public string UserRole { get; }
-
-    /// <summary>
-    /// Gets current logged in UserSubRole or empty string in other case.
-    /// </summary>
-    /// <returns>A <see cref="string"/> id of current logged in user.</returns>
-    public string UserSubRole { get; }
-
-    /// <summary>
     /// Check if user's role is the same as provided.
     /// </summary>
     /// <param name="role">A <see cref="Role"/> to check.</param>

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -79,7 +79,8 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.Status, opt => opt.Ignore())
             .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
             .ForMember(dest => dest.ProviderOwnership, opt => opt.Ignore())
-            .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore());
+            .ForMember(dest => dest.Document, opt => opt.Ignore())
+            .ForMember(dest => dest.File, opt => opt.Ignore());
 
         CreateMap<Workshop, WorkshopDto>()
             .IncludeBase<Workshop, WorkshopBaseDto>()

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -80,7 +80,14 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
             .ForMember(dest => dest.ProviderOwnership, opt => opt.Ignore())
             .ForMember(dest => dest.Document, opt => opt.Ignore())
-            .ForMember(dest => dest.File, opt => opt.Ignore());
+            .ForMember(dest => dest.File, opt => opt.Ignore())
+            .ForMember(dest => dest.IsSystemProtected, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedBy, opt => opt.Ignore())
+            .ForMember(dest => dest.ModifiedBy, opt => opt.Ignore())
+            .ForMember(dest => dest.DeletedBy, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.DeleteDate, opt => opt.Ignore());
 
         CreateMap<Workshop, WorkshopDto>()
             .IncludeBase<Workshop, WorkshopBaseDto>()

--- a/OutOfSchool/OutOfSchool.Common/Models/ICurrentUser.cs
+++ b/OutOfSchool/OutOfSchool.Common/Models/ICurrentUser.cs
@@ -1,0 +1,13 @@
+namespace OutOfSchool.Common.Models;
+
+/// <summary>
+/// Defines interface for current user id.
+/// </summary>
+public interface ICurrentUser
+{
+    /// <summary>
+    /// Gets current logged in UserId or empty string in other case.
+    /// </summary>
+    /// <returns>A <see cref="string"/> id of current logged in user.</returns>
+    public string UserId { get; }
+}

--- a/OutOfSchool/OutOfSchool.Common/Models/ICurrentUser.cs
+++ b/OutOfSchool/OutOfSchool.Common/Models/ICurrentUser.cs
@@ -1,13 +1,50 @@
+#nullable enable
+
+using System;
+
 namespace OutOfSchool.Common.Models;
 
 /// <summary>
-/// Defines interface for current user id.
+/// Defines interface for current user.
 /// </summary>
 public interface ICurrentUser
 {
     /// <summary>
     /// Gets current logged in UserId or empty string in other case.
     /// </summary>
-    /// <returns>A <see cref="string"/> id of current logged in user.</returns>
+    /// <returns><see cref="string"/> id of current logged-in user.</returns>
     public string UserId { get; }
+
+    /// <summary>
+    /// Gets current logged in UserRole or empty string in other case.
+    /// </summary>
+    /// <returns>A <see cref="string"/> id of current logged in user.</returns>
+    public string UserRole { get; }
+
+    /// <summary>
+    /// Gets current logged in UserSubRole or empty string in other case.
+    /// </summary>
+    /// <returns>A <see cref="string"/> id of current logged in user.</returns>
+    public string UserSubRole { get; }
+
+    /// <summary>Determines whether the current user belongs to the specified role.</summary>
+    /// <param name="role">The name of the role for which to check membership.</param>
+    /// <returns>
+    /// <see langword="true" /> if the current user is a member of the specified role; otherwise, <see langword="false" />.</returns>
+    bool IsInRole(string role);
+
+    /// <summary>Gets a value indicating whether the user has been authenticated.</summary>
+    /// <returns>
+    /// <see langword="true" /> if the user was authenticated; otherwise, <see langword="false" />.</returns>
+    bool IsAuthenticated { get; }
+
+    /// <summary>
+    /// Determines whether the current user has a claim with the specified type and value.
+    /// </summary>
+    /// <param name="type">The claim type to check for.</param>
+    /// <param name="valueComparer">Function to check the claim value. If empty, it only checks if the claim type is present.</param>
+    /// <returns>
+    /// <see langword="true" /> if the user has the specified claim; otherwise, <see langword="false" />.
+    /// </returns>
+    bool HasClaim(string type, Func<string, bool>? valueComparer = null);
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/AspNetUser.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/AspNetUser.cs
@@ -4,10 +4,8 @@ using OutOfSchool.Services.Models;
 
 namespace OutOfSchool.Services;
 
-public class AspNetUser : BusinessEntity<User>
+public class AspNetUser : BusinessEntity
 {
-    public Guid Id { get; set; }
-
     public bool IsRegistered { get; set; }
 
     [DataType(DataType.DateTime)]

--- a/OutOfSchool/OutOfSchool.DataAccess/BusinessEntityInterceptor.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/BusinessEntityInterceptor.cs
@@ -52,7 +52,7 @@ public class BusinessEntityInterceptor : SaveChangesInterceptor
         var userId = currentUser?.UserId ?? string.Empty;
 
         var businessEntries = context.ChangeTracker.Entries()
-            .Where(entity => entity.GetType().IsSubclassOf(typeof(BusinessEntity)));
+            .Where(entry => entry.Entity is BusinessEntity);
 
         foreach (var entry in businessEntries)
         {

--- a/OutOfSchool/OutOfSchool.DataAccess/BusinessEntityInterceptor.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/BusinessEntityInterceptor.cs
@@ -1,0 +1,91 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using OutOfSchool.Common.Models;
+using OutOfSchool.Services.Models;
+
+namespace OutOfSchool.Services;
+
+public class BusinessEntityInterceptor(in IServiceProvider provider) : SaveChangesInterceptor
+{
+    private readonly IServiceProvider serviceProvider = provider;
+
+
+    public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+    {
+        if (eventData.Context is not null)
+        {
+            UpdateBusinessEntities(eventData.Context, serviceProvider);
+        }
+
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is not null)
+        {
+            UpdateBusinessEntities(eventData.Context, serviceProvider);
+        }
+
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    private static void UpdateBusinessEntities(
+        DbContext context,
+        IServiceProvider provider)
+    {
+        var currentUser = provider.GetRequiredService<ICurrentUser>();
+        var userId = currentUser.UserId;
+
+        var businessEntries = context.ChangeTracker.Entries()
+            .Where(entity => entity.GetType().IsSubclassOf(typeof(BusinessEntity)));
+
+        foreach (var entry in businessEntries)
+        {
+            var now = DateTime.UtcNow;
+
+            if (entry.State == EntityState.Added)
+            {
+                SetCurrentValue(entry, "CreatedAt", now);
+                SetCurrentValue(entry, "CreatedBy", userId);
+            }
+
+            if (entry.State == EntityState.Modified)
+            {
+                SetCurrentValue(entry, "UpdatedAt", now);
+                SetCurrentValue(entry, "ModifiedBy", userId);
+            }
+
+            // TODO: Any business entity currently is ISoftDeleted but not every ISoftDeleted is a business entity
+            // TODO: so having this double check for now. Maybe there is a better solution?
+            if (entry.State == EntityState.Deleted || (entry.CurrentValues["IsDeleted"] is true && entry.State == EntityState.Modified))
+            {
+                // This is a failsafe for cases that were not handled by similar check in repository
+                if (entry.OriginalValues["IsSystemProtected"] is true)
+                {
+                    throw new InvalidOperationException("Cannot delete a protected object");
+                }
+
+                SetCurrentValue(entry, "DeleteDate", now);
+                SetCurrentValue(entry, "DeletedBy", userId);
+            }
+        }
+    }
+
+    private static void SetCurrentValue<T>(
+        EntityEntry entry,
+        string propertyName,
+        T newValue) =>
+        entry.CurrentValues[propertyName] = newValue;
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/BusinessEntity.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/BusinessEntity.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -33,28 +32,56 @@ public abstract class BusinessEntity : IKeyedEntity<Guid>, ISoftDeleted
 
     public bool IsBlocked { get; set; } = false;
 
-    public bool IsSystemProtected => _isSystemProtected;
+    public bool IsSystemProtected
+    {
+        get { return _isSystemProtected; }
+        private set { _isSystemProtected = value; }
+    }
 
     [Column(TypeName = "char")]
     [MaxLength(36)]
-    public string CreatedBy => _createdBy;
+    public string CreatedBy
+    {
+        get { return _createdBy; }
+        private set { _createdBy = value; }
+    }
 
     [Column(TypeName = "char")]
     [MaxLength(36)]
-    public string ModifiedBy => _modifiedBy;
+    public string ModifiedBy
+    {
+        get { return _modifiedBy; }
+        private set { _modifiedBy = value; }
+    }
 
     [Column(TypeName = "char")]
     [MaxLength(36)]
-    public string DeletedBy => _deletedBy;
+    public string DeletedBy
+    {
+        get { return _deletedBy; }
+        private set { _deletedBy = value; }
+    }
 
     [DataType(DataType.DateTime)]
-    public DateTime CreatedAt => _createdAt;
+    public DateTime CreatedAt
+    {
+        get { return _createdAt; }
+        private set { _createdAt = value; }
+    }
 
     [DataType(DataType.DateTime)]
-    public DateTime? UpdatedAt => _updatedAt;
+    public DateTime? UpdatedAt
+    {
+        get { return _updatedAt; }
+        private set { _updatedAt = value; }
+    }
 
     [DataType(DataType.DateTime)]
-    public DateTime? DeleteDate => _deleteDate;
+    public DateTime? DeleteDate
+    {
+        get { return _deleteDate; }
+        private set { _deleteDate = value; }
+    }
 
     public bool IsDeleted { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/BusinessEntity.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/BusinessEntity.cs
@@ -1,9 +1,28 @@
 using System;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace OutOfSchool.Services.Models;
 
-public abstract class BusinessEntity<TKey> : IKeyedEntity<TKey>
+public abstract class BusinessEntity : IKeyedEntity<Guid>, ISoftDeleted
 {
+    protected string _createdBy;
+
+    protected string _modifiedBy;
+
+    protected string _deletedBy;
+
+    protected DateTime _createdAt;
+
+    protected DateTime? _updatedAt;
+
+    protected DateTime? _deleteDate;
+
+    protected bool _isSystemProtected = false;
+
+    public Guid Id { get; set; }
+
     public string Document { get; set; }
 
     public string File { get; set; }
@@ -12,19 +31,30 @@ public abstract class BusinessEntity<TKey> : IKeyedEntity<TKey>
 
     public DateOnly ActiveTo { get; set; }
 
-    public User DeletedBy { get; set; }
+    public bool IsBlocked { get; set; } = false;
 
-    public DateTime DeleteDate { get; set; }
+    public bool IsSystemProtected => _isSystemProtected;
 
-    public DateTime DateOfCreationInTheSystem { get; set; }
+    [Column(TypeName = "char")]
+    [MaxLength(36)]
+    public string CreatedBy => _createdBy;
 
-    public bool IsBlocked { get; set; }
+    [Column(TypeName = "char")]
+    [MaxLength(36)]
+    public string ModifiedBy => _modifiedBy;
 
-    public User ModifiedBy { get; set; }
+    [Column(TypeName = "char")]
+    [MaxLength(36)]
+    public string DeletedBy => _deletedBy;
 
-    public User CreatedBy { get; set; }
+    [DataType(DataType.DateTime)]
+    public DateTime CreatedAt => _createdAt;
 
-    public bool IsSystemProtected { get; set; }
+    [DataType(DataType.DateTime)]
+    public DateTime? UpdatedAt => _updatedAt;
 
-    public TKey Id { get; set; }
+    [DataType(DataType.DateTime)]
+    public DateTime? DeleteDate => _deleteDate;
+
+    public bool IsDeleted { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/Base/BusinessEntityConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/Base/BusinessEntityConfiguration.cs
@@ -1,0 +1,42 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace OutOfSchool.Services.Models.Configurations.Base;
+
+public abstract class BusinessEntityConfiguration<TBase> : IEntityTypeConfiguration<TBase>
+    where TBase : BusinessEntity
+{
+    public virtual void Configure(EntityTypeBuilder<TBase> entityTypeBuilder)
+    {
+        entityTypeBuilder.HasKey(x => x.Id);
+
+        entityTypeBuilder.HasIndex(x => x.IsDeleted);
+
+        entityTypeBuilder.Property(x => x.IsDeleted).HasDefaultValue(false);
+
+        entityTypeBuilder.Property(e => e.CreatedBy)
+            .HasField("_createdBy");
+
+        entityTypeBuilder.Property(e => e.ModifiedBy)
+            .HasField("_modifiedBy");
+
+        entityTypeBuilder.Property(e => e.DeletedBy)
+            .HasField("_deletedBy");
+
+        entityTypeBuilder.Property(e => e.CreatedAt)
+            .HasField("_createdAt");
+
+        entityTypeBuilder.Property(e => e.UpdatedAt)
+            .HasField("_updatedAt");
+
+        entityTypeBuilder.Property(e => e.DeleteDate)
+            .HasField("_deleteDate");
+
+        entityTypeBuilder.Property(e => e.IsSystemProtected)
+            .HasField("_isSystemProtected");
+
+        entityTypeBuilder.Property(e => e.ActiveTo)
+            .HasDefaultValue(DateOnly.MaxValue);
+    }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/WorkshopConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/WorkshopConfiguration.cs
@@ -1,19 +1,15 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using OutOfSchool.Common;
+using OutOfSchool.Services.Models.Configurations.Base;
 
 namespace OutOfSchool.Services.Models.Configurations;
 
-internal class WorkshopConfiguration : IEntityTypeConfiguration<Workshop>
+internal class WorkshopConfiguration : BusinessEntityConfiguration<Workshop>
 {
-    public void Configure(EntityTypeBuilder<Workshop> builder)
+    public override void Configure(EntityTypeBuilder<Workshop> builder)
     {
-        builder.HasKey(x => x.Id);
-
-        builder.HasIndex(x => x.IsDeleted);
-
-        builder.Property(x => x.IsDeleted).HasDefaultValue(false);
-
         builder.HasMany(x => x.ProviderAdmins)
             .WithMany(x => x.ManagedWorkshops);
 
@@ -25,9 +21,6 @@ internal class WorkshopConfiguration : IEntityTypeConfiguration<Workshop>
             .WithOne(x => x.Workshop)
             .HasForeignKey(x => x.WorkshopId);
 
-        builder.Property(x => x.UpdatedAt)
-            .ValueGeneratedOnAddOrUpdate();
-
         builder.Property(x => x.Title)
             .IsRequired()
             .HasMaxLength(Constants.MaxWorkshopTitleLength);
@@ -35,5 +28,7 @@ internal class WorkshopConfiguration : IEntityTypeConfiguration<Workshop>
         builder.Property(x => x.ShortTitle)
             .IsRequired()
             .HasMaxLength(Constants.MaxWorkshopShortTitleLength);
+
+        base.Configure(builder);
     }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Newtonsoft.Json;
 using OutOfSchool.Common;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Validators;
@@ -13,12 +11,8 @@ using OutOfSchool.Services.Models.SubordinationStructure;
 
 namespace OutOfSchool.Services.Models;
 
-public class Workshop : IKeyedEntity<Guid>, IImageDependentEntity<Workshop>, ISoftDeleted, IHasEntityImages<Workshop>
+public class Workshop : BusinessEntity, IImageDependentEntity<Workshop>, IHasEntityImages<Workshop>
 {
-    public Guid Id { get; set; }
-
-    public bool IsDeleted { get; set; }
-
     [Required(ErrorMessage = "Workshop title is required")]
     [MinLength(Constants.MinWorkshopTitleLength)]
     [MaxLength(Constants.MaxWorkshopTitleLength)]
@@ -130,7 +124,4 @@ public class Workshop : IKeyedEntity<Guid>, IImageDependentEntity<Workshop>, ISo
     public virtual List<Image<Workshop>> Images { get; set; }
 
     public bool IsBlocked { get; set; } = false;
-
-    [DataType(DataType.DateTime)]
-    public DateTime UpdatedAt { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/OutOfSchoolDbContext.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/OutOfSchoolDbContext.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;

--- a/OutOfSchool/OutOfSchool.DataAccess/OutOfSchoolDbContext.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/OutOfSchoolDbContext.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240818201538_AddModeratorRole.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240818201538_AddModeratorRole.cs
@@ -2,83 +2,82 @@
 
 #nullable disable
 
-namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations;
+
+/// <inheritdoc />
+public partial class AddModeratorRole : Migration
 {
     /// <inheritdoc />
-    public partial class AddModeratorRole : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 1L,
-                column: "PackedPermissions",
-                value: "ZGVmAwIBBAoLDQweIB8hKCkrLBc0MzI1Nzg+PTw/SEdJRlBRW11cXnJwcW9ufHp7eXh9kI6PjYyRVGc=");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 1L,
+            column: "PackedPermissions",
+            value: "ZGVmAwIBBAoLDQweIB8hKCkrLBc0MzI1Nzg+PTw/SEdJRlBRW11cXnJwcW9ufHp7eXh9kI6PjYyRVGc=");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 5L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoLBRQUUZUblteenh5e32OjI2PkWc=");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 5L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoLBRQUUZUblteenh5e32OjI2PkWc=");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 6L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoFFBRRlR4eY6MjY+RW15n");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 6L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoFFBRRlR4eY6MjY+RW15n");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 7L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoFFBRRlSMjVteZw==");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 7L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoFFBRRlSMjVteZw==");
 
-            migrationBuilder.InsertData(
-                table: "PermissionsForRoles",
-                columns: new[] { "Id", "Description", "PackedPermissions", "RoleName" },
-                values: new object[] { 8L, "moderator permissions", "MjdaXlQ=", "Moderator" });
-        }
+        migrationBuilder.InsertData(
+            table: "PermissionsForRoles",
+            columns: new[] { "Id", "Description", "PackedPermissions", "RoleName" },
+            values: new object[] { 8L, "moderator permissions", "MjdaXlQ=", "Moderator" });
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DeleteData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 8L);
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DeleteData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 8L);
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 1L,
-                column: "PackedPermissions",
-                value: "ZGVmAwIBBAoLDQweIB8hKCkrLBc0MzI1Nzg+PTw/SEdJRlBRW11ccnBxb258ent5eH2Qjo+NjJFUZw==");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 1L,
+            column: "PackedPermissions",
+            value: "ZGVmAwIBBAoLDQweIB8hKCkrLBc0MzI1Nzg+PTw/SEdJRlBRW11ccnBxb258ent5eH2Qjo+NjJFUZw==");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 5L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoLBRQUUZUblt6eHl7fY6MjY+RZw==");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 5L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoLBRQUUZUblt6eHl7fY6MjY+RZw==");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 6L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoFFBRRlR4eY6MjY+RW2c=");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 6L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoFFBRRlR4eY6MjY+RW2c=");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 7L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoFFBRRlSMjVtn");
-        }
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 7L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoFFBRRlSMjVtn");
     }
 }

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240923114851_CompetitiveEvents.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240923114851_CompetitiveEvents.cs
@@ -6,21 +6,21 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
 
-namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations;
+
+/// <inheritdoc />
+public partial class CompetitiveEvents : Migration
 {
     /// <inheritdoc />
-    public partial class CompetitiveEvents : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AddColumn<Guid>(
-                name: "CompetitiveEventId",
-                table: "Providers",
-                type: "binary(16)",
-                nullable: true);
+        migrationBuilder.AddColumn<Guid>(
+            name: "CompetitiveEventId",
+            table: "Providers",
+            type: "binary(16)",
+            nullable: true);
 
-            migrationBuilder.CreateTable(
+        migrationBuilder.CreateTable(
                 name: "CompetitiveEventRegistrationDeadlines",
                 columns: table => new
                 {
@@ -36,9 +36,9 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                 {
                     table.PrimaryKey("PK_CompetitiveEventRegistrationDeadlines", x => x.Id);
                 })
-                .Annotation("MySql:CharSet", "utf8mb4");
+            .Annotation("MySql:CharSet", "utf8mb4");
 
-            migrationBuilder.CreateTable(
+        migrationBuilder.CreateTable(
                 name: "CompetitiveEvents",
                 columns: table => new
                 {
@@ -106,9 +106,9 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySql:CharSet", "utf8mb4");
+            .Annotation("MySql:CharSet", "utf8mb4");
 
-            migrationBuilder.CreateTable(
+        migrationBuilder.CreateTable(
                 name: "CompetitiveEventAccountingTypes",
                 columns: table => new
                 {
@@ -130,9 +130,9 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         principalTable: "CompetitiveEvents",
                         principalColumn: "Id");
                 })
-                .Annotation("MySql:CharSet", "utf8mb4");
+            .Annotation("MySql:CharSet", "utf8mb4");
 
-            migrationBuilder.CreateTable(
+        migrationBuilder.CreateTable(
                 name: "CompetitiveEventCoverages",
                 columns: table => new
                 {
@@ -154,9 +154,9 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         principalTable: "CompetitiveEvents",
                         principalColumn: "Id");
                 })
-                .Annotation("MySql:CharSet", "utf8mb4");
+            .Annotation("MySql:CharSet", "utf8mb4");
 
-            migrationBuilder.CreateTable(
+        migrationBuilder.CreateTable(
                 name: "CompetitiveEventDescriptionItems",
                 columns: table => new
                 {
@@ -178,236 +178,235 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySql:CharSet", "utf8mb4");
+            .Annotation("MySql:CharSet", "utf8mb4");
 
-            migrationBuilder.InsertData(
-                table: "CompetitiveEventAccountingTypes",
-                columns: new[] { "Id", "CompetitiveEventId", "Title", "TitleEn" },
-                values: new object[,]
-                {
-                    { 1, null, "Освітній проєкт", "Educational project" },
-                    { 2, null, "Конкурс (не має етапів)", "Competition" },
-                    { 3, null, "Основний конкурс (має мати підпорядковані конкурси-етапи)", "Main competition" },
-                    { 4, null, "Етап конкурсу (має мати батьківський основний конкурс)", "Contest stage" }
-                });
+        migrationBuilder.InsertData(
+            table: "CompetitiveEventAccountingTypes",
+            columns: new[] { "Id", "CompetitiveEventId", "Title", "TitleEn" },
+            values: new object[,]
+            {
+                { 1, null, "Освітній проєкт", "Educational project" },
+                { 2, null, "Конкурс (не має етапів)", "Competition" },
+                { 3, null, "Основний конкурс (має мати підпорядковані конкурси-етапи)", "Main competition" },
+                { 4, null, "Етап конкурсу (має мати батьківський основний конкурс)", "Contest stage" }
+            });
 
-            migrationBuilder.InsertData(
-                table: "CompetitiveEventCoverages",
-                columns: new[] { "Id", "CompetitiveEventId", "Title", "TitleEn" },
-                values: new object[,]
-                {
-                    { 1, null, "Локальний (Шкільний)", "Local (School)" },
-                    { 2, null, "Міський", "City" },
-                    { 3, null, "Районний", "Raional" },
-                    { 4, null, "Обласний", "Regional" },
-                    { 5, null, "Всеукраїнський", "All-Ukrainian" },
-                    { 6, null, "Міжнародний", "International" }
-                });
+        migrationBuilder.InsertData(
+            table: "CompetitiveEventCoverages",
+            columns: new[] { "Id", "CompetitiveEventId", "Title", "TitleEn" },
+            values: new object[,]
+            {
+                { 1, null, "Локальний (Шкільний)", "Local (School)" },
+                { 2, null, "Міський", "City" },
+                { 3, null, "Районний", "Raional" },
+                { 4, null, "Обласний", "Regional" },
+                { 5, null, "Всеукраїнський", "All-Ukrainian" },
+                { 6, null, "Міжнародний", "International" }
+            });
 
-            migrationBuilder.InsertData(
-                table: "CompetitiveEventRegistrationDeadlines",
-                columns: new[] { "Id", "Title", "TitleEn" },
-                values: new object[,]
-                {
-                    { 1, "Постійно (протягом року)", "Constantly (during the year)" },
-                    { 2, "Певний місяць або місяці року", "A certain month or months of the year" }
-                });
+        migrationBuilder.InsertData(
+            table: "CompetitiveEventRegistrationDeadlines",
+            columns: new[] { "Id", "Title", "TitleEn" },
+            values: new object[,]
+            {
+                { 1, "Постійно (протягом року)", "Constantly (during the year)" },
+                { 2, "Певний місяць або місяці року", "A certain month or months of the year" }
+            });
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 1L,
-                column: "PackedPermissions",
-                value: "ZGVmAwIBBAoLDQweIB8hKCkrLBc0MzI1Nzg+PTw/SEdJRlBRW11cXnJwcW9ufHp7eXh9kI6PjYyRVGeW");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 1L,
+            column: "PackedPermissions",
+            value: "ZGVmAwIBBAoLDQweIB8hKCkrLBc0MzI1Nzg+PTw/SEdJRlBRW11cXnJwcW9ufHp7eXh9kI6PjYyRVGeW");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 2L,
-                column: "PackedPermissions",
-                value: "ZQMCAQQKCzQzMjU2SEdJRlBRW11cVJaYl5k=");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 2L,
+            column: "PackedPermissions",
+            value: "ZQMCAQQKCzQzMjU2SEdJRlBRW11cVJaYl5k=");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 3L,
-                column: "PackedPermissions",
-                value: "ZQMKCwwUFhUXHiAfISgpKz49PFBRVJY=");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 3L,
+            column: "PackedPermissions",
+            value: "ZQMKCwwUFhUXHiAfISgpKz49PFBRVJY=");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 4L,
-                column: "PackedPermissions",
-                value: "ZQMCAQQKCzI2SEdJRlBRW1xUlg==");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 4L,
+            column: "PackedPermissions",
+            value: "ZQMCAQQKCzI2SEdJRlBRW1xUlg==");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 5L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoLBRQUUZUblteenh5e32OjI2PkWeW");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 5L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoLBRQUUZUblteenh5e32OjI2PkWeW");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 6L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoFFBRRlR4eY6MjY+RW15nlg==");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 6L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoFFBRRlR4eY6MjY+RW15nlg==");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 7L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoFFBRRlSMjVteZ5Y=");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 7L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoFFBRRlSMjVteZ5Y=");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_Providers_CompetitiveEventId",
-                table: "Providers",
-                column: "CompetitiveEventId");
+        migrationBuilder.CreateIndex(
+            name: "IX_Providers_CompetitiveEventId",
+            table: "Providers",
+            column: "CompetitiveEventId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEventAccountingTypes_CompetitiveEventId",
-                table: "CompetitiveEventAccountingTypes",
-                column: "CompetitiveEventId");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEventAccountingTypes_CompetitiveEventId",
+            table: "CompetitiveEventAccountingTypes",
+            column: "CompetitiveEventId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEventAccountingTypes_IsDeleted",
-                table: "CompetitiveEventAccountingTypes",
-                column: "IsDeleted");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEventAccountingTypes_IsDeleted",
+            table: "CompetitiveEventAccountingTypes",
+            column: "IsDeleted");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEventCoverages_CompetitiveEventId",
-                table: "CompetitiveEventCoverages",
-                column: "CompetitiveEventId");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEventCoverages_CompetitiveEventId",
+            table: "CompetitiveEventCoverages",
+            column: "CompetitiveEventId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEventCoverages_IsDeleted",
-                table: "CompetitiveEventCoverages",
-                column: "IsDeleted");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEventCoverages_IsDeleted",
+            table: "CompetitiveEventCoverages",
+            column: "IsDeleted");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEventDescriptionItems_CompetitiveEventId",
-                table: "CompetitiveEventDescriptionItems",
-                column: "CompetitiveEventId");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEventDescriptionItems_CompetitiveEventId",
+            table: "CompetitiveEventDescriptionItems",
+            column: "CompetitiveEventId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEventDescriptionItems_IsDeleted",
-                table: "CompetitiveEventDescriptionItems",
-                column: "IsDeleted");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEventDescriptionItems_IsDeleted",
+            table: "CompetitiveEventDescriptionItems",
+            column: "IsDeleted");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEventRegistrationDeadlines_IsDeleted",
-                table: "CompetitiveEventRegistrationDeadlines",
-                column: "IsDeleted");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEventRegistrationDeadlines_IsDeleted",
+            table: "CompetitiveEventRegistrationDeadlines",
+            column: "IsDeleted");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEvents_CategoryId",
-                table: "CompetitiveEvents",
-                column: "CategoryId");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEvents_CategoryId",
+            table: "CompetitiveEvents",
+            column: "CategoryId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEvents_IsDeleted",
-                table: "CompetitiveEvents",
-                column: "IsDeleted");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEvents_IsDeleted",
+            table: "CompetitiveEvents",
+            column: "IsDeleted");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEvents_OrganizerOfTheEventId",
-                table: "CompetitiveEvents",
-                column: "OrganizerOfTheEventId");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEvents_OrganizerOfTheEventId",
+            table: "CompetitiveEvents",
+            column: "OrganizerOfTheEventId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitiveEvents_ParentId",
-                table: "CompetitiveEvents",
-                column: "ParentId");
+        migrationBuilder.CreateIndex(
+            name: "IX_CompetitiveEvents_ParentId",
+            table: "CompetitiveEvents",
+            column: "ParentId");
 
-            migrationBuilder.AddForeignKey(
-                name: "FK_Providers_CompetitiveEvents_CompetitiveEventId",
-                table: "Providers",
-                column: "CompetitiveEventId",
-                principalTable: "CompetitiveEvents",
-                principalColumn: "Id");
-        }
+        migrationBuilder.AddForeignKey(
+            name: "FK_Providers_CompetitiveEvents_CompetitiveEventId",
+            table: "Providers",
+            column: "CompetitiveEventId",
+            principalTable: "CompetitiveEvents",
+            principalColumn: "Id");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropForeignKey(
-                name: "FK_Providers_CompetitiveEvents_CompetitiveEventId",
-                table: "Providers");
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropForeignKey(
+            name: "FK_Providers_CompetitiveEvents_CompetitiveEventId",
+            table: "Providers");
 
-            migrationBuilder.DropTable(
-                name: "CompetitiveEventAccountingTypes");
+        migrationBuilder.DropTable(
+            name: "CompetitiveEventAccountingTypes");
 
-            migrationBuilder.DropTable(
-                name: "CompetitiveEventCoverages");
+        migrationBuilder.DropTable(
+            name: "CompetitiveEventCoverages");
 
-            migrationBuilder.DropTable(
-                name: "CompetitiveEventDescriptionItems");
+        migrationBuilder.DropTable(
+            name: "CompetitiveEventDescriptionItems");
 
-            migrationBuilder.DropTable(
-                name: "CompetitiveEventRegistrationDeadlines");
+        migrationBuilder.DropTable(
+            name: "CompetitiveEventRegistrationDeadlines");
 
-            migrationBuilder.DropTable(
-                name: "CompetitiveEvents");
+        migrationBuilder.DropTable(
+            name: "CompetitiveEvents");
 
-            migrationBuilder.DropIndex(
-                name: "IX_Providers_CompetitiveEventId",
-                table: "Providers");
+        migrationBuilder.DropIndex(
+            name: "IX_Providers_CompetitiveEventId",
+            table: "Providers");
 
-            migrationBuilder.DropColumn(
-                name: "CompetitiveEventId",
-                table: "Providers");
+        migrationBuilder.DropColumn(
+            name: "CompetitiveEventId",
+            table: "Providers");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 1L,
-                column: "PackedPermissions",
-                value: "ZGVmAwIBBAoLDQweIB8hKCkrLBc0MzI1Nzg+PTw/SEdJRlBRW11cXnJwcW9ufHp7eXh9kI6PjYyRVGc=");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 1L,
+            column: "PackedPermissions",
+            value: "ZGVmAwIBBAoLDQweIB8hKCkrLBc0MzI1Nzg+PTw/SEdJRlBRW11cXnJwcW9ufHp7eXh9kI6PjYyRVGc=");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 2L,
-                column: "PackedPermissions",
-                value: "ZQMCAQQKCzQzMjU2SEdJRlBRW11cVA==");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 2L,
+            column: "PackedPermissions",
+            value: "ZQMCAQQKCzQzMjU2SEdJRlBRW11cVA==");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 3L,
-                column: "PackedPermissions",
-                value: "ZQMKCwwUFhUXHiAfISgpKz49PFBRVA==");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 3L,
+            column: "PackedPermissions",
+            value: "ZQMKCwwUFhUXHiAfISgpKz49PFBRVA==");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 4L,
-                column: "PackedPermissions",
-                value: "ZQMCAQQKCzI2SEdJRlBRW1xU");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 4L,
+            column: "PackedPermissions",
+            value: "ZQMCAQQKCzI2SEdJRlBRW1xU");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 5L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoLBRQUUZUblteenh5e32OjI2PkWc=");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 5L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoLBRQUUZUblteenh5e32OjI2PkWc=");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 6L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoFFBRRlR4eY6MjY+RW15n");
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 6L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoFFBRRlR4eY6MjY+RW15n");
 
-            migrationBuilder.UpdateData(
-                table: "PermissionsForRoles",
-                keyColumn: "Id",
-                keyValue: 7L,
-                column: "PackedPermissions",
-                value: "ZWYDAgEECjI1NzgoFFBRRlSMjVteZw==");
-        }
+        migrationBuilder.UpdateData(
+            table: "PermissionsForRoles",
+            keyColumn: "Id",
+            keyValue: 7L,
+            column: "PackedPermissions",
+            value: "ZWYDAgEECjI1NzgoFFBRRlSMjVteZw==");
     }
 }

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240925152617_AddWorkshopBusinessEntity.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240925152617_AddWorkshopBusinessEntity.Designer.cs
@@ -2,17 +2,20 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
 #nullable disable
 
-namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240925152617_AddWorkshopBusinessEntity")]
+    partial class AddWorkshopBusinessEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240925152617_AddWorkshopBusinessEntity.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20240925152617_AddWorkshopBusinessEntity.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations;
+
+/// <inheritdoc />
+public partial class AddWorkshopBusinessEntity : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Workshops",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)")
+            .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
+
+        migrationBuilder.AddColumn<DateOnly>(
+            name: "ActiveFrom",
+            table: "Workshops",
+            type: "date",
+            nullable: false,
+            defaultValue: new DateOnly(1, 1, 1));
+
+        migrationBuilder.AddColumn<DateOnly>(
+            name: "ActiveTo",
+            table: "Workshops",
+            type: "date",
+            nullable: false,
+            defaultValue: new DateOnly(9999, 12, 31));
+
+        migrationBuilder.AddColumn<DateTime>(
+            name: "CreatedAt",
+            table: "Workshops",
+            type: "datetime(6)",
+            nullable: false,
+            defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+        migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Workshops",
+                type: "char(36)",
+                maxLength: 36,
+                nullable: true)
+            .Annotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.AddColumn<DateTime>(
+            name: "DeleteDate",
+            table: "Workshops",
+            type: "datetime(6)",
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+                name: "DeletedBy",
+                table: "Workshops",
+                type: "char(36)",
+                maxLength: 36,
+                nullable: true)
+            .Annotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.AddColumn<string>(
+                name: "Document",
+                table: "Workshops",
+                type: "longtext",
+                nullable: true)
+            .Annotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.AddColumn<string>(
+                name: "File",
+                table: "Workshops",
+                type: "longtext",
+                nullable: true)
+            .Annotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.AddColumn<bool>(
+            name: "IsSystemProtected",
+            table: "Workshops",
+            type: "tinyint(1)",
+            nullable: false,
+            defaultValue: false);
+
+        migrationBuilder.AddColumn<string>(
+                name: "ModifiedBy",
+                table: "Workshops",
+                type: "char(36)",
+                maxLength: 36,
+                nullable: true)
+            .Annotation("MySql:CharSet", "utf8mb4");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "ActiveFrom",
+            table: "Workshops");
+
+        migrationBuilder.DropColumn(
+            name: "ActiveTo",
+            table: "Workshops");
+
+        migrationBuilder.DropColumn(
+            name: "CreatedAt",
+            table: "Workshops");
+
+        migrationBuilder.DropColumn(
+            name: "CreatedBy",
+            table: "Workshops");
+
+        migrationBuilder.DropColumn(
+            name: "DeleteDate",
+            table: "Workshops");
+
+        migrationBuilder.DropColumn(
+            name: "DeletedBy",
+            table: "Workshops");
+
+        migrationBuilder.DropColumn(
+            name: "Document",
+            table: "Workshops");
+
+        migrationBuilder.DropColumn(
+            name: "File",
+            table: "Workshops");
+
+        migrationBuilder.DropColumn(
+            name: "IsSystemProtected",
+            table: "Workshops");
+
+        migrationBuilder.DropColumn(
+            name: "ModifiedBy",
+            table: "Workshops");
+
+        migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Workshops",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true)
+            .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CurrentUserAccessorTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CurrentUserAccessorTests.cs
@@ -1,0 +1,240 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Security.Claims;
+using NUnit.Framework;
+using OutOfSchool.BusinessLogic.Services;
+using OutOfSchool.Common;
+
+namespace OutOfSchool.WebApi.Tests.Services;
+
+[TestFixture]
+public class CurrentUserAccessorTests
+{
+    [Test]
+    public void UserId_WhenUserIsNull_ReturnsEmptyString()
+    {
+        // Arrange
+        ClaimsPrincipal? user = null;
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var userId = currentUser.UserId;
+
+        // Assert
+        Assert.AreEqual(string.Empty, userId);
+    }
+
+    [Test]
+    public void UserId_WhenUserHasSubClaim_ReturnsSubClaimValue()
+    {
+        // Arrange
+        var expected = "patron";
+        var user = SetupClaimsPrincipal(IdentityResourceClaimsTypes.Sub, expected);
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var userId = currentUser.UserId;
+
+        // Assert
+        Assert.AreEqual(expected, userId);
+    }
+
+    [Test]
+    public void UserRole_WhenUserIsNull_ReturnsEmptyString()
+    {
+        // Arrange
+        ClaimsPrincipal? user = null;
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var userRole = currentUser.UserRole;
+
+        // Assert
+        Assert.AreEqual(string.Empty, userRole);
+    }
+
+    [Test]
+    public void UserRole_WhenUserHasRoleClaim_ReturnsUserRole()
+    {
+        // Arrange
+        var expected = "provider";
+        var user = SetupClaimsPrincipal(IdentityResourceClaimsTypes.Role, expected);
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var userRole = currentUser.UserRole;
+
+        // Assert
+        Assert.AreEqual(expected, userRole);
+    }
+
+    [Test]
+    public void IsInRole_WhenUserIsNull_ReturnsFalse()
+    {
+        // Arrange
+        ClaimsPrincipal? user = null;
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var isInRole = currentUser.IsInRole("provider");
+
+        // Assert
+        Assert.IsFalse(isInRole);
+    }
+
+    [Test]
+    public void IsInRole_WhenUserIsInRole_ReturnsTrue()
+    {
+        // Arrange
+        var expected = "provider";
+        var user = SetupClaimsPrincipal(ClaimTypes.Role, expected);
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var isInRole = currentUser.IsInRole(expected);
+
+        // Assert
+        Assert.IsTrue(isInRole);
+    }
+
+    [Test]
+    public void IsInRole_WhenUserIsNotInRole_ReturnsFalse()
+    {
+        // Arrange
+        var user = SetupClaimsPrincipal(ClaimTypes.Role, "parent");
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var isInRole = currentUser.IsInRole("provider");
+
+        // Assert
+        Assert.IsFalse(isInRole);
+    }
+
+    [Test]
+    public void IsAuthenticated_WhenUserIsNull_ReturnsFalse()
+    {
+        // Arrange
+        ClaimsPrincipal? user = null;
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var isAuthenticated = currentUser.IsAuthenticated;
+
+        // Assert
+        Assert.IsFalse(isAuthenticated);
+    }
+
+    [Test]
+    public void IsAuthenticated_WhenUserIsAuthenticated_ReturnsTrue()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity(authenticationType: "test");
+        var user = new ClaimsPrincipal(identity);
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var isAuthenticated = currentUser.IsAuthenticated;
+
+        // Assert
+        Assert.IsTrue(isAuthenticated);
+    }
+
+    [Test]
+    public void IsAuthenticated_WhenUserIsNotAuthenticated_ReturnsFalse()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+        var user = new ClaimsPrincipal(identity);
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var isAuthenticated = currentUser.IsAuthenticated;
+
+        // Assert
+        Assert.IsFalse(isAuthenticated);
+    }
+
+    [Test]
+    public void HasClaim_WhenUserIsNull_ReturnsFalse()
+    {
+        // Arrange
+        ClaimsPrincipal? user = null;
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var hasClaim = currentUser.HasClaim(ClaimTypes.Email);
+
+        // Assert
+        Assert.IsFalse(hasClaim);
+    }
+
+    [Test]
+    public void HasClaim_WhenUserHasClaimType_ReturnsTrue()
+    {
+        // Arrange
+        var user = SetupClaimsPrincipal(ClaimTypes.Email, "patron@gmail.com");
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var hasClaim = currentUser.HasClaim(ClaimTypes.Email);
+
+        // Assert
+        Assert.IsTrue(hasClaim);
+    }
+
+    [Test]
+    public void HasClaim_WhenUserDoesNotHaveClaimType_ReturnsFalse()
+    {
+        // Arrange
+        var user = SetupClaimsPrincipal(ClaimTypes.Name, "patron");
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var hasClaim = currentUser.HasClaim(ClaimTypes.Email);
+
+        // Assert
+        Assert.IsFalse(hasClaim);
+    }
+
+    [Test]
+    public void HasClaim_WhenValueComparerMatches_ReturnsTrue()
+    {
+        // Arrange
+        var expected = "patron@gmail.com";
+        var user = SetupClaimsPrincipal(ClaimTypes.Email, "patron@gmail.com");
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var hasClaim = currentUser.HasClaim(ClaimTypes.Email, value => value == expected);
+
+        // Assert
+        Assert.IsTrue(hasClaim);
+    }
+
+    [Test]
+    public void HasClaim_WhenValueComparerDoesNotMatch_ReturnsFalse()
+    {
+        // Arrange
+        var user = SetupClaimsPrincipal(ClaimTypes.Email, "patron@gmail.com");
+        var currentUser = new CurrentUserAccessor(user);
+
+        // Act
+        var hasClaim = currentUser.HasClaim(ClaimTypes.Email, value => value == "mykola@gmail.com");
+
+        // Assert
+        Assert.IsFalse(hasClaim);
+    }
+
+    private static ClaimsPrincipal SetupClaimsPrincipal(string claimType, string expectedValue)
+    {
+        var claims = new List<Claim>
+        {
+            new(claimType, expectedValue),
+        };
+        var identity = new ClaimsIdentity(claims, "test");
+        var user = new ClaimsPrincipal(identity);
+        return user;
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -243,6 +243,7 @@ public static class Startup
                 GuidFormat = options.GuidFormat.ToEnum(MySqlGuidFormat.Default),
             });
 
+        services.AddTransient<BusinessEntityInterceptor>();
         services
             .AddDbContext<OutOfSchoolDbContext>((sp, options) => options
                 .UseLazyLoadingProxies()
@@ -254,7 +255,7 @@ public static class Startup
                             .EnableRetryOnFailure(3, TimeSpan.FromSeconds(5), null)
                             .EnableStringComparisonTranslations())
                 .AddInterceptors(
-                    new BusinessEntityInterceptor(sp)))
+                    sp.GetRequiredService<BusinessEntityInterceptor>()))
                 .AddCustomDataProtection("WebApi");
 
         services.AddAutoMapper(typeof(CommonProfile), typeof(MappingProfile), typeof(ElasticProfile));
@@ -383,9 +384,8 @@ public static class Startup
         services.AddTransient<IAchievementRepository, AchievementRepository>();
         services.AddTransient<IAchievementService, AchievementService>();
         services.AddTransient(s => s.GetService<IHttpContextAccessor>()?.HttpContext?.User);
-        services.AddTransient<CurrentUserService>();
-        services.AddTransient<ICurrentUserService>(provider => provider.GetRequiredService<CurrentUserService>());
-        services.AddTransient<ICurrentUser>(provider => provider.GetRequiredService<CurrentUserService>());
+        services.AddTransient<ICurrentUser, CurrentUserAccessor>();
+        services.AddTransient<ICurrentUserService, CurrentUserService>();
 
         services.AddTransient<ICodeficatorRepository, CodeficatorRepository>();
 

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -244,7 +244,7 @@ public static class Startup
             });
 
         services
-            .AddDbContext<OutOfSchoolDbContext>(options => options
+            .AddDbContext<OutOfSchoolDbContext>((sp, options) => options
                 .UseLazyLoadingProxies()
                 .UseMySql(
                     connectionString,
@@ -252,7 +252,9 @@ public static class Startup
                     mySqlOptions =>
                         mySqlOptions
                             .EnableRetryOnFailure(3, TimeSpan.FromSeconds(5), null)
-                            .EnableStringComparisonTranslations()))
+                            .EnableStringComparisonTranslations())
+                .AddInterceptors(
+                    new BusinessEntityInterceptor(sp)))
                 .AddCustomDataProtection("WebApi");
 
         services.AddAutoMapper(typeof(CommonProfile), typeof(MappingProfile), typeof(ElasticProfile));
@@ -381,7 +383,9 @@ public static class Startup
         services.AddTransient<IAchievementRepository, AchievementRepository>();
         services.AddTransient<IAchievementService, AchievementService>();
         services.AddTransient(s => s.GetService<IHttpContextAccessor>()?.HttpContext?.User);
-        services.AddTransient<ICurrentUserService, CurrentUserService>();
+        services.AddTransient<CurrentUserService>();
+        services.AddTransient<ICurrentUserService>(provider => provider.GetRequiredService<CurrentUserService>());
+        services.AddTransient<ICurrentUser>(provider => provider.GetRequiredService<CurrentUserService>());
 
         services.AddTransient<ICodeficatorRepository, CodeficatorRepository>();
 

--- a/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/BusinessEntityInterceptorTests.cs
+++ b/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/BusinessEntityInterceptorTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NUnit.Framework;
+using OutOfSchool.Common.Models;
+using OutOfSchool.Services;
+using OutOfSchool.Services.Models;
+
+namespace OutOfSchool.WebApi.IntegrationTests;
+
+[TestFixture]
+public class BusinessEntityInterceptorTests
+{
+    [Test]
+    public void SavingChanges_AddEntity_SetsCreatedAtAndCreatedBy()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var options = GetDbContextOptions(userId);
+
+        using var context = new TestDbContext(options);
+        var entity = new TestEntity
+        {
+            Name = "Test Entity",
+        };
+        context.TestEntities.Add(entity);
+
+        // Act
+        context.SaveChanges();
+
+        // Assert
+        Assert.IsNotNull(entity.CreatedAt);
+        Assert.AreEqual(userId, entity.CreatedBy);
+    }
+
+    [Test]
+    public void SavingChanges_ModifyEntity_SetsUpdatedAtAndModifiedBy()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var options = GetDbContextOptions(userId);
+
+        using var context = new TestDbContext(options);
+
+        var entity = new TestEntity
+        {
+            Name = "Original",
+        };
+        context.TestEntities.Add(entity);
+        context.SaveChanges();
+
+        // Act
+        entity.Name = "Modified";
+        context.SaveChanges();
+
+        // Assert
+        Assert.IsNotNull(entity.UpdatedAt);
+        Assert.AreEqual(userId, entity.ModifiedBy);
+    }
+
+    [Test]
+    public void SavingChanges_DeleteEntity_WhenNotSystemProtected_SetsDeleteDateAndDeletedBy()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var options = GetDbContextOptions(userId);
+
+        using var context = new TestDbContext(options);
+
+        var entity = new TestEntity
+        {
+            Name = "Test Entity",
+        };
+        context.TestEntities.Add(entity);
+        context.SaveChanges();
+
+        // Act
+        context.TestEntities.Remove(entity);
+        context.SaveChanges();
+
+        // Assert
+        Assert.IsNotNull(entity.DeleteDate);
+        Assert.AreEqual(userId, entity.DeletedBy);
+    }
+
+    [Test]
+    public void SavingChanges_DeleteEntity_WhenSystemProtected_ThrowsException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var options = GetDbContextOptions(userId);
+
+        using var context = new TestDbContext(options);
+
+        var entity = new TestEntity
+        {
+            Name = "Protected Entity",
+        };
+
+        SetPrivateField(entity, "_isSystemProtected", true);
+
+        context.TestEntities.Add(entity);
+        context.SaveChanges();
+
+        // Delete the entity
+        context.TestEntities.Remove(entity);
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => context.SaveChanges());
+        Assert.AreEqual("Cannot delete a protected object", ex?.Message);
+    }
+
+    [Test]
+    public void SavingChanges_ModifyEntityWithIsDeletedTrue_WhenNotSystemProtected_SetsDeleteDateAndDeletedBy()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var options = GetDbContextOptions(userId);
+
+        using var context = new TestDbContext(options);
+
+        var entity = new TestEntity
+        {
+            Name = "Test Entity",
+        };
+        context.TestEntities.Add(entity);
+        context.SaveChanges();
+
+        // Act
+        entity.IsDeleted = true;
+        context.SaveChanges();
+
+        // Assert
+        Assert.IsNotNull(entity.DeleteDate);
+        Assert.AreEqual(userId, entity.DeletedBy);
+    }
+
+    /// <summary>
+    /// This test is here for the future if we move soft delete logic to business entity entirely
+    /// </summary>
+    [Test]
+    public void SavingChanges_ModifyEntityWithIsDeletedTrue_WhenSystemProtected_ThrowsException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var options = GetDbContextOptions(userId);
+
+        using var context = new TestDbContext(options);
+
+        var entity = new TestEntity
+        {
+            Name = "Protected Entity",
+        };
+
+        SetPrivateField(entity, "_isSystemProtected", true);
+
+        context.TestEntities.Add(entity);
+        context.SaveChanges();
+
+        entity.IsDeleted = true;
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => context.SaveChanges());
+        Assert.AreEqual("Cannot delete a protected object", ex?.Message);
+    }
+
+    [Test]
+    public async Task SavingChangesAsync_AddEntity_SetsCreatedAtAndCreatedBy()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var options = GetDbContextOptions(userId);
+
+        using var context = new TestDbContext(options);
+
+        var entity = new TestEntity
+        {
+            Name = "Async Test Entity",
+        };
+        context.TestEntities.Add(entity);
+
+        // Act
+        await context.SaveChangesAsync();
+
+        // Assert
+        Assert.IsNotNull(entity.CreatedAt);
+        Assert.AreEqual(userId, entity.CreatedBy);
+    }
+
+    [Test]
+    public void SavingChanges_WithNullCurrentUser_SetsUserIdToEmptyString()
+    {
+        // Arrange
+        var interceptor = new BusinessEntityInterceptor(null);
+        var options = new DbContextOptionsBuilder<OutOfSchoolDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .AddInterceptors(interceptor)
+            .Options;
+        var expectedUserId = string.Empty;
+
+        using var context = new TestDbContext(options);
+
+        var entity = new TestEntity
+        {
+            Name = "Test Entity",
+        };
+        context.TestEntities.Add(entity);
+
+        // Act
+        context.SaveChanges();
+
+        // Assert
+        Assert.AreEqual(expectedUserId, entity.CreatedBy);
+    }
+
+    private static DbContextOptions<OutOfSchoolDbContext> GetDbContextOptions(string userId)
+    {
+        var currentUserMock = new Mock<ICurrentUser>();
+        currentUserMock.Setup(cu => cu.UserId).Returns(userId);
+
+        var interceptor = new BusinessEntityInterceptor(currentUserMock.Object);
+
+        var options = new DbContextOptionsBuilder<OutOfSchoolDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .AddInterceptors(interceptor)
+            .Options;
+        return options;
+    }
+
+    private static void SetPrivateField<T>(object obj, string fieldName, T value)
+    {
+        var fieldInfo = obj.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        fieldInfo.SetValue(obj, value);
+    }
+
+    internal class TestEntity : BusinessEntity
+    {
+        public string Name { get; set; }
+    }
+
+    internal class TestDbContext : OutOfSchoolDbContext
+    {
+        public TestDbContext(DbContextOptions<OutOfSchoolDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<TestEntity> TestEntities { get; set; }
+    }
+}


### PR DESCRIPTION
- Implemented columns that should be managed by system as read only properties.
  - After consideration `BusinessEntity` has only `Guid` key as all entities that we will refactor to be a `BusinessEntity` have `Guid` keys at the moment.
- Added a base configuration to be used for every configuration class for entities that extend `BusinessEntity`
- Extracted `ICurrentUser` interface to common layer and use it as a `s.GetService<IHttpContextAccessor>()?.HttpContext?.User` more direct wrapper interface so we don't introduce circular dependency. 
- Implemented working with readonly fields in a `BusinessEntityInterceptor`, so DbContext is not dependent on injected `ICurrentUser`.
  - Consideration: Can we inject it in DbContext?
 