### PR TITLE
Switch from MySQL.Data to MySqlConnector

### DIFF
--- a/OutOfSchool/Directory.Packages.props
+++ b/OutOfSchool/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="OneOf" Version="3.0.263" />
     <!--MySQL-->
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
-    <PackageVersion Include="MySql.Data" Version="8.4.0" />
+    <PackageVersion Include="MySqlConnector" Version="2.4.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.25.2" />
     <!--Elasticsearch-->
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.15.6" />

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/OutOfSchool.AuthorizationServer.csproj
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/OutOfSchool.AuthorizationServer.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="Quartz.Plugins.TimeZoneConverter" />
         <PackageReference Include="Quartz.Serialization.SystemTextJson" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
-        <PackageReference Include="MySql.Data" />
+        <PackageReference Include="MySqlConnector" />
         <PackageReference Include="Elastic.Apm.AspNetCore" />
         <PackageReference Include="Elastic.Apm.EntityFrameworkCore" />
         <PackageReference Include="Elastic.Apm.Elasticsearch" />

--- a/OutOfSchool/OutOfSchool.BusinessLogic/OutOfSchool.BusinessLogic.csproj
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/OutOfSchool.BusinessLogic.csproj
@@ -57,7 +57,6 @@
     <PackageReference Include="Microsoft.FeatureManagement" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
-    <PackageReference Include="MySql.Data" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
     <PackageReference Include="Quartz.AspNetCore" />
     <PackageReference Include="Quartz.Extensions.DependencyInjection" />

--- a/OutOfSchool/OutOfSchool.Migrations/OutOfSchool.Migrations.csproj
+++ b/OutOfSchool/OutOfSchool.Migrations/OutOfSchool.Migrations.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
+    <PackageReference Include="MySqlConnector" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
   </ItemGroup>
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/OutOfSchool.WebApi.Tests.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/OutOfSchool.WebApi.Tests.csproj
@@ -21,7 +21,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="MockQueryable.EntityFrameworkCore" />
-    <PackageReference Include="MySql.Data" />
 	<PackageReference Include="FluentAssertions" />
 	<PackageReference Include="IdentityModel" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />

--- a/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
@@ -53,7 +53,7 @@
         <PackageReference Include="Microsoft.FeatureManagement" />
         <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" />
         <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
-        <PackageReference Include="MySql.Data" />
+        <PackageReference Include="MySqlConnector" />
 		<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
         <PackageReference Include="Quartz.AspNetCore" />
         <PackageReference Include="Quartz.Extensions.DependencyInjection" />


### PR DESCRIPTION
First step for moving from MySQL to MariadDb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the MySQL database connectivity by replacing the previous provider with a new, streamlined connector across various system components. This change simplifies dependency management and may enhance overall performance and reliability for database interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->