### PR TITLE
Fixed JsonStringEnumConverter

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -206,7 +206,7 @@ public static class Startup
             })
 
             .AddJsonOptions(options =>
-                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)));
+                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
         services.AddHttpClient(configuration["Communication:ClientName"])
             .AddHttpMessageHandler(handler =>


### PR DESCRIPTION
Changed Startup class - replaced the line of code:.
AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(
new JsonStringEnumConverter(JsonNamingPolicy.CamelCase))); 
with:
.AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));