### PR TITLE
Added the Authorize attribute to the methods whereby BusinessEntityIn…

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -263,6 +263,7 @@ public class WorkshopController : ControllerBase
     /// <response code="403">If the user has no rights to use this method, or sets some properties that are forbidden.</response>
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.WorkshopAddNew)]
+    [Authorize]
     [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(WorkshopCreateUpdateDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -337,6 +338,7 @@ public class WorkshopController : ControllerBase
     /// <response code="403">If the user has no rights to use this method, or sets some properties that are forbidden to change.</response>
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.WorkshopEdit)]
+    [Authorize]
     [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(WorkshopCreateUpdateDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -394,6 +396,8 @@ public class WorkshopController : ControllerBase
     /// <response code="401">If the user is not authorized.</response>
     /// <response code="403">If the user has no rights to use this method, or sets some properties that are forbidden to change.</response>
     /// <response code="500">If any server error occures.</response>
+    [HasPermission(Permissions.WorkshopEdit)]
+    [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(Workshop))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -428,6 +432,7 @@ public class WorkshopController : ControllerBase
     /// <response code="403">If the user has no rights to use this method, or sets some properties that are forbidden to change.</response>
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.WorkshopEdit)]
+    [Authorize]
     [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(WorkshopStatusDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -485,6 +490,7 @@ public class WorkshopController : ControllerBase
     /// <response code="403">If the user has no rights to use this method, or deletes not own workshop.</response>
     /// <response code="500">If any server error occures.</response>
     [HasPermission(Permissions.WorkshopRemove)]
+    [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]


### PR DESCRIPTION
Adding the Authorize attribute although HasPermission is derived from Authorize seems to be the only way to make the BusinessEntityInterceptor able to retrieve the UserId. Also added it to the Delete method because an unauthenticated user would never be able to delete an existing Workshop anyway (This method had the HasPermission as well so it seems to be right).