### PR TITLE
Removed Languages property from StudySubject entity

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/StudySubjects/LanguagesSelection.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/StudySubjects/LanguagesSelection.cs
@@ -1,6 +1,0 @@
-﻿namespace OutOfSchool.BusinessLogic.Models.StudySubjects;
-public class LanguagesSelection
-{
-    public long Id { get; set; }
-    public bool IsPrimary { get; set; }
-}

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/StudySubjects/StudySubjectCreateUpdateDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/StudySubjects/StudySubjectCreateUpdateDto.cs
@@ -18,30 +18,23 @@ public class StudySubjectCreateUpdateDto : IValidatableObject
     public string NameInInstructionLanguage { get; set; }
 
     [Required(ErrorMessage = "It's required to know if primary languge is Ukrainian.")]
-    public bool IsPrimaryLanguageUkrainian { get; set; }
+    public bool IsLanguageUkrainian { get; set; }
 
     /// <summary>
-    /// Language of instruction (allows multiple selection)
+    /// Primary language of the subject
     /// </summary>
-    [Required(ErrorMessage = "The language of instruction is required.")]
-    public List<LanguagesSelection> LanguagesSelection { get; set; }
+    [Required(ErrorMessage = "The primary language is required.")]
+    public LanguageDto Language { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-        if (LanguagesSelection == null || !LanguagesSelection.Any())
+        if (Language == null)
         {
-            yield return new ValidationResult("Languages cannot be null or empty.", new[] { nameof(LanguagesSelection) });
+            yield return new ValidationResult("Language cannot be null.", new[] { nameof(Language) });
         }
-        else
+        else if (Language.Id <= 0)
         {
-            if (LanguagesSelection.Count(l => l.IsPrimary) != 1)
-                yield return new ValidationResult("Languages must contain primary language.", new[] { nameof(LanguagesSelection) });
-
-            if (LanguagesSelection.Count() != LanguagesSelection.Distinct().Count())
-                yield return new ValidationResult("Languages cannot contain duplicates.", new[] { nameof(LanguagesSelection) });
-
-            if (LanguagesSelection.Any(l => l.Id <= 0))
-                yield return new ValidationResult("Languages cannot contain values smaller than 1.", new[] { nameof(LanguagesSelection) });
+            yield return new ValidationResult("Language ID must be greater than 0.", new[] { nameof(Language.Id) });
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/StudySubjects/StudySubjectDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/StudySubjects/StudySubjectDto.cs
@@ -6,6 +6,7 @@ public class StudySubjectDto
     public string NameInInstructionLanguage { get; set; }
     public bool IsLanguageUkrainian { get; set; }
     public long LanguageId { get; set; }
+    public LanguageDto Language { get; set; }
     public Guid WorkshopId { get; set; }
     public DateOnly ActiveFrom { get; set; }
     public DateOnly ActiveTo { get; set; }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/StudySubjects/StudySubjectDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/StudySubjects/StudySubjectDto.cs
@@ -4,9 +4,8 @@ public class StudySubjectDto
     public Guid Id { get; set; }
     public string NameInUkrainian { get; set; }
     public string NameInInstructionLanguage { get; set; }
-    public bool IsPrimaryLanguageUkrainian { get; set; }
-    public List<LanguageDto> Languages { get; set; }
-    public long PrimaryLanguageId { get; set; }
+    public bool IsLanguageUkrainian { get; set; }
+    public long LanguageId { get; set; }
     public Guid WorkshopId { get; set; }
     public DateOnly ActiveFrom { get; set; }
     public DateOnly ActiveTo { get; set; }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/StudySubjectService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/StudySubjectService.cs
@@ -21,7 +21,6 @@ public class StudySubjectService : IStudySubjectService
     /// <param name="languageRepository">Repository for Language.</param>
     /// <param name="providerService">Provider service.</param>
     /// <param name="logger">Logger.</param>
-    /// <param name="localizer">Localizer.</param>
     /// <param name="mapper">Mapper.</param>
     public StudySubjectService(
         IEntityRepositorySoftDeleted<Guid, StudySubject> studySubjectRepository,
@@ -50,11 +49,10 @@ public class StudySubjectService : IStudySubjectService
             return null;
         }
 
-        await CheckIfPrimaryLanguageIdIsCorrect(dto);
-
+        await CheckIfLanguageIdIsCorrect(dto);
 
         var studySubject = mapper.Map<StudySubject>(dto);
-        await UpdateEntityLanguages(dto, studySubject);
+        //await UpdateEntityLanguages(dto, studySubject);
 
         var newStudySubject = await studySubjectRepository.Create(studySubject).ConfigureAwait(false);
 
@@ -180,7 +178,7 @@ public class StudySubjectService : IStudySubjectService
             });
         }
 
