### PR TITLE
Nakoneshniuk/fixed dto ambiguous property

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/IHasCoverImage.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/IHasCoverImage.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
-
-namespace OutOfSchool.BusinessLogic.Models;
+﻿namespace OutOfSchool.BusinessLogic.Models;
 
 public interface IHasCoverImage
 {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/IHasImages.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/IHasImages.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
-
-namespace OutOfSchool.BusinessLogic.Models;
+﻿namespace OutOfSchool.BusinessLogic.Models;
 
 public interface IHasImages
 {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopDto.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
+using OutOfSchool.BusinessLogic.Util.JsonTools;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Models;
 
@@ -11,9 +13,11 @@ public class WorkshopDto : WorkshopBaseDto, IHasRating
 
     public float Rating { get; set; }
 
+    [MaxLength(256)]
     public string CoverImageId { get; set; } = string.Empty;
 
-    public List<Guid> ImageIds { get; set; }
+    [ModelBinder(BinderType = typeof(JsonModelBinder))]
+    public IList<string> ImageIds { get; set; }
 
     public int NumberOfRatings { get; set; }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
@@ -1,21 +1,11 @@
-﻿using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
-using OutOfSchool.BusinessLogic.Util.JsonTools;
+﻿using Newtonsoft.Json;
 
 namespace OutOfSchool.BusinessLogic.Models.Workshops;
 
 public class WorkshopV2Dto : WorkshopDto, IHasCoverImage, IHasImages
 {
-    [MaxLength(256)]
-    public string CoverImageId { get; set; } = string.Empty;
-
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public IFormFile CoverImage { get; set; }
-
-    [ModelBinder(BinderType = typeof(JsonModelBinder))]
-    public IList<string> ImageIds { get; set; }
 
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public List<IFormFile> ImageFiles { get; set; }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -693,6 +693,6 @@ public class MappingProfile : Profile
         where TSource : class, IHasEntityImages<TSource>
         where TDestination : class, IHasImages
         => mappings
-            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId).ToList()))
+            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)))
         ;
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -94,7 +94,7 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.TakenSeats, opt => opt.MapFrom(src => src.Applications.TakenSeats()))
             .IncludeBase<object, IHasRating>()
             .ForMember(dest => dest.IsBlocked, opt => opt.MapFrom(src => src.Provider.IsBlocked))
-            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(w => w.ExternalStorageId)))
+            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(w => w.ExternalStorageId).ToList()))
             .ForMember(dest => dest.CoverImageId, opt => opt.MapFrom(src => src.CoverImageId))
             .ForMember(dest => dest.ProviderStatus, opt => opt.MapFrom(src => src.Provider.Status));
 
@@ -103,9 +103,7 @@ public class MappingProfile : Profile
 
         CreateMap<Workshop, WorkshopV2Dto>()
             .IncludeBase<Workshop, WorkshopDto>()
-            .Apply(MapImageIds)
-            .Apply(IgnoreAllImages)
-            ;
+            .Apply(IgnoreAllImages);
 
         CreateMap<WorkshopV2Dto, Workshop>()
             .IncludeBase<WorkshopDto, Workshop>();
@@ -695,6 +693,6 @@ public class MappingProfile : Profile
         where TSource : class, IHasEntityImages<TSource>
         where TDestination : class, IHasImages
         => mappings
-            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)))
+            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId).ToList()))
         ;
 }


### PR DESCRIPTION
### Summary of Changes:
- **Resolved Swagger AmbiguousMatchException**: Fixed the AmbiguousMatchException error caused by a conflict between the `ImageIds` property in base and derived classes during Swagger documentation generation.
- Moved the `ImageIds` property (`IList<string>`) to the base class  (WorkshopDto) to avoid duplication.