### PR TITLE
TKyryk/ add external API client in OpenIddict

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthCommon/Config/AuthorizationServerConfig.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Config/AuthorizationServerConfig.cs
@@ -10,7 +10,7 @@ public class AuthorizationServerConfig
 
     public AuthorizationCertificateConfig Certificate { get; set; }
 
-    public OpenIdClient[] OpenIdClients { get; set; }
+    public Dictionary<string, OpenIdClient> OpenIdClients { get; set; }
 
     public ExternalLogin ExternalLogin { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.AuthCommon/Config/OpenIdClients.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Config/OpenIdClients.cs
@@ -13,4 +13,6 @@ public class OpenIdClient
     public Dictionary<string, string> DisplayNames { get; set; }
 
     public bool IsIntrospection { get; set; }
+
+    public string ClientSecret { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.AuthCommon/Config/OpenIdClients.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Config/OpenIdClients.cs
@@ -2,7 +2,7 @@ namespace OutOfSchool.AuthCommon.Config;
 
 public class OpenIdClient
 {
-    public string ClientId { get; set; }
+    public string? ClientId { get; set; }
 
     public string[] RedirectUris { get; set; }
 
@@ -14,5 +14,5 @@ public class OpenIdClient
 
     public bool IsIntrospection { get; set; }
 
-    public string ClientSecret { get; set; }
+    public string? ClientSecret { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Extensions/QuartzExtension.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Extensions/QuartzExtension.cs
@@ -14,7 +14,7 @@ public static class QuartzExtension
     /// <param name="configureJobs">Expose Quartz Configurator to Configure Jobs.</param>
     /// <returns><see cref="IServiceCollection"/> instance.</returns>
     /// <exception cref="ArgumentNullException">Whenever the services collection is null.</exception>
-    public static async Task<IServiceCollection> AddDefaultQuartz(
+    public static IServiceCollection AddDefaultQuartz(
         this IServiceCollection services,
         IConfiguration configuration,
         string quartzConnectionString = "QuartzConnection",

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Program.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Program.cs
@@ -14,7 +14,7 @@ builder.Host.UseSerilog((ctx, lc) => lc
 GlobalLogContext.PushProperty("AppVersion", builder.Configuration.GetSection("AppDefaults:Version").Value);
 
 // Add services to the container.
-await builder.AddApplicationServices();
+builder.AddApplicationServices();
 
 var app = builder.Build();
 

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Startup.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Startup.cs
@@ -173,7 +173,9 @@ public static class Startup
                     OpenIddictConstants.Scopes.Email,
                     OpenIddictConstants.Scopes.Profile,
                     OpenIddictConstants.Scopes.Roles,
-                    "outofschoolapi");
+                    Constants.OpenIddictScopes.OutOfSchoolApi,
+                    Constants.OpenIddictScopes.ExternalExportRead
+                    );
 
                 var aspNetCoreBuilder = options.UseAspNetCore()
                     .EnableAuthorizationEndpointPassthrough()

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Startup.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Startup.cs
@@ -25,7 +25,7 @@ namespace OutOfSchool.AuthorizationServer;
 
 public static class Startup
 {
-    public static async Task AddApplicationServices(this WebApplicationBuilder builder)
+    public static void AddApplicationServices(this WebApplicationBuilder builder)
     {
         var services = builder.Services;
         var config = builder.Configuration;
@@ -45,7 +45,7 @@ public static class Startup
         }
 
         var quartzConfig = config.GetSection(QuartzConfig.Name).Get<QuartzConfig>();
-        await services.AddDefaultQuartz(
+        services.AddDefaultQuartz(
             config,
             quartzConfig.ConnectionStringKey,
             t => t.AddEmailSender(quartzConfig));
@@ -162,10 +162,10 @@ public static class Startup
                     .SetEndSessionEndpointUris("connect/logout")
                     .SetTokenEndpointUris("connect/token")
                     .SetUserInfoEndpointUris("connect/userinfo")
-                    .SetEndUserVerificationEndpointUris("connect/verify");
+                    .SetEndUserVerificationEndpointUris("connect/verify")
+                    .SetRevocationEndpointUris("connect/revoke");
 
                 options.AllowAuthorizationCodeFlow()
-                    .AllowHybridFlow()
                     .AllowClientCredentialsFlow()
                     .AllowRefreshTokenFlow();
 

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Worker.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Worker.cs
@@ -7,40 +7,58 @@ namespace OutOfSchool.AuthorizationServer;
 
 // TODO: Use client info from settings
 public class Worker : IHostedService
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public Worker(IServiceProvider serviceProvider)
+        => _serviceProvider = serviceProvider;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
-        private readonly IServiceProvider _serviceProvider;
+        using var scope = _serviceProvider.CreateScope();
 
-        public Worker(IServiceProvider serviceProvider)
-            => _serviceProvider = serviceProvider;
+        var context = scope.ServiceProvider.GetRequiredService<OutOfSchoolDbContext>();
+        await context.Database.EnsureCreatedAsync(cancellationToken);
 
-        public async Task StartAsync(CancellationToken cancellationToken)
+        await RegisterApplicationsAsync(scope.ServiceProvider);
+        await RegisterScopesAsync(scope.ServiceProvider);
+
+        static async Task RegisterApplicationsAsync(IServiceProvider provider)
         {
-            using var scope = _serviceProvider.CreateScope();
-
-            var context = scope.ServiceProvider.GetRequiredService<OutOfSchoolDbContext>();
-            await context.Database.EnsureCreatedAsync(cancellationToken);
-
-            await RegisterApplicationsAsync(scope.ServiceProvider);
-            await RegisterScopesAsync(scope.ServiceProvider);
-
-            static async Task RegisterApplicationsAsync(IServiceProvider provider)
+            var manager = provider.GetRequiredService<IOpenIddictApplicationManager>();
+            var options = provider.GetRequiredService<IOptions<AuthorizationServerConfig>>().Value;
+            foreach (var client in options.OpenIdClients)
             {
-                var manager = provider.GetRequiredService<IOpenIddictApplicationManager>();
-                var options = provider.GetRequiredService<IOptions<AuthorizationServerConfig>>().Value;
-                foreach (var client in options.OpenIdClients)
+                if (await manager.FindByClientIdAsync(client.ClientId) is null)
                 {
-                    if (await manager.FindByClientIdAsync(client.ClientId) is null)
+                    OpenIddictApplicationDescriptor descriptor;
+                    if (client.IsIntrospection)
                     {
-                        OpenIddictApplicationDescriptor descriptor;
-                        if (client.IsIntrospection)
+                        descriptor = new()
+                        {
+                            ClientId = client.ClientId,
+                            ClientSecret = options.IntrospectionSecret,
+                            Permissions =
+                            {
+                                Permissions.Endpoints.Introspection,
+                            },
+                        };
+                    }
+                    else
+                    {
+                        if (client.ClientSecret is not null)
                         {
                             descriptor = new()
                             {
                                 ClientId = client.ClientId,
-                                ClientSecret = options.IntrospectionSecret,
+                                DisplayName = client.DisplayName,
+                                ClientSecret = client.ClientSecret,
                                 Permissions =
                                 {
-                                    Permissions.Endpoints.Introspection,
+                                    Permissions.Endpoints.Token,
+                                    Permissions.GrantTypes.ClientCredentials,
+                                    Permissions.Scopes.Profile,
+                                    Permissions.Prefixes.Scope + Constants.OpenIddictScopes.ExternalExportRead,
                                 },
                             };
                         }
@@ -63,51 +81,75 @@ public class Worker : IHostedService
                                     Permissions.Scopes.Email,
                                     Permissions.Scopes.Profile,
                                     Permissions.Scopes.Roles,
-                                    Permissions.Prefixes.Scope + "outofschoolapi",
+                                    Permissions.Prefixes.Scope + Constants.OpenIddictScopes.OutOfSchoolApi,
                                 },
                                 Requirements =
                                 {
                                     Requirements.Features.ProofKeyForCodeExchange,
                                 },
                             };
-                            descriptor.PostLogoutRedirectUris.UnionWith(client.PostLogoutRedirectUris.Select(s => new Uri(s)));
-                            descriptor.RedirectUris.UnionWith(client.RedirectUris.Select(s => new Uri(s)));
-                            foreach (var entry in client.DisplayNames)
-                            {
-                                descriptor.DisplayNames.Add(CultureInfo.GetCultureInfo(entry.Key), entry.Value);
-                            }
                         }
-
-                        await manager.CreateAsync(descriptor);
+                        if (descriptor.PostLogoutRedirectUris.Any())
+                        {
+                            descriptor.PostLogoutRedirectUris.UnionWith(client.PostLogoutRedirectUris.Select(s => new Uri(s)));
+                        }
+                        if (descriptor.RedirectUris.Any())
+                        {
+                            descriptor.RedirectUris.UnionWith(client.RedirectUris.Select(s => new Uri(s)));
+                        }
+                        foreach (var entry in client.DisplayNames)
+                        {
+                            descriptor.DisplayNames.Add(CultureInfo.GetCultureInfo(entry.Key), entry.Value);
+                        }
                     }
-                }
-            }
 
-            // TODO: Maybe extract to appsettigns too later.
-            static async Task RegisterScopesAsync(IServiceProvider provider)
-            {
-                var manager = provider.GetRequiredService<IOpenIddictScopeManager>();
-
-                if (await manager.FindByNameAsync("outofschoolapi") is null)
-                {
-                    await manager.CreateAsync(new OpenIddictScopeDescriptor
-                    {
-                        DisplayName = "outofschoolapi API access",
-                        DisplayNames =
-                        {
-                            [CultureInfo.GetCultureInfo("uk-UA")] = "Позашкілля",
-                            [CultureInfo.GetCultureInfo("en-US")] = "Pozashkillia",
-                            [CultureInfo.GetCultureInfo("en-GB")] = "Pozashkillia",
-                        },
-                        Name = "outofschoolapi",
-                        Resources =
-                        {
-                            "outofschool_api",
-                        },
-                    });
+                    await manager.CreateAsync(descriptor);
                 }
             }
         }
 
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        // TODO: Maybe extract to appsettigns too later.
+        static async Task RegisterScopesAsync(IServiceProvider provider)
+        {
+            var manager = provider.GetRequiredService<IOpenIddictScopeManager>();
+
+            if (await manager.FindByNameAsync(Constants.OpenIddictScopes.OutOfSchoolApi) is null)
+            {
+                await manager.CreateAsync(new OpenIddictScopeDescriptor
+                {
+                    DisplayName = "outofschoolapi API access",
+                    DisplayNames =
+                    {
+                        [CultureInfo.GetCultureInfo("uk-UA")] = "Позашкілля",
+                        [CultureInfo.GetCultureInfo("en-US")] = "Pozashkillia",
+                        [CultureInfo.GetCultureInfo("en-GB")] = "Pozashkillia",
+                    },
+                    Name = Constants.OpenIddictScopes.OutOfSchoolApi, //"outofschoolapi",
+                    Resources =
+                    {
+                       Constants.OpenIddictResources.OutOfSchoolApi,
+                    },
+                });
+            }
+            if (await manager.FindByNameAsync(Constants.OpenIddictScopes.ExternalExportRead) is null)
+            {
+                await manager.CreateAsync(new OpenIddictScopeDescriptor
+                {
+                    DisplayName = "external_api API access",
+                    DisplayNames =
+                    {
+                        [CultureInfo.GetCultureInfo("en-US")] = "External API access",
+                    },
+                    Name = Constants.OpenIddictScopes.ExternalExportRead,
+                    Resources =
+                    {
+                        Constants.OpenIddictResources.ExternalApi,
+                        Constants.OpenIddictResources.OutOfSchoolApi,
+                    },
+                });
+            }
+        }
     }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Worker.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Worker.cs
@@ -27,16 +27,17 @@ public class Worker : IHostedService
         {
             var manager = provider.GetRequiredService<IOpenIddictApplicationManager>();
             var options = provider.GetRequiredService<IOptions<AuthorizationServerConfig>>().Value;
-            foreach (var client in options.OpenIdClients)
+            foreach (var (name, client) in options.OpenIdClients)
             {
-                if (await manager.FindByClientIdAsync(client.ClientId) is null)
+                var clientId = client.ClientId ?? name;
+                if (await manager.FindByClientIdAsync(clientId) is null)
                 {
                     OpenIddictApplicationDescriptor descriptor;
                     if (client.IsIntrospection)
                     {
                         descriptor = new()
                         {
-                            ClientId = client.ClientId,
+                            ClientId = clientId,
                             ClientSecret = options.IntrospectionSecret,
                             Permissions =
                             {
@@ -50,7 +51,7 @@ public class Worker : IHostedService
                         {
                             descriptor = new()
                             {
-                                ClientId = client.ClientId,
+                                ClientId = clientId,
                                 DisplayName = client.DisplayName,
                                 ClientSecret = client.ClientSecret,
                                 Permissions =
@@ -66,7 +67,7 @@ public class Worker : IHostedService
                         {
                             descriptor = new OpenIddictApplicationDescriptor
                             {
-                                ClientId = client.ClientId,
+                                ClientId = clientId,
                                 ConsentType = ConsentTypes.Implicit,
                                 DisplayName = client.DisplayName,
                                 Permissions =
@@ -143,7 +144,6 @@ public class Worker : IHostedService
                     Name = Constants.OpenIddictScopes.ExternalExportRead,
                     Resources =
                     {
-                        Constants.OpenIddictResources.ExternalApi,
                         Constants.OpenIddictResources.OutOfSchoolApi,
                     },
                 });

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Google.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Google.json
@@ -49,9 +49,8 @@
       "PfxFileName": null,
       "PfxPassword": null
     },
-    "OpenIdClients": [
-      {
-        "ClientId": "angular",
+    "OpenIdClients": {
+      "angular": {
         "DisplayName": "angular client PKCE",
         "DisplayNames": {
           "uk-UA": "Позашкілля",
@@ -70,8 +69,7 @@
         ],
         "IsIntrospection": false
       },
-      {
-        "ClientId": "Swagger",
+      "Swagger": {
         "DisplayName": "Swagger UI PKCE",
         "DisplayNames": {
           "uk-UA": "Позашкілля API",
@@ -85,12 +83,8 @@
           "https://api.oos.dmytrominochkin.cloud/swagger/oauth2-redirect.html"
         ],
         "IsIntrospection": false
-      },
-      {
-        "ClientId": "outofschool_api",
-        "IsIntrospection": true
       }
-    ]
+    }
   },
   "Issuer": {
     "Uri": "https://auth.oos.dmytrominochkin.cloud",

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Kubernetes.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Kubernetes.json
@@ -71,9 +71,8 @@
       "PfxFileName": null,
       "PfxPassword": null
     },
-    "OpenIdClients": [
-      {
-        "ClientId": "angular",
+    "OpenIdClients": {
+      "angular": {
         "DisplayName": "angular client PKCE",
         "DisplayNames": {
           "uk-UA": "Позашкілля",
@@ -94,8 +93,7 @@
         ],
         "IsIntrospection": false
       },
-      {
-        "ClientId": "Swagger",
+      "Swagger": {
         "DisplayName": "Swagger UI PKCE",
         "DisplayNames": {
           "uk-UA": "Позашкілля API",
@@ -111,12 +109,8 @@
           "https://pozashkillia-test.iea.gov.ua/web/swagger/oauth2-redirect.html"
         ],
         "IsIntrospection": false
-      },
-      {
-        "ClientId": "outofschool_api",
-        "IsIntrospection": true
       }
-    ],
+    },
     "ExternalLogin": {
       "IdServerUri": "https://test.id.gov.ua",
       "EUSignServiceUri": "http://encryption-webapp:8080",

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Release.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Release.json
@@ -62,9 +62,8 @@
       "PfxFileName": null,
       "PfxPassword": null
     },
-    "OpenIdClients": [
-      {
-        "ClientId": "angular",
+    "OpenIdClients": {
+      "angular": {
         "DisplayName": "angular client PKCE",
         "DisplayNames": {
           "uk-UA": "Позашкілля",
@@ -79,8 +78,7 @@
         ],
         "IsIntrospection": false
       },
-      {
-        "ClientId": "Swagger",
+      "Swagger": {
         "DisplayName": "Swagger UI PKCE",
         "DisplayNames": {
           "uk-UA": "Позашкілля API",
@@ -94,12 +92,8 @@
           "https://pozashkillia.iea.gov.ua/web/swagger/oauth2-redirect.html"
         ],
         "IsIntrospection": false
-      },
-      {
-        "ClientId": "outofschool_api",
-        "IsIntrospection": true
       }
-    ]
+    }
   },
   "ReverseProxy": {
     "BasePath": "/users"

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.json
@@ -119,7 +119,7 @@
       "PfxPassword": null
     },
     "OpenIdClients": [
-      {
+       {
         "ClientId": "angular",
         "DisplayName": "angular client PKCE",
         "DisplayNames": {
@@ -156,6 +156,15 @@
       {
         "ClientId": "outofschool_api",
         "IsIntrospection": true
+      },
+      {
+        "ClientId": "cc_external_api",
+        "DisplayName": "External API Client",
+        "IsIntrospection": false,
+        "ClientSecret": "super-secret",
+        "DisplayNames": {
+          "en-US": "External API"
+        }
       }
     ],
     "ExternalLogin" : {

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.json
@@ -118,9 +118,8 @@
       "PfxFileName": null,
       "PfxPassword": null
     },
-    "OpenIdClients": [
-       {
-        "ClientId": "angular",
+    "OpenIdClients": {
+      "angular": {
         "DisplayName": "angular client PKCE",
         "DisplayNames": {
           "uk-UA": "Позашкілля",
@@ -135,8 +134,7 @@
         ],
         "IsIntrospection": false
       },
-      {
-        "ClientId": "Swagger",
+      "Swagger": {
         "DisplayName": "Swagger UI PKCE",
         "DisplayNames": {
           "uk-UA": "Позашкілля API",
@@ -153,11 +151,11 @@
         ],
         "IsIntrospection": false
       },
-      {
+      "Introspection": {
         "ClientId": "outofschool_api",
         "IsIntrospection": true
       },
-      {
+      "ExternalApi": {
         "ClientId": "cc_external_api",
         "DisplayName": "External API Client",
         "IsIntrospection": false,
@@ -166,7 +164,7 @@
           "en-US": "External API"
         }
       }
-    ],
+    },
     "ExternalLogin" : {
       "IdServerUri": "http://localhost:8081",
       "IdServerPaths": {

--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -293,7 +293,6 @@ public static class Constants
 
     public static class OpenIddictResources
     {
-        public const string ExternalApi = "external_api";
         public const string OutOfSchoolApi = "outofschool_api";
     }
 }

--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -285,4 +285,15 @@ public static class Constants
         public const string AikomProviderId = "aikom_provider_id";
         public const string ExternalIdProviderName = "external_id_provider_name";
     }
+    public static class OpenIddictScopes
+    {
+        public const string ExternalExportRead = "external_export.read";
+        public const string OutOfSchoolApi = "outofschoolapi";
+    }
+
+    public static class OpenIddictResources
+    {
+        public const string ExternalApi = "external_api";
+        public const string OutOfSchoolApi = "outofschool_api";
+    }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ExternalExportController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ExternalExportController.cs
@@ -10,6 +10,7 @@ namespace OutOfSchool.WebApi.Controllers.V1;
 [ApiController]
 [AspApiVersion(1)]
 [Route("api/v{version:apiVersion}/export")]
+[Authorize(Policy = "ExternalClientPolicy")]
 public class ExternalExportController : ControllerBase
 {
     private readonly IExternalExportService externalProviderService;
@@ -32,7 +33,7 @@ public class ExternalExportController : ControllerBase
     [Route("providers")]
     public async Task<IActionResult> GetProvidersByFilter([FromQuery] DateTime updatedAfter,
         [FromQuery] OffsetFilter offsetFilter) =>
-        await externalProviderService.GetProviders(updatedAfter, offsetFilter)
+   await externalProviderService.GetProviders(updatedAfter, offsetFilter)
             .ProtectAndMap(this.SearchResultToOkOrNoContent);
 
     /// <summary>
@@ -48,7 +49,7 @@ public class ExternalExportController : ControllerBase
     [Route("workshops")]
     public async Task<IActionResult> GetWorkshopsByFilter([FromQuery] DateTime updatedAfter,
         [FromQuery] OffsetFilter offsetFilter) =>
-        await externalProviderService.GetWorkshops(updatedAfter, offsetFilter)
+         await externalProviderService.GetWorkshops(updatedAfter, offsetFilter)
             .ProtectAndMap(this.SearchResultToOkOrNoContent);
 
     /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ExternalExportController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ExternalExportController.cs
@@ -31,9 +31,10 @@ public class ExternalExportController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("providers")]
-    public async Task<IActionResult> GetProvidersByFilter([FromQuery] DateTime updatedAfter,
+    public async Task<IActionResult> GetProvidersByFilter(
+        [FromQuery] DateTime updatedAfter,
         [FromQuery] OffsetFilter offsetFilter) =>
-   await externalProviderService.GetProviders(updatedAfter, offsetFilter)
+        await externalProviderService.GetProviders(updatedAfter, offsetFilter)
             .ProtectAndMap(this.SearchResultToOkOrNoContent);
 
     /// <summary>
@@ -47,9 +48,10 @@ public class ExternalExportController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("workshops")]
-    public async Task<IActionResult> GetWorkshopsByFilter([FromQuery] DateTime updatedAfter,
+    public async Task<IActionResult> GetWorkshopsByFilter(
+        [FromQuery] DateTime updatedAfter,
         [FromQuery] OffsetFilter offsetFilter) =>
-         await externalProviderService.GetWorkshops(updatedAfter, offsetFilter)
+        await externalProviderService.GetWorkshops(updatedAfter, offsetFilter)
             .ProtectAndMap(this.SearchResultToOkOrNoContent);
 
     /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/SwaggerExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/SwaggerExtensions.cs
@@ -1,7 +1,5 @@
 using System.Reflection;
 using Asp.Versioning.ApiExplorer;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -35,20 +33,8 @@ public static class SwaggerExtensions
                 c.AddSecurityDefinition(config.SecurityDefinitions.Title, new OpenApiSecurityScheme
                 {
                     Description = config.SecurityDefinitions.Description,
-                    Type = SecuritySchemeType.OAuth2,
-                    Flows = new OpenApiOAuthFlows
-                    {
-                        AuthorizationCode = new OpenApiOAuthFlow
-                        {
-                            AuthorizationUrl = new Uri($"{identityBaseUrl}/connect/authorize?prompt=login",
-                                UriKind.Absolute),
-                            TokenUrl = new Uri($"{identityBaseUrl}/connect/token", UriKind.Absolute),
-                            Scopes = new Dictionary<string, string>
-                            {
-                                {string.Join(" ", config.SecurityDefinitions.AccessScopes), "Scopes"},
-                            },
-                        },
-                    },
+                    Type = SecuritySchemeType.OpenIdConnect,
+                    OpenIdConnectUrl = new Uri($"{identityBaseUrl}/.well-known/openid-configuration")
                 });
                 c.UseOneOfForPolymorphism();
                 c.UseAllOfForInheritance();
@@ -60,7 +46,8 @@ public static class SwaggerExtensions
     public static IApplicationBuilder UseSwaggerWithVersioning(
         this IApplicationBuilder app,
         IApiVersionDescriptionProvider provider,
-        ReverseProxyOptions options)
+        ReverseProxyOptions options,
+        SwaggerConfig config)
     {
         // Enable middleware to serve generated Swagger as a JSON endpoint.
         app.UseSwagger();
@@ -82,6 +69,11 @@ public static class SwaggerExtensions
 
             c.OAuthClientId("Swagger");
             c.OAuthUsePkce();
+            c.OAuthAdditionalQueryStringParams(new Dictionary<string, string>
+            {
+                {"prompt", "login"},
+            });
+            c.OAuthScopes(config.SecurityDefinitions.AccessScopes.ToArray());
         });
 
         return app;

--- a/OutOfSchool/OutOfSchool.WebApi/Program.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Program.cs
@@ -8,12 +8,12 @@ builder.Host.UseSerilog((ctx, lc) => lc
     .ReadFrom.Configuration(ctx.Configuration)
     .Enrich.WithExceptionDetails(new DestructuringOptionsBuilder()
         .WithDefaultDestructurers()
-        .WithDestructurers(new[] { new DbUpdateExceptionDestructurer() })));
+        .WithDestructurers([new DbUpdateExceptionDestructurer()])));
 
 GlobalLogContext.PushProperty("AppVersion", builder.Configuration.GetSection("AppDefaults:Version").Value);
 
 // Add services to the container.
-await builder.AddApplicationServices();
+builder.AddApplicationServices();
 
 var app = builder.Build();
 

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Primitives;
+using OpenIddict.Abstractions;
 using OpenIddict.Validation.AspNetCore;
 using OutOfSchool.AikomApiClient.Extensions;
 using OutOfSchool.BackgroundJobs.Config;
@@ -100,7 +101,7 @@ public static class Startup
 
         app.UseMiddleware<ExceptionMiddlewareExtension>();
 
-        app.UseSwaggerWithVersioning(provider, proxyOptions);
+        app.UseSwaggerWithVersioning(provider, proxyOptions, app.Configuration.GetSection(SwaggerConfig.Name).Get<SwaggerConfig>());
 
         if (!app.Environment.IsDevelopment())
         {
@@ -148,7 +149,7 @@ public static class Startup
         app.MapHub<NotificationHub>(Constants.PathToNotificationHub);
     }
 
-    public static async Task AddApplicationServices(this WebApplicationBuilder builder)
+    public static void AddApplicationServices(this WebApplicationBuilder builder)
     {
         var services = builder.Services;
         var configuration = builder.Configuration;
@@ -326,7 +327,7 @@ public static class Startup
         // ElasticPinger must precede ElasticIndexEnsureCreatedHostedService
         services.AddSingleton<ElasticPinger>();
         services.AddSingleton<IElasticsearchHealthService>(provider => provider.GetService<ElasticPinger>());
-        services.AddHostedService<ElasticPinger>(provider => provider.GetService<ElasticPinger>());
+        services.AddHostedService(provider => provider.GetService<ElasticPinger>());
 
         if (elasticConfig.EnsureIndex)
         {
@@ -648,7 +649,7 @@ public static class Startup
             .Get<EmailOptions>();
 
         services.AddEmailSender(builder.Environment.IsDevelopment(), mailConfig.SendGridKey);
-        services.AddEmailSenderService(builder => builder.Bind(configuration.GetSection(EmailOptions.SectionName)));
+        services.AddEmailSenderService(b => b.Bind(configuration.GetSection(EmailOptions.SectionName)));
 
         // Hosts options
         services.Configure<HostsConfig>(configuration.GetSection(HostsConfig.Name));
@@ -658,8 +659,7 @@ public static class Startup
             options.AddPolicy("ExternalClientPolicy", policy =>
             {
                 policy.RequireAuthenticatedUser();
-                policy.RequireClaim("scope", Constants.OpenIddictScopes.ExternalExportRead);
-                policy.RequireClaim("aud", Constants.OpenIddictResources.ExternalApi); 
+                policy.RequireClaim(OpenIddictConstants.Claims.Scope, Constants.OpenIddictScopes.ExternalExportRead);
             });
         });
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -126,14 +126,14 @@ public static class Startup
             .WithMetadata(new AllowAnonymousAttribute());
 
         app.MapHealthChecks("/healthz/active", new HealthCheckOptions
+        {
+            Predicate = healthCheck => healthCheck.Name == "Liveness",
+            ResponseWriter = async (context, _) =>
             {
-                Predicate = healthCheck => healthCheck.Name == "Liveness",
-                ResponseWriter = async (context, _) =>
-                {
-                    context.Response.ContentType = "application/json";
-                    await context.Response.WriteAsync("{\"status\":\"Healthy\"}");
-                },
-            })
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync("{\"status\":\"Healthy\"}");
+            },
+        })
             .WithMetadata(new AllowAnonymousAttribute());
 
         app.MapControllers();
@@ -652,5 +652,15 @@ public static class Startup
 
         // Hosts options
         services.Configure<HostsConfig>(configuration.GetSection(HostsConfig.Name));
+
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy("ExternalClientPolicy", policy =>
+            {
+                policy.RequireAuthenticatedUser();
+                policy.RequireClaim("scope", Constants.OpenIddictScopes.ExternalExportRead);
+                policy.RequireClaim("aud", Constants.OpenIddictResources.ExternalApi); 
+            });
+        });
     }
 }


### PR DESCRIPTION
- Registered external_api client in OpenIddict
- Configured scopes and permissions
- Enabled authorization for external API
- Granted external_api client access to ExternalExportController
- Added named constants for OpenIddict scopes and resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a secure external API client configuration with enhanced authentication.
  - Expanded authorization policies and scopes to tighten access controls for external endpoints.
  - Updated health check endpoints to provide clear, JSON-formatted service status.
  - Added a new client entry for "ExternalApi" with specific properties.

- **Improvements**
  - Enhanced clarity and maintainability by utilizing constants for scope and resource definitions.
  - Improved handling of client applications and permissions in the authorization server.
  - Implemented a new authorization policy for external clients to enforce specific claims.
  - Simplified the structure of OpenID client configurations for better organization.
  - Transitioned several methods from asynchronous to synchronous execution for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->