-        await CheckIfPrimaryLanguageIdIsCorrect(dto);
+        await CheckIfLanguageIdIsCorrect(dto);
 
         var studySubject = await studySubjectRepository.GetById(dto.Id).ConfigureAwait(false);
 
@@ -194,7 +192,7 @@ public class StudySubjectService : IStudySubjectService
             });
         }
 
-        await UpdateEntityLanguages(dto, studySubject);
+        //await UpdateEntityLanguages(dto, studySubject);
 
         mapper.Map(dto, studySubject);
 
@@ -218,9 +216,9 @@ public class StudySubjectService : IStudySubjectService
         }
     }
 
-    private async Task CheckIfPrimaryLanguageIdIsCorrect(StudySubjectCreateUpdateDto dto)
+    private async Task CheckIfLanguageIdIsCorrect(StudySubjectCreateUpdateDto dto)
     {
-        if (dto.IsPrimaryLanguageUkrainian)
+        if (dto.IsLanguageUkrainian)
         {
             var query = languageRepository
                 .Get(
@@ -236,40 +234,25 @@ public class StudySubjectService : IStudySubjectService
             }
 
             var ukrainianLanguageId = ukrainianLanguage.Id;
-            var primaryLanguage = dto.LanguagesSelection.FirstOrDefault(l => l.IsPrimary);
+            var language = dto.Language;
 
-            if (primaryLanguage == null || ukrainianLanguageId != primaryLanguage.Id)
+            if (language == null || ukrainianLanguageId != language.Id)
             {
-                foreach (var language in dto.LanguagesSelection)
-                {
-                    language.IsPrimary = language.Id == ukrainianLanguage.Id;
-                }
+                language = mapper.Map<LanguageDto>(ukrainianLanguage);
 
-                if (!dto.LanguagesSelection.Any(l => l.Id == ukrainianLanguageId))
-                {
-                    dto.LanguagesSelection.Add(new LanguagesSelection
-                    {
-                        Id = ukrainianLanguageId,
-                        IsPrimary = true
-                    });
-                    logger.LogDebug("Ukrainian language was added to dto as the primary language");
-                }
-                else
-                {
-                    logger.LogDebug("Ukrainian language was set in dto as the primary language");
-                }
+                logger.LogDebug("Ukrainian language was set in dto as the primary language");
             }
         }
     }
 
-    private async Task UpdateEntityLanguages(StudySubjectCreateUpdateDto dto, StudySubject studySubject)
-    {
-        var languageIds = dto.LanguagesSelection.Select(x => x.Id).ToHashSet();
-        var languages = await languageRepository.Get(
-            whereExpression: l => languageIds.Contains(l.Id))
-            .ToListAsync();
+    //private async Task UpdateEntityLanguages(StudySubjectCreateUpdateDto dto, StudySubject studySubject)
+    //{
+    //    var languageIds = dto.LanguagesSelection.Select(x => x.Id).ToHashSet();
+    //    var languages = await languageRepository.Get(
+    //        whereExpression: l => languageIds.Contains(l.Id))
+    //        .ToListAsync();
         
-        studySubject.Languages = new List<Language>();
-        studySubject.Languages.AddRange(languages);
-    }
+    //    studySubject.Languages = new List<Language>();
+    //    studySubject.Languages.AddRange(languages);
+    //}
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/StudySubjectService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/StudySubjectService.cs
@@ -52,7 +52,7 @@ public class StudySubjectService : IStudySubjectService
         await CheckIfLanguageIdIsCorrect(dto);
 
         var studySubject = mapper.Map<StudySubject>(dto);
-        //await UpdateEntityLanguages(dto, studySubject);
+        await UpdateEntityLanguages(dto, studySubject);
 
         var newStudySubject = await studySubjectRepository.Create(studySubject).ConfigureAwait(false);
 
@@ -123,7 +123,7 @@ public class StudySubjectService : IStudySubjectService
             .Get(
                 skip: filter.From,
                 take: filter.Size,
-                includeProperties: "Languages",
+                includeProperties: "Language",
                 whereExpression: predicate
             ).AsNoTracking()
             .ToListAsync()
@@ -192,7 +192,7 @@ public class StudySubjectService : IStudySubjectService
             });
         }
 
-        //await UpdateEntityLanguages(dto, studySubject);
+        await UpdateEntityLanguages(dto, studySubject);
 
         mapper.Map(dto, studySubject);
 
@@ -238,21 +238,20 @@ public class StudySubjectService : IStudySubjectService
 
             if (language == null || ukrainianLanguageId != language.Id)
             {
-                language = mapper.Map<LanguageDto>(ukrainianLanguage);
+                dto.Language = mapper.Map<LanguageDto>(ukrainianLanguage);
 
                 logger.LogDebug("Ukrainian language was set in dto as the primary language");
             }
         }
     }
 
