### PR TITLE
Add minimal support for client credentials grant type

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Controllers/TokenController.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Controllers/TokenController.cs
@@ -395,7 +395,7 @@ public class TokenController : Controller
     }
     #endregion
 
-    #region Password, authorization code, device and refresh token flows
+    #region Password, authorization code, client credentials, device and refresh token flows
     [HttpPost("~/connect/token")]
     [IgnoreAntiforgeryToken]
     [Produces("application/json")]
@@ -409,12 +409,23 @@ public class TokenController : Controller
             return await this.HandleExchangePasswordGrantType(request);
         }
 
+        if (request.IsClientCredentialsGrantType())
+        {
+            return await this.HandleExchangeClientCredentialsGrantType(request);
+        }
+
         if (request.IsAuthorizationCodeGrantType() || request.IsDeviceCodeGrantType() || request.IsRefreshTokenGrantType())
         {
             return await this.HandleExchangeCodeAndRefreshGrantTypes();
         }
 
-        throw new InvalidOperationException("The specified grant type is not supported.");
+        return this.Forbid(
+            authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
+            properties: new AuthenticationProperties(new Dictionary<string, string>
+            {
+                [OpenIddictServerAspNetCoreConstants.Properties.Error] = OpenIddictConstants.Errors.UnsupportedGrantType,
+                [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] = "The specified grant type is not supported."
+            }));
     }
 
     private async Task<IActionResult> HandleExchangeCodeAndRefreshGrantTypes()
@@ -514,6 +525,43 @@ public class TokenController : Controller
         identity.SetDestinations(this.GetDestinations);
 
         // Returning a SignInResult will ask OpenIddict to issue the appropriate access/identity tokens.
+        return this.SignIn(new ClaimsPrincipal(identity), OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+    }
+
+    private async Task<IActionResult> HandleExchangeClientCredentialsGrantType(OpenIddictRequest request)
+    {
+        // Note: the client credentials are automatically validated by OpenIddict:
+        // if client_id or client_secret are invalid, this action won't be invoked.
+
+        var application = await _applicationManager.FindByClientIdAsync(request.ClientId);
+        if (application == null)
+        {
+            throw new InvalidOperationException("The application details cannot be found in the database.");
+        }
+
+        // Create the claims-based identity that will be used by OpenIddict to generate tokens.
+        var identity = new ClaimsIdentity(
+            authenticationType: TokenValidationParameters.DefaultAuthenticationType,
+            nameType: OpenIddictConstants.Claims.Name,
+            roleType: OpenIddictConstants.Claims.Role);
+
+        // Add the claims that will be persisted in the tokens (use the client_id as the subject identifier).
+        identity.SetClaim(OpenIddictConstants.Claims.Subject, await _applicationManager.GetClientIdAsync(application));
+        identity.SetClaim(OpenIddictConstants.Claims.Name, await _applicationManager.GetDisplayNameAsync(application));
+
+        // Note: In the original OAuth 2.0 specification, the client credentials grant
+        // doesn't return an identity token, which is an OpenID Connect concept.
+        //
+        // As a non-standardized extension, OpenIddict allows returning an id_token
+        // to convey information about the client application when the "openid" scope
+        // is granted (i.e specified when calling principal.SetScopes()). When the "openid"
+        // scope is not explicitly set, no identity token is returned to the client application.
+
+        // Set the list of scopes granted to the client application in access_token.
+        identity.SetScopes(request.GetScopes());
+        identity.SetResources(await _scopeManager.ListResourcesAsync(identity.GetScopes()).ToListAsync());
+        identity.SetDestinations(GetDestinations);
+
         return this.SignIn(new ClaimsPrincipal(identity), OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
     }
 


### PR DESCRIPTION
When we upgraded to OpenIdDict 4.5 client credentials support was removed in the new reference implementation. Re-adding it to support new features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the token exchange process to support client credentials, enabling new authentication scenarios.
- **Bug Fixes**
	- Enhanced error handling for unsupported grant types, now offering clearer feedback instead of unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->