### PR TITLE
Fix to display Officials only for current provider

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/OfficialService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/OfficialService.cs
@@ -41,7 +41,9 @@ public class OfficialService : IOfficialService
         logger.LogDebug("Getting Officials by filter started.");
 
         filter ??= new SearchStringFilter();
-        var predicate = BuildPredicate(filter);
+        var predicate = BuildPredicate(filter);              
+        predicate = predicate.And(p => p.Position.ProviderId == providerId);
+        
         int count = await officialRepository.Count(predicate).ConfigureAwait(false);
 
         var officials = await officialRepository

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/OfficialServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/OfficialServiceTests.cs
@@ -76,7 +76,7 @@ public class OfficialServiceTests
     public async Task GetByFilter_ReturnsSearchResultWithFilteredListOfOfficials_WhenFilterIsSpecified()
     {
         // Arrange
-        var expected = Officials().FirstOrDefault();
+        var expected = Officials().FirstOrDefault();        
         var filter = new SearchStringFilter()
         {
             SearchString = "TestPosition1"
@@ -116,7 +116,8 @@ public class OfficialServiceTests
                 Position = new Position()
                 {
                     Id = Guid.NewGuid(),
-                    FullName = "TestPosition1"
+                    FullName = "TestPosition1",
+                    ProviderId = providerId
                 },
                 Individual = new Individual()
                 {
@@ -133,7 +134,8 @@ public class OfficialServiceTests
                 Position = new Position()
                 {
                     Id = Guid.NewGuid(),
-                    FullName = "TestPosition2"
+                    FullName = "TestPosition2",
+                    ProviderId = providerId
                 },
                 Individual = new Individual()
                 {

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/OfficialServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/OfficialServiceTests.cs
@@ -76,7 +76,7 @@ public class OfficialServiceTests
     public async Task GetByFilter_ReturnsSearchResultWithFilteredListOfOfficials_WhenFilterIsSpecified()
     {
         // Arrange
-        var expected = Officials().FirstOrDefault();        
+        var expected = Officials().FirstOrDefault();
         var filter = new SearchStringFilter()
         {
             SearchString = "TestPosition1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved search functionality for officials: Officials now appear in listings only if they are linked to the specific provider, ensuring more precise and relevant search results.
- **Bug Fixes**
	- Enhanced test coverage for the `GetByFilter` method to ensure accurate filtering based on provider association.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->