-    //private async Task UpdateEntityLanguages(StudySubjectCreateUpdateDto dto, StudySubject studySubject)
-    //{
-    //    var languageIds = dto.LanguagesSelection.Select(x => x.Id).ToHashSet();
-    //    var languages = await languageRepository.Get(
-    //        whereExpression: l => languageIds.Contains(l.Id))
-    //        .ToListAsync();
-        
-    //    studySubject.Languages = new List<Language>();
-    //    studySubject.Languages.AddRange(languages);
-    //}
+    private async Task UpdateEntityLanguages(StudySubjectCreateUpdateDto dto, StudySubject studySubject)
+    {
+        var languageId = dto.Language.Id;
+        var language = await languageRepository.Get(
+            whereExpression: l => languageId == l.Id)
+            .FirstOrDefaultAsync();
+
+        studySubject.Language = language;
+    }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/StudySubjectService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/StudySubjectService.cs
@@ -129,7 +129,7 @@ public class StudySubjectService : IStudySubjectService
             .ToListAsync()
             .ConfigureAwait(false);
 
-        logger.LogDebug("{Count} records were successfully received from the StudySubjects table", studySubjects.Count());
+        logger.LogDebug("{Count} records were successfully received from the StudySubjects table", studySubjects.Count);
 
         var result = new SearchResult<StudySubjectDto>
         {
@@ -251,6 +251,12 @@ public class StudySubjectService : IStudySubjectService
         var language = await languageRepository.Get(
             whereExpression: l => languageId == l.Id)
             .FirstOrDefaultAsync();
+
+        if (language == null)
+        {
+            logger.LogWarning("Operation failed, Language with Id = {languageId} was not found.", languageId);
+            throw new ArgumentException($"Language with Id = {languageId} was not found");
+        }
 
         studySubject.Language = language;
     }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -932,9 +932,8 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.ActiveFrom, opt => opt.Ignore())
             .ForMember(dest => dest.ActiveTo, opt => opt.Ignore())
             .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
-            .ForMember(dest => dest.Language, opt => opt.Ignore())
             .ForMember(dest => dest.LanguageId,
-                opt => opt.MapFrom(src => src.LanguagesSelection.FirstOrDefault(l => l.IsPrimary).Id));
+                opt => opt.MapFrom(src => src.Language.Id));
 
         CreateMap<StudySubject, StudySubjectDto>()
             .ForMember(dest => dest.WorkshopId, opt => opt.Ignore());

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -29,7 +29,6 @@ using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Models.CompetitiveEvents;
 using OutOfSchool.Services.Models.Images;
-using OutOfSchool.BusinessLogic.Models.Official;
 
 namespace OutOfSchool.BusinessLogic.Util;
 
@@ -933,25 +932,14 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.ActiveFrom, opt => opt.Ignore())
             .ForMember(dest => dest.ActiveTo, opt => opt.Ignore())
             .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
-            .ForMember(dest => dest.PrimaryLanguage, opt => opt.Ignore())
-            .ForMember(dest => dest.Languages,
-                opt => opt.Ignore())
-            .ForMember(dest => dest.PrimaryLanguageId,
+            .ForMember(dest => dest.Language, opt => opt.Ignore())
+            .ForMember(dest => dest.LanguageId,
                 opt => opt.MapFrom(src => src.LanguagesSelection.FirstOrDefault(l => l.IsPrimary).Id));
 
         CreateMap<StudySubject, StudySubjectDto>()
             .ForMember(dest => dest.WorkshopId, opt => opt.Ignore());
 
         CreateMap<Language, LanguageDto>().ReverseMap();
-
-        CreateMap<Official, OfficialDto>()
-            .ForMember(dest => dest.DismissalOrder, opt => opt.MapFrom(src => src.DismissalOrder ?? string.Empty))
-            .ForMember(dest => dest.RecruitmentOrder, opt => opt.MapFrom(src => src.RecruitmentOrder ?? string.Empty))
-            .ForMember(dest => dest.DismissalReason, opt => opt.MapFrom(src => src.DismissalReason ?? string.Empty));
-
-        CreateMap<Position, OfficialPositionDto>();
-
-        CreateMap<Individual, OfficialIndividualDto>();
     }
 
     public IMappingExpression<TSource, TDestination> CreateSoftDeletedMap<TSource, TDestination>()

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -29,6 +29,7 @@ using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Models.CompetitiveEvents;
 using OutOfSchool.Services.Models.Images;
+using OutOfSchool.BusinessLogic.Models.Official;
 
 namespace OutOfSchool.BusinessLogic.Util;
 
@@ -939,6 +940,15 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.WorkshopId, opt => opt.Ignore());
 
         CreateMap<Language, LanguageDto>().ReverseMap();
