### PR TITLE
TKyryk/ added image-related properties to CompetitiveEventDto

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventBaseDto.cs
@@ -1,10 +1,11 @@
 ﻿using OutOfSchool.Common.Enums;
 using OutOfSchool.Services.Enums;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 
-public class CompetitiveEventBaseDto
+public class CompetitiveEventBaseDto: IHasCoverImage, IHasImages
 {
     [Required(ErrorMessage = "Title is required")]
     [DataType(DataType.Text)]
@@ -99,4 +100,14 @@ public class CompetitiveEventBaseDto
     public uint? NumberOfOccupiedSeats { get; set; }
 
     public List<Guid> ParticipantsOfTheEvent { get; set; } = new List<Guid>();
+
+    public string CoverImageId { get; set; } = string.Empty;
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IFormFile CoverImage { get; set; }
+
+    public IList<string> ImageIds { get; set; } = new List<string>();
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<IFormFile> ImageFiles { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -781,7 +781,11 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.Judges, opt => opt.MapFrom(src => src.Judges))
             .ForMember(dest => dest.ParticipantsOfTheEvent, opt => opt.Ignore())
             .ForMember(dest => dest.Rating, opt => opt.Ignore())
-            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore());
+            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore())
+            .Apply(IgnoreAllImages)
+            .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
+            .ForMember(dest => dest.ImageIds, opt => opt.Ignore());
+            
 
         CreateSoftDeletedMap<CompetitiveEventCreateDto, CompetitiveEvent>()
             .ForMember(dest => dest.InstitutionHierarchy, opt => opt.Ignore())


### PR DESCRIPTION
Added new image-related properties to the CompetitiveEvent DTO models.
Updated mapping to correctly handle the new fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `CompetitiveEventBaseDto` to support cover images and multiple image files
	- Added image-related properties with JSON serialization considerations

- **Refactor**
	- Updated mapping configurations for competitive event data transfer objects
	- Improved handling of image-related properties during object mapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->