### PR TITLE
update quartz version

### DIFF
--- a/OutOfSchool/Directory.Packages.props
+++ b/OutOfSchool/Directory.Packages.props
@@ -4,7 +4,7 @@
     <EFCoreVersion>8.0.7</EFCoreVersion>
     <OpenIdDictVersion>5.8.0</OpenIdDictVersion>
     <SwaggerVersion>6.9.0</SwaggerVersion>
-    <QuartzVersion>3.5.0</QuartzVersion>
+    <QuartzVersion>3.13.1</QuartzVersion>
     <RedisVersion>6.0.21</RedisVersion>
     <AutoMapVersion>12.0.1</AutoMapVersion>
     <ElasticApmVersion>1.28.6</ElasticApmVersion>

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Extensions/QuartzExtension.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Extensions/QuartzExtension.cs
@@ -1,6 +1,5 @@
 using OutOfSchool.AuthorizationServer.Config;
 using Quartz;
-using Quartz.Impl;
 
 namespace OutOfSchool.AuthorizationServer.Extensions;
 
@@ -48,13 +47,12 @@ public static class QuartzExtension
                 s.UseClustering();
             });
 
-            q.UseMicrosoftDependencyInjectionJobFactory();
             q.UseTimeZoneConverter();
 
             configureJobs?.Invoke(q);
         });
 
-        services.AddQuartzServer(options => { options.WaitForJobsToComplete = true; });
+        services.AddQuartzHostedService(options => { options.WaitForJobsToComplete = true; });
 
         return services;
     }

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/QuartzExtension.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/QuartzExtension.cs
@@ -51,13 +51,12 @@ public static class QuartzExtension
                 s.UseClustering();
             });
 
-            q.UseMicrosoftDependencyInjectionJobFactory();
             q.UseTimeZoneConverter();
 
             configureJobs?.Invoke(q);
         });
 
-        services.AddQuartzServer(options => { options.WaitForJobsToComplete = true; });
+        services.AddQuartzHostedService(options => { options.WaitForJobsToComplete = true; });
 
         return services;
     }


### PR DESCRIPTION
Fixed a warning that version `3.5.0` for `Quartz.Serialization.SystemTextJson` does not exist and specified newer existing version for entire quartz stack.