### PR TITLE
upgrade api versioning and swagger to latest version

### DIFF
--- a/OutOfSchool/Directory.Packages.props
+++ b/OutOfSchool/Directory.Packages.props
@@ -3,11 +3,12 @@
     <BaseVersion>8.0.0</BaseVersion>
     <EFCoreVersion>8.0.7</EFCoreVersion>
     <OpenIdDictVersion>5.8.0</OpenIdDictVersion>
-    <SwaggerVersion>6.3.1</SwaggerVersion>
+    <SwaggerVersion>6.9.0</SwaggerVersion>
     <QuartzVersion>3.5.0</QuartzVersion>
     <RedisVersion>6.0.21</RedisVersion>
     <AutoMapVersion>12.0.1</AutoMapVersion>
     <ElasticApmVersion>1.27.1</ElasticApmVersion>
+    <VersioningVersion>8.1.0</VersioningVersion>
   </PropertyGroup>
   <ItemGroup>
     <!--Basic Microsoft Packages-->
@@ -80,12 +81,11 @@
     <PackageVersion Include="Microsoft.FeatureManagement" Version="2.5.1" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="2.5.1" />
     <!--Swagger & Versioning-->
-    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="$(SwaggerVersion)" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="$(SwaggerVersion)" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="$(SwaggerVersion)" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="$(SwaggerVersion)" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Newtonsoft" Version="$(SwaggerVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="$(VersioningVersion)" />
+    <PackageVersion Include="Asp.Versioning.Http" Version="$(VersioningVersion)" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="$(VersioningVersion)" />
     <!--JSON-->
     <PackageVersion Include="JsonSubTypes" Version="1.9.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/OutOfSchool/OutOfSchool.BusinessLogic/OutOfSchool.BusinessLogic.csproj
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/OutOfSchool.BusinessLogic.csproj
@@ -72,12 +72,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" />
   </ItemGroup>

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AboutPortalController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AboutPortalController.cs
@@ -8,7 +8,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for AboutPortal entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class AboutPortalController : CompanyInformationController
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AchievementController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AchievementController.cs
@@ -12,7 +12,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for Achievement entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class AchievementController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AchievementTypeController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AchievementTypeController.cs
@@ -8,7 +8,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for Achievement Type entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class AchievementTypeController : Controller
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AdminController.cs
@@ -14,7 +14,7 @@ using OutOfSchool.WebApi.Enums;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class AdminController : Controller
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ApplicationController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ApplicationController.cs
@@ -12,7 +12,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for a Application entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/applications")]
 public class ApplicationController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AreaAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/AreaAdminController.cs
@@ -11,7 +11,7 @@ using OutOfSchool.Services.Enums;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class AreaAdminController : Controller
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/BlockedProviderParentController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/BlockedProviderParentController.cs
@@ -6,7 +6,7 @@ using OutOfSchool.BusinessLogic.Services.ProviderServices;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class BlockedProviderParentController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ChangesLogController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ChangesLogController.cs
@@ -8,7 +8,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for ChangesLog entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class ChangesLogController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ChatWorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ChatWorkshopController.cs
@@ -13,7 +13,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller for chat operations between Parent and Provider.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
 [Authorize(Roles = "provider,parent")]
 public class ChatWorkshopController : ControllerBase

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ChildController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ChildController.cs
@@ -11,7 +11,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for a Child entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/children")]
 public class ChildController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CodeficatorController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CodeficatorController.cs
@@ -5,7 +5,7 @@ using OutOfSchool.Common.Models;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class CodeficatorController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CompetitiveEventController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CompetitiveEventController.cs
@@ -6,7 +6,7 @@ using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class CompetitiveEventController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/DirectionController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/DirectionController.cs
@@ -9,7 +9,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for Direction entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 [HasPermission(Permissions.SystemManagement)]
 public class DirectionController : ControllerBase

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ElasticsearchWorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ElasticsearchWorkshopController.cs
@@ -3,7 +3,7 @@
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 [HasPermission(Permissions.SystemManagement)]
 public class ElasticsearchWorkshopController : ControllerBase

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ExternalExportProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ExternalExportProviderController.cs
@@ -5,7 +5,7 @@ using OutOfSchool.BusinessLogic.Models.ProvidersInfo;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/providers")]
 public class ExternalExportProviderController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/FavoriteController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/FavoriteController.cs
@@ -7,7 +7,7 @@ using OutOfSchool.BusinessLogic.Models.Workshops;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class FavoriteController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/FeatureManagementController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/FeatureManagementController.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class FeatureManagementController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/GeocodingController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/GeocodingController.cs
@@ -8,7 +8,7 @@ using OutOfSchool.Common.Models;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
 [HasPermission(Permissions.WorkshopEdit)]
 public class GeocodingController : Controller

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/InstitutionStatusController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/InstitutionStatusController.cs
@@ -7,7 +7,7 @@ using OutOfSchool.BusinessLogic.Models;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class InstitutionStatusController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/LawsAndRegulationsController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/LawsAndRegulationsController.cs
@@ -8,7 +8,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for LawsAndRegulations entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class LawsAndRegulationsController : CompanyInformationController
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/MainInformationController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/MainInformationController.cs
@@ -8,7 +8,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for AboutPortal entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class MainInformationController: CompanyInformationController
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/MinistryAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/MinistryAdminController.cs
@@ -11,7 +11,7 @@ using OutOfSchool.Services.Enums;
 namespace OutOfSchool.WebApi.Controllers;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class MinistryAdminController : Controller
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/NotificationController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/NotificationController.cs
@@ -7,7 +7,7 @@ using OutOfSchool.Services.Enums;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class NotificationController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ParentController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ParentController.cs
@@ -10,7 +10,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for parent entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/parents")]
 public class ParentController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PermissionsForRoleController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PermissionsForRoleController.cs
@@ -5,7 +5,7 @@ using OutOfSchool.BusinessLogic.Models;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 [HasPermission(Permissions.SystemManagement)]
 public class PermissionsForRoleController : ControllerBase

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PersonalInfoController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PersonalInfoController.cs
@@ -6,7 +6,7 @@ using OutOfSchool.Services.Enums;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/users/personalinfo")]
 [HasPermission(Permissions.PersonalInfo)]
 public class PersonalInfoController : ControllerBase

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PrivateProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PrivateProviderController.cs
@@ -7,7 +7,7 @@ using OutOfSchool.BusinessLogic.Services.ProviderServices;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class PrivateProviderController : Controller
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderAdminController.cs
@@ -12,7 +12,7 @@ using OutOfSchool.Services.Enums;
 namespace OutOfSchool.WebApi.Controllers;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 [HasPermission(Permissions.ProviderAdmins)]
 public class ProviderAdminController : Controller

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderController.cs
@@ -10,7 +10,7 @@ using OutOfSchool.BusinessLogic.Services.ProviderServices;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class ProviderController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderTypeController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ProviderTypeController.cs
@@ -7,7 +7,7 @@ using OutOfSchool.BusinessLogic.Models.SocialGroup;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class ProviderTypeController:ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PublicImageController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PublicImageController.cs
@@ -3,7 +3,7 @@
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]")]
 public class PublicImageController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PublicProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/PublicProviderController.cs