+
+        CreateMap<Official, OfficialDto>()
+            .ForMember(dest => dest.DismissalOrder, opt => opt.MapFrom(src => src.DismissalOrder ?? string.Empty))
+            .ForMember(dest => dest.RecruitmentOrder, opt => opt.MapFrom(src => src.RecruitmentOrder ?? string.Empty))
+            .ForMember(dest => dest.DismissalReason, opt => opt.MapFrom(src => src.DismissalReason ?? string.Empty));
+
+        CreateMap<Position, OfficialPositionDto>();
+
+        CreateMap<Individual, OfficialIndividualDto>();
     }
 
     public IMappingExpression<TSource, TDestination> CreateSoftDeletedMap<TSource, TDestination>()

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/StudySubjectConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/StudySubjectConfiguration.cs
@@ -15,16 +15,13 @@ public class StudySubjectConfiguration : BusinessEntityConfiguration<StudySubjec
             .IsRequired()
             .HasMaxLength(100);
 
-        builder.Property(x => x.IsPrimaryLanguageUkrainian)
+        builder.Property(x => x.IsLanguageUkrainian)
             .IsRequired();
 
-        builder.HasOne(x => x.PrimaryLanguage)
+        builder.HasOne(x => x.Language)
             .WithMany()
-            .HasForeignKey(x => x.PrimaryLanguageId)
+            .HasForeignKey(x => x.LanguageId)
             .OnDelete(DeleteBehavior.Restrict);
-
-        builder.HasMany(x => x.Languages)
-            .WithMany();
 
         base.Configure(builder);
     }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/StudySubject.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/StudySubject.cs
@@ -1,6 +1,4 @@
-﻿
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace OutOfSchool.Services.Models;
 
@@ -29,19 +27,13 @@ public class StudySubject : BusinessEntity
     /// Property determines if the primary language is Ukrainian
     /// </summary>
     [Required(ErrorMessage = "It's required to know if primary languge is Ukrainian.")]
-    public bool IsPrimaryLanguageUkrainian { get; set; }
-
-    /// <summary>
-    /// Language of instruction (allows multiple selection)
-    /// </summary>
-    [Required(ErrorMessage = "The language of instruction is required.")]
-    public virtual List<Language> Languages { get; set; }
+    public bool IsLanguageUkrainian { get; set; }
 
     /// <summary>
     /// Primary language of the subject
     /// </summary>
     [Required(ErrorMessage = "The primary language's ID is required.")]
-    public long PrimaryLanguageId { get; set; }
-    public virtual Language PrimaryLanguage { get; set; }
+    public long LanguageId { get; set; }
+    public virtual Language Language { get; set; }
 }
 

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250124123347_RemoveLanguagesFromStudySubject.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250124123347_RemoveLanguagesFromStudySubject.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
 #nullable disable
 
