### PR TITLE
Hot fix removed content disposition .Net client issue

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Images/ImageService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Images/ImageService.cs
@@ -205,11 +205,7 @@ public class ImageService : IImageService
             var imageStorageId = await imageStorage
                 .UploadAsync(
                     new ImageFileModel { ContentStream = contentStream, ContentType = contentType },
-                    Constants.PublicImageCacheControl,
-                    new Dictionary<string, string>
-                    {
-                        {"Content-Disposition", "inline"}
-                    })
+                    Constants.PublicImageCacheControl)
                 .ConfigureAwait(false);
 
             return Result<string>.Success(imageStorageId);


### PR DESCRIPTION
looks like .Net client is one of the few clients that blocks `Content-Disposition` header, while it is supported by storage service and other client :(

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the image upload process by streamlining the interface and reducing unnecessary parameters for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->