### PR TITLE
Kyryk/Add ServiceController with a health check endpoint

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ServiceController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ServiceController.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace OutOfSchool.WebApi.Controllers.V1;
+
+/// <summary>
+/// Controller for service health check.
+/// </summary>
+
+[ApiController]
+[AspApiVersion(1)]
+[Route("api/v{version:apiVersion}/[controller]/[action]")]
+public class ServiceController : ControllerBase
+{
+    /// <summary>
+    /// Performs a health check for the service.
+    /// </summary>
+    /// <returns>
+    /// Returns 204 No Content if the service is healthy and running.
+    /// </returns>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None, Duration = -1)]
+    public IActionResult GetHealth()
+    {
+        Response.Headers["Expires"] = "-1";
+        return NoContent();
+    }
+}


### PR DESCRIPTION
This PR adds a ServiceController with a health check endpoint at GET /api/v{version}/service/gethealth. The endpoint returns 204 No Content to indicate the service is healthy and includes headers to prevent caching.
Please review when you have time. Thank you!