-namespace OutOfSchool.IdentityServer.Data.Migrations.OutOfSchoolMigrations
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250124123347_RemoveLanguagesFromStudySubject")]
+    partial class RemoveLanguagesFromStudySubject
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250124123347_RemoveLanguagesFromStudySubject.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250124123347_RemoveLanguagesFromStudySubject.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+{
+    /// <inheritdoc />
+    public partial class RemoveLanguagesFromStudySubject : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitiveEvents_InstitutionHierarchies_InstitutionHierarch~",
+                table: "CompetitiveEvents");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_StudySubjects_Languages_PrimaryLanguageId",
+                table: "StudySubjects");
+
+            migrationBuilder.DropTable(
+                name: "LanguageStudySubject");
+
+            migrationBuilder.RenameColumn(
+                name: "PrimaryLanguageId",
+                table: "StudySubjects",
+                newName: "LanguageId");
+
+            migrationBuilder.RenameColumn(
+                name: "IsPrimaryLanguageUkrainian",
+                table: "StudySubjects",
+                newName: "IsLanguageUkrainian");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_StudySubjects_PrimaryLanguageId",
+                table: "StudySubjects",
+                newName: "IX_StudySubjects_LanguageId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitiveEvents_InstitutionHierarchies_InstitutionHierarch~",
+                table: "CompetitiveEvents",
+                column: "InstitutionHierarchyId",
+                principalTable: "InstitutionHierarchies",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_StudySubjects_Languages_LanguageId",
+                table: "StudySubjects",
+                column: "LanguageId",
+                principalTable: "Languages",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitiveEvents_InstitutionHierarchies_InstitutionHierarch~",
+                table: "CompetitiveEvents");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_StudySubjects_Languages_LanguageId",
+                table: "StudySubjects");
+
+            migrationBuilder.RenameColumn(
+                name: "LanguageId",
+                table: "StudySubjects",
+                newName: "PrimaryLanguageId");
+
+            migrationBuilder.RenameColumn(
+                name: "IsLanguageUkrainian",
+                table: "StudySubjects",
+                newName: "IsPrimaryLanguageUkrainian");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_StudySubjects_LanguageId",
+                table: "StudySubjects",
+                newName: "IX_StudySubjects_PrimaryLanguageId");
+
+            migrationBuilder.CreateTable(
+                name: "LanguageStudySubject",
+                columns: table => new
+                {
+                    LanguagesId = table.Column<long>(type: "bigint", nullable: false),
+                    StudySubjectId = table.Column<Guid>(type: "binary(16)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LanguageStudySubject", x => new { x.LanguagesId, x.StudySubjectId });
+                    table.ForeignKey(
+                        name: "FK_LanguageStudySubject_Languages_LanguagesId",
+                        column: x => x.LanguagesId,
+                        principalTable: "Languages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LanguageStudySubject_StudySubjects_StudySubjectId",
+                        column: x => x.StudySubjectId,
+                        principalTable: "StudySubjects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LanguageStudySubject_StudySubjectId",
+                table: "LanguageStudySubject",
+                column: "StudySubjectId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitiveEvents_InstitutionHierarchies_InstitutionHierarch~",
+                table: "CompetitiveEvents",
+                column: "InstitutionHierarchyId",
+                principalTable: "InstitutionHierarchies",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_StudySubjects_Languages_PrimaryLanguageId",
+                table: "StudySubjects",
+                column: "PrimaryLanguageId",
+                principalTable: "Languages",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/StudySubjectControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/StudySubjectControllerTests.cs
@@ -221,8 +221,32 @@ public class StudySubjectControllerTests
         Assert.That(result.StatusCode, Is.EqualTo(400));
     }
 
+    [Test]
+    public void Create_ReturnsValidationError_WhenLanguageIdIsLessThanOrEqualToZero()
+    {
+        // Arrange
+        var dto = new StudySubjectCreateUpdateDto()
+        {
+            Id = Guid.NewGuid(),
+            NameInUkrainian = "тест",
+            NameInInstructionLanguage = "тест",
+            IsLanguageUkrainian = true,
+            Language = new LanguageDto { Id = 0, Code = "Ua", Name = "Українська" }
+        };
+
+        // Act
+        var validationResults = new List<ValidationResult>();
+        var validationContext = new ValidationContext(dto);
+        bool isValid = Validator.TryValidateObject(dto, validationContext, validationResults, true);
+
+        // Assert
+        Assert.IsFalse(isValid);
+        Assert.AreEqual(1, validationResults.Count);
+        Assert.AreEqual("Language ID must be greater than 0.", validationResults[0].ErrorMessage);
+    }
+
     #endregion
-    
+
     #region Update
 
     [Test]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/StudySubjectControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/StudySubjectControllerTests.cs
@@ -519,7 +519,7 @@ public class StudySubjectControllerTests
             ActiveFrom = DateOnly.FromDateTime(DateTime.Now),
             ActiveTo = DateOnly.FromDateTime(DateTime.Now),
             Id = Guid.NewGuid(),
-            IsPrimaryLanguageUkrainian = true,
+            IsLanguageUkrainian = true,
             Languages = new List<LanguageDto>
             {
                 new LanguageDto()
@@ -538,7 +538,7 @@ public class StudySubjectControllerTests
             },
             NameInInstructionLanguage = "тест",
             NameInUkrainian = "тест",
-            PrimaryLanguageId = 1,
+            LanguageId = 1,
             WorkshopId = Guid.NewGuid()
         };
     }
