### PR TITLE
Fix Quartz use MySqlConnector

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Extensions/QuartzExtension.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Extensions/QuartzExtension.cs
@@ -30,7 +30,7 @@ public static class QuartzExtension
             q.UsePersistentStore(s =>
             {
                 s.UseProperties = true;
-                s.UseMySql(sqlServer =>
+                s.UseMySqlConnector(sqlServer =>
                 {
                     sqlServer.ConnectionString = configuration.GetMySqlConnectionString<QuartzConnectionOptions>(
                         quartzConnectionString,

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/QuartzExtension.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/QuartzExtension.cs
@@ -34,7 +34,7 @@ public static class QuartzExtension
             q.UsePersistentStore(s =>
             {
                 s.UseProperties = true;
-                s.UseMySql(sqlServer =>
+                s.UseMySqlConnector(sqlServer =>
                 {
                     sqlServer.ConnectionString = configuration.GetMySqlConnectionString<QuartzConnectionOptions>(
                         quartzConnectionString,


### PR DESCRIPTION
Did not do `dotnet clean` while testing locally and was testing everything still using `MySql.Data` under the hood.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced MySQL connectivity for scheduling and background operations, using an updated integration method for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->