@@ -7,7 +7,7 @@ using OutOfSchool.BusinessLogic.Services.ProviderServices;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class PublicProviderController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/RatingController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/RatingController.cs
@@ -7,7 +7,7 @@ using OutOfSchool.BusinessLogic.Services.AverageRatings;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class RatingController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/RegionAdminController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/RegionAdminController.cs
@@ -10,7 +10,7 @@ using OutOfSchool.Services.Enums;
 namespace OutOfSchool.WebApi.Controllers;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class RegionAdminController : Controller
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SocialGroupController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SocialGroupController.cs
@@ -7,7 +7,7 @@ using OutOfSchool.BusinessLogic.Models.SocialGroup;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class SocialGroupController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/StatisticController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/StatisticController.cs
@@ -7,7 +7,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// <summary>
 /// Controller with operations to get popular workshops and categories.
 /// </summary>
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/popular")]
 [ApiController]
 public class StatisticController : ControllerBase

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/StatisticReportController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/StatisticReportController.cs
@@ -5,7 +5,7 @@ using OutOfSchool.BusinessLogic.Models.StatisticReports;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class StatisticReportController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SubordinationStructure/InstitutionController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SubordinationStructure/InstitutionController.cs
@@ -7,7 +7,7 @@ namespace OutOfSchool.WebApi.Controllers.V1.SubordinationStructure;
 /// Controller with CRUD operations for Institution entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class InstitutionController : Controller
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SubordinationStructure/InstitutionFieldDescriptionController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SubordinationStructure/InstitutionFieldDescriptionController.cs
@@ -7,7 +7,7 @@ namespace OutOfSchool.WebApi.Controllers.V1.SubordinationStructure;
 /// Controller with CRUD operations for Institution entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class InstitutionFieldDescriptionController : Controller
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SubordinationStructure/InstitutionHierarchyController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SubordinationStructure/InstitutionHierarchyController.cs
@@ -8,7 +8,7 @@ namespace OutOfSchool.WebApi.Controllers.V1.SubordinationStructure;
 /// Controller with CRUD operations for InstitutionHierarchy entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class InstitutionHierarchyController : Controller
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SupportInformationController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/SupportInformationController.cs
@@ -5,7 +5,7 @@ using OutOfSchool.Services.Enums;
 namespace OutOfSchool.WebApi.Controllers.V1;
 
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class SupportInformationController : CompanyInformationController
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/TeacherController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/TeacherController.cs
@@ -10,7 +10,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for a Teacher entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 [HasPermission(Permissions.SystemManagement)]
 public class TeacherController : ControllerBase // check permissions for workshopIds for public controller

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -14,7 +14,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 /// Controller with CRUD operations for Workshop entity.
 /// </summary>
 [ApiController]
-[ApiVersion("1.0")]
+[AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class WorkshopController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/ProviderController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/ProviderController.cs
@@ -10,7 +10,7 @@ namespace OutOfSchool.WebApi.Controllers.V2;
 
 [ApiController]
 [FeatureGate(nameof(Feature.Images))]
-[ApiVersion("2.0")]
+[AspApiVersion(2)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class ProviderController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/TeacherController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/TeacherController.cs
@@ -13,7 +13,7 @@ namespace OutOfSchool.WebApi.Controllers.V2;
 /// </summary>
 [ApiController]
 [FeatureGate(nameof(Feature.Images))]
-[ApiVersion("2.0")]
+[AspApiVersion(2)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 [HasPermission(Permissions.SystemManagement)]
 public class TeacherController : ControllerBase // check permissions for workshopIds for public controller

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopController.cs
@@ -15,7 +15,7 @@ namespace OutOfSchool.WebApi.Controllers.V2;
 /// </summary>
 [ApiController]
 [FeatureGate(nameof(Feature.Images))]
-[ApiVersion("2.0")]
+[AspApiVersion(2)]
 [Route("api/v{version:apiVersion}/[controller]/[action]")]
 public class WorkshopController : ControllerBase
 {

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/ApiVersioningExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/ApiVersioningExtensions.cs
@@ -1,5 +1,4 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Versioning;
+using Asp.Versioning;
 
 namespace OutOfSchool.WebApi.Extensions.Startup;
 
@@ -7,25 +6,17 @@ public static class ApiVersioningExtensions
 {
     public static IServiceCollection AddVersioning(this IServiceCollection services)
     {
-        services.AddApiVersioning(
-            options =>
+        services.AddApiVersioning(options =>
             {
-                // reporting api versions will return the headers "api-supported-versions" and "api-deprecated-versions"
+                options.DefaultApiVersion = new ApiVersion(1);
                 options.ReportApiVersions = true;
-                options.ApiVersionReader = new UrlSegmentApiVersionReader();
                 options.AssumeDefaultVersionWhenUnspecified = true;
-                options.DefaultApiVersion = new ApiVersion(1, 0);
-            });
-
-        services.AddVersionedApiExplorer(
-            options =>
+                options.ApiVersionReader = new UrlSegmentApiVersionReader();
+            })
+            .AddMvc()
+            .AddApiExplorer(options =>
             {
-                // add the versioned api explorer, which also adds IApiVersionDescriptionProvider service
-                // note: the specified format code will format the version as "'v'major[.minor][-status]"
-                options.GroupNameFormat = "'v'VVV";
-
-                // note: this option is only necessary when versioning by url segment. the SubstitutionFormat
-                // can also be used to control the format of the API version in route templates
+                options.GroupNameFormat = "'v'V";
                 options.SubstituteApiVersionInUrl = true;
             });
 

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/CustomSwaggerOptions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/CustomSwaggerOptions.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning.ApiExplorer;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/SwaggerExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/SwaggerExtensions.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Asp.Versioning.ApiExplorer;
 using Microsoft.OpenApi.Models;
 
 namespace OutOfSchool.WebApi.Extensions.Startup;

--- a/OutOfSchool/OutOfSchool.WebApi/GlobalUsings.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/GlobalUsings.cs
@@ -43,3 +43,6 @@ global using OutOfSchool.WebApi.Middlewares;
 global using OutOfSchool.WebApi.Util;
 global using Serilog;
 global using Serilog.Context;
+
+// Needed to solve ambiguity of new Asp.Versioning objects and olv AspNetCore.Mvc objects
+global using AspApiVersionAttribute = Asp.Versioning.ApiVersionAttribute;

--- a/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
@@ -69,12 +69,10 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
         <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" />
+        <PackageReference Include="Asp.Versioning.Mvc" />
+        <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
         <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" />
         <PackageReference Include="Elastic.Apm.AspNetCore"/>

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Asp.Versioning.ApiExplorer;
 using AutoMapper;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Elasticsearch;


### PR DESCRIPTION
Introduced a global alias so the old Mvc namespace classes and methods do not conflict with new methods in new `Asp.Versioning` package.

```casharp
global using AspApiVersionAttribute = Asp.Versioning.ApiVersionAttribute;
```