@@ -548,7 +548,7 @@ public class StudySubjectControllerTests
         return new StudySubjectCreateUpdateDto()
         {
             Id = Guid.NewGuid(),
-            IsPrimaryLanguageUkrainian = true,
+            IsLanguageUkrainian = true,
             LanguagesSelection = new List<LanguagesSelection>
             {
                 new LanguagesSelection()
@@ -572,7 +572,7 @@ public class StudySubjectControllerTests
         return new StudySubjectCreateUpdateDto()
         {
             Id = Guid.NewGuid(),
-            IsPrimaryLanguageUkrainian = true,
+            IsLanguageUkrainian = true,
             LanguagesSelection = new List<LanguagesSelection>
             {
                 new LanguagesSelection()

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/StudySubjectControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/StudySubjectControllerTests.cs
@@ -520,21 +520,11 @@ public class StudySubjectControllerTests
             ActiveTo = DateOnly.FromDateTime(DateTime.Now),
             Id = Guid.NewGuid(),
             IsLanguageUkrainian = true,
-            Languages = new List<LanguageDto>
+            Language = new LanguageDto()
             {
-                new LanguageDto()
-                {
-                    Id = 1,
-                    Name = "Українська",
-                    Code = "uk"
-
-                },
-                new LanguageDto()
-                {
-                    Id = 2,
-                    Name = "English",
-                    Code = "en"
-                }
+                Id = 2,
+                Name = "English",
+                Code = "en"
             },
             NameInInstructionLanguage = "тест",
             NameInUkrainian = "тест",
@@ -549,18 +539,11 @@ public class StudySubjectControllerTests
         {
             Id = Guid.NewGuid(),
             IsLanguageUkrainian = true,
-            LanguagesSelection = new List<LanguagesSelection>
+            Language = new LanguageDto()
             {
-                new LanguagesSelection()
-                {
-                    Id = 1,
-                    IsPrimary = false
-                },
-                new LanguagesSelection()
-                {
-                    Id = 2,
-                    IsPrimary = true
-                }
+                Id = 2,
+                Name = "English",
+                Code = "en"
             },
             NameInInstructionLanguage = "тест",
             NameInUkrainian = "тест"
@@ -573,18 +556,11 @@ public class StudySubjectControllerTests
         {
             Id = Guid.NewGuid(),
             IsLanguageUkrainian = true,
-            LanguagesSelection = new List<LanguagesSelection>
+            Language = new LanguageDto()
             {
-                new LanguagesSelection()
-                {
-                    Id = 1,
-                    IsPrimary = false
-                },
-                new LanguagesSelection()
-                {
-                    Id = 2,
-                    IsPrimary = true
-                }
+                Id = 2,
+                Name = "English",
+                Code = "en"
             },
             NameInInstructionLanguage = null,
             NameInUkrainian = null

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StudySubjectServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StudySubjectServiceTests.cs
@@ -153,13 +153,11 @@ public class StudySubjectServiceTests
         {
             Id = Guid.NewGuid(),
             IsLanguageUkrainian = true,
-            LanguagesSelection = new List<LanguagesSelection>()
+            Language = new LanguageDto()
             {
-                new LanguagesSelection()
-                {
-                    Id = 2,
-                    IsPrimary = true
-                }
+                Id = 2,
+                Code = "Ua",
+                Name = "Українська"
             },
             NameInInstructionLanguage = "ім'я",
             NameInUkrainian = "ім'я",
@@ -182,13 +180,11 @@ public class StudySubjectServiceTests
         {
             Id = Guid.NewGuid(),
             IsLanguageUkrainian = true,
-            LanguagesSelection = new List<LanguagesSelection>()
+            Language = new LanguageDto()
             {
-                new LanguagesSelection()
-                {
-                    Id = 1,
-                    IsPrimary = true
-                }
+                Id = 1,
+                Code = "Ua",
+                Name = "Українська"
             },
             NameInInstructionLanguage = "ім'я",
             NameInUkrainian = "ім'я",
@@ -200,7 +196,7 @@ public class StudySubjectServiceTests
         // Assert
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Id, Is.EqualTo(dto.Id));
-        Assert.That(result.Languages.Any(l => l.Id == 2));
+        Assert.That(result.LanguageId == 2);
         Assert.IsInstanceOf<StudySubjectDto>(result);
     }
 
@@ -227,13 +223,11 @@ public class StudySubjectServiceTests
         {
             Id = Guid.Empty,
             IsLanguageUkrainian = true,
-            LanguagesSelection = new List<LanguagesSelection>()
+            Language = new LanguageDto()
             {
-                new LanguagesSelection()
-                {
-                    Id = 2,
-                    IsPrimary = true
-                }
+                Id = 2,
+                Code = "Ua",
+                Name = "Українська"
             },
             NameInInstructionLanguage = "ім'я",
             NameInUkrainian = "ім'я"
@@ -256,13 +250,11 @@ public class StudySubjectServiceTests
         {
             Id = new Guid("eb49a87c-7042-45e9-a76b-79ebd98b6b16"),
             IsLanguageUkrainian = true,
-            LanguagesSelection = new List<LanguagesSelection>()
+            Language = new LanguageDto()
             {
-                new LanguagesSelection()
-                {
-                    Id = 2,
-                    IsPrimary = true
-                }
+                Id = 2,
+                Code = "Ua",
+                Name = "Українська"
             },
             NameInInstructionLanguage = "ім'я",
             NameInUkrainian = "ім'я"

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StudySubjectServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StudySubjectServiceTests.cs
@@ -56,7 +56,9 @@ public class StudySubjectServiceTests
 
         SeedDatabase();
     }
-    
+
+    #region GetByFilter
+
     [Test]
     public async Task GetByFilter_ReturnsAListOfStudySubjects_WhenSearchStringIsEmpty()
     {
@@ -102,7 +104,11 @@ public class StudySubjectServiceTests
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Entities, Is.Empty);
     }
-    
+
+    #endregion
+
+    #region GetById
+
     [Test]
     public async Task GetById_ReturnsNull_WhenStudySubjectDoesNotExist()
     {
@@ -131,7 +137,11 @@ public class StudySubjectServiceTests
         Assert.That(result.Id, Is.EqualTo(expected.Id));
         Assert.IsInstanceOf<StudySubjectDto>(result);
     }
-    
+
+    #endregion
+
+    #region Create
+
     [Test]
     public async Task Create_ReturnsNull_WhenDtoIsNull()
     {
@@ -200,6 +210,10 @@ public class StudySubjectServiceTests
         Assert.IsInstanceOf<StudySubjectDto>(result);
     }
 
+    #endregion
+
+    #region Update
+
     [Test]
     public async Task Update_ReturnsResultFailed_WhenDtoIsNull()
     {
@@ -241,7 +255,49 @@ public class StudySubjectServiceTests
         Assert.That(result.OperationResult.Errors.FirstOrDefault().Code, Is.EqualTo("404"));
         Assert.IsInstanceOf<Result<StudySubjectDto>>(result);
     }
-    
+
+    [Test]
+    public async Task Update_ReturnsResultFailed_WhenDbUpdateConcurrencyExceptionOccurs()
+    {
+        // Arrange
+        var dto = new StudySubjectCreateUpdateDto()
+        {
+            Id = new Guid("eb49a87c-7042-45e9-a76b-79ebd98b6b16"),
+            IsLanguageUkrainian = true,
+            Language = new LanguageDto()
+            {
+                Id = 2,
+                Code = "Ua",
+                Name = "Українська"
+            },
+            NameInInstructionLanguage = "ім'я",
+            NameInUkrainian = "ім'я",
+        };
+
+        var mockRepository = SetUpMockRepositoryForGetById(dto.Id);
+        mockRepository
+            .Setup(repo => repo.Update(It.IsAny<StudySubject>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+
+        service = new StudySubjectService(
+            mockRepository.Object,
+            languageRepository,
+            providerService.Object,
+            logger.Object,
+            mapper);
+
+        // Act
+        var result = await service.Update(dto, providerId);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.OperationResult.Errors, Is.Not.Null);
+        Assert.That(result.OperationResult.Errors.FirstOrDefault().Code, Is.EqualTo("400"));
+        Assert.That(result.OperationResult.Errors.FirstOrDefault().Description,
+                    Is.EqualTo("Updating failed. StudySubject to update was not found"));
+        Assert.IsInstanceOf<Result<StudySubjectDto>>(result);
+    }
+
     [Test]
     public async Task Update_ReturnsResultSuccess_WhenEntityWasUpdated()
     {
@@ -268,7 +324,11 @@ public class StudySubjectServiceTests
         Assert.That(result.Value.Id, Is.EqualTo(dto.Id));
         Assert.IsInstanceOf<Result<StudySubjectDto>>(result);
     }
-    
+
+    #endregion
+
+    #region Delete
+
     [Test]
     public async Task Delete_ReturnsResutlFailed_WhenStudySubjectWithIdDoesNotExist()
     {
@@ -302,7 +362,39 @@ public class StudySubjectServiceTests
         Assert.That(result, Is.Not.Null);
         Assert.That(result.IsDeleted, Is.True);
     }
-    
+
+    [Test]
+    public async Task Delete_ReturnsResultFailed_WhenDbUpdateConcurrencyExceptionOccurs()
+    {
+        // Arrange
+        var id = new Guid("eb49a87c-7042-45e9-a76b-79ebd98b6b16");
+        
+        var mockRepository = SetUpMockRepositoryForGetById(id);
+        mockRepository
+            .Setup(repo => repo.Delete(It.IsAny<StudySubject>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+
+        service = new StudySubjectService(
+            mockRepository.Object,
+            languageRepository,
+            providerService.Object,
+            logger.Object,
+            mapper);
+
+        // Act
+        var result = await service.Delete(id, providerId);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.OperationResult.Errors, Is.Not.Null);
+        Assert.That(result.OperationResult.Errors.FirstOrDefault().Code, Is.EqualTo("400"));
+        Assert.That(result.OperationResult.Errors.FirstOrDefault().Description,
+                    Is.EqualTo($"Deleting StudySubject with Id = {id} failed"));
+        Assert.IsInstanceOf<Result<StudySubjectDto>>(result);
+    }
+
+    #endregion
+
     private void SeedDatabase()
     {
         using var ctx = new TestOutOfSchoolDbContext(options);
@@ -314,6 +406,25 @@ public class StudySubjectServiceTests
 
             ctx.SaveChanges();
         }
+    }
+
+    private Mock<IEntityRepositorySoftDeleted<Guid, StudySubject>> SetUpMockRepositoryForGetById(Guid id)
+    {
+        var studySubject = new StudySubject()
+        {
+            Id = id,
+            LanguageId = 2,
+            NameInInstructionLanguage = "тест",
+            NameInUkrainian = "тест",
+            IsLanguageUkrainian = true,
+        };
+
+        var mockRepository = new Mock<IEntityRepositorySoftDeleted<Guid, StudySubject>>();
+        mockRepository
+            .Setup(repo => repo.GetById(id))
+            .ReturnsAsync(studySubject);
+
+        return mockRepository;
     }
 
     private List<StudySubject> StudySubjects()

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StudySubjectServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StudySubjectServiceTests.cs
@@ -333,16 +333,16 @@ public class StudySubjectServiceTests
                 Id = new Guid("eb49a87c-7042-45e9-a76b-79ebd98b6b16"),
                 NameInInstructionLanguage = "тест",
                 NameInUkrainian = "тест",
-                PrimaryLanguageId = 2,
-                IsPrimaryLanguageUkrainian = true
+                LanguageId = 2,
+                IsLanguageUkrainian = true
             },
             new StudySubject()
             {
                 Id = new Guid("4ca6f3af-5d02-4c16-b4b2-e202c71470f4"),
                 NameInInstructionLanguage = "test",
                 NameInUkrainian = "тест",
-                PrimaryLanguageId = 1,
-                IsPrimaryLanguageUkrainian = false
+                LanguageId = 1,
+                IsLanguageUkrainian = false
             }
         };
     }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StudySubjectServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StudySubjectServiceTests.cs
@@ -152,7 +152,7 @@ public class StudySubjectServiceTests
         var dto = new StudySubjectCreateUpdateDto()
         {
             Id = Guid.NewGuid(),
-            IsPrimaryLanguageUkrainian = true,
+            IsLanguageUkrainian = true,
             LanguagesSelection = new List<LanguagesSelection>()
             {
                 new LanguagesSelection()
@@ -181,7 +181,7 @@ public class StudySubjectServiceTests
         var dto = new StudySubjectCreateUpdateDto()
         {
             Id = Guid.NewGuid(),
-            IsPrimaryLanguageUkrainian = true,
+            IsLanguageUkrainian = true,
             LanguagesSelection = new List<LanguagesSelection>()
             {
                 new LanguagesSelection()
@@ -226,7 +226,7 @@ public class StudySubjectServiceTests
         var dto = new StudySubjectCreateUpdateDto()
         {
             Id = Guid.Empty,
-            IsPrimaryLanguageUkrainian = true,
+            IsLanguageUkrainian = true,
             LanguagesSelection = new List<LanguagesSelection>()
             {
                 new LanguagesSelection()
@@ -255,7 +255,7 @@ public class StudySubjectServiceTests
         var dto = new StudySubjectCreateUpdateDto()
         {
             Id = new Guid("eb49a87c-7042-45e9-a76b-79ebd98b6b16"),
-            IsPrimaryLanguageUkrainian = true,
+            IsLanguageUkrainian = true,
             LanguagesSelection = new List<LanguagesSelection>()
             {
                 new LanguagesSelection()

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/StudySubjectController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/StudySubjectController.cs
@@ -37,12 +37,9 @@ public class StudySubjectController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpGet]
-    public async Task<IActionResult> Get(Guid providerId, [FromQuery] SearchStringFilter filter = null)
-    {
-        var studySubjects = await _studySubjectService.GetByFilter(providerId, filter).ConfigureAwait(false);
-
-        return this.SearchResultToOkOrNoContent(studySubjects);
-    }
+    public async Task<IActionResult> Get(Guid providerId, [FromQuery] SearchStringFilter filter = null) =>
+        await _studySubjectService.GetByFilter(providerId, filter)
+            .ProtectAndMap(this.SearchResultToOkOrNoContent);
 
     /// <summary>
     /// Get StudySubject by it's id.
@@ -105,7 +102,7 @@ public class StudySubjectController : ControllerBase
 
                 return CreatedAtAction(
                 nameof(GetById),
-                new { id = creationResult.Id, },
+                new { id = creationResult.Id, providerId = providerId },
                 creationResult);
             }
 


### PR DESCRIPTION
Removed many-to-many relationship between Language and StudySubject entities, updated tests, service and controller for StudySubject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
	- Simplified language handling in study subjects from multiple languages to a single primary language.
	- Renamed language-related properties across multiple models and services.

- **Refactoring**
	- Removed `LanguagesSelection` class.
	- Updated property names from `PrimaryLanguageId` to `LanguageId`.
	- Updated property names from `IsPrimaryLanguageUkrainian` to `IsLanguageUkrainian`.
	- Replaced list-based language management with a single language object.

- **Code Improvements**
	- Streamlined language validation and mapping logic.
	- Simplified service and controller methods related to language handling.
	- Enhanced clarity of API responses in the `Create` method.
	- Improved organization and readability of test cases for study subject services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->