### PR TITLE
Refactor impossible mappings that are used for testing only

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -156,30 +156,10 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.ActiveFrom, opt => opt.Ignore())
             .ForMember(dest => dest.ActiveTo, opt => opt.Ignore());
 
-        CreateMap<Workshop, WorkshopCreateRequestDto>()
-            .ForMember(
-                dest => dest.Keywords,
-                opt => opt.MapFrom(src => src.Keywords.Split(Constants.MappingSeparator, StringSplitOptions.None)))
-            .ForMember(
-                dest => dest.DirectionIds,
-                opt => opt.MapFrom(src => src.InstitutionHierarchy.Directions.Where(x => !x.IsDeleted).Select(d => d.Id)))
-            .ForMember(dest => dest.InstitutionId, opt => opt.MapFrom(src => src.InstitutionHierarchy.InstitutionId))
-            .ForMember(dest => dest.Teachers, opt => opt.MapFrom(src => src.Teachers.Where(x => !x.IsDeleted)))
-            .ForMember(dest => dest.DateTimeRanges, opt => opt.MapFrom(src => src.DateTimeRanges.Where(x => !x.IsDeleted)))
-            .ForMember(dest => dest.WorkshopDescriptionItems, opt => opt.MapFrom(src => src.WorkshopDescriptionItems.Where(x => !x.IsDeleted)))
-            .ForMember(dest => dest.TagIds, opt => opt.MapFrom(src => src.Tags.Select(tag => tag.Id).ToList()));
-
         CreateMap<WorkshopV2CreateRequestDto, Workshop>()
             .IncludeBase<WorkshopCreateRequestDto, Workshop>()
             .ForMember(dest => dest.Images, opt => opt.Ignore())
             .ForMember(dest => dest.CoverImageId, opt => opt.Ignore());
-
-        CreateMap<Workshop, WorkshopV2CreateRequestDto>()
-            .IncludeBase<Workshop, WorkshopCreateRequestDto>()
-            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(w => w.ExternalStorageId).ToList()))
-            .ForMember(dest => dest.CoverImageId, opt => opt.MapFrom(src => src.CoverImageId))
-            .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())
-            .ForMember(dest => dest.CoverImage, opt => opt.Ignore());
 
         CreateMap<Workshop, WorkshopDto>()
             .IncludeBase<Workshop, WorkshopBaseDto>()
@@ -206,54 +186,18 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.Instagram,
                 opt => opt.MapFrom(src => src.Contacts.FirstOrDefault(c => c.IsDefault).SocialNetworks.FirstOrDefault(s => s.Type == SocialNetworkContactType.Instagram).Url));
 
-        CreateMap<WorkshopDto, Workshop>()
-            .IncludeBase<WorkshopBaseDto, Workshop>();
-
         CreateMap<Workshop, WorkshopV2Dto>()
             .IncludeBase<Workshop, WorkshopDto>()
             .Apply(IgnoreAllImages);
-
-        CreateMap<WorkshopV2Dto, Workshop>()
-            .IncludeBase<WorkshopDto, Workshop>();
-
-        CreateMap<Workshop, WorkshopCreateUpdateDto>()
-            .IncludeBase<Workshop, WorkshopBaseDto>()
-            .ForMember(dest => dest.TagIds, opt => opt.MapFrom(src => src.Tags.Select(tag => tag.Id).ToList()));
-
-        CreateMap<WorkshopDto, WorkshopCreateUpdateDto>()
-            .ForMember(dest => dest.TagIds, opt => opt.MapFrom(src => src.Tags.Select(tag => tag.Id).ToList()));
 
         CreateMap<WorkshopCreateUpdateDto, Workshop>()
             .IncludeBase<WorkshopBaseDto, Workshop>()
             .ForMember(dest => dest.Tags, opt => opt.Ignore());
 
-        CreateMap<WorkshopCreateUpdateDto, WorkshopDto>()
-            .ForMember(dest => dest.Tags, opt => opt.MapFrom(src =>
-                src.TagIds.Select(id => new TagDto {Id = id}).ToList()))
-            .ForMember(dest => dest.TakenSeats, opt => opt.Ignore())
-            .ForMember(dest => dest.Rating, opt => opt.Ignore())
-            .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
-            .ForMember(dest => dest.ImageIds, opt => opt.Ignore())
-            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore())
-            .ForMember(dest => dest.Status, opt => opt.Ignore())
-            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
-            .ForMember(dest => dest.ProviderOwnership, opt => opt.Ignore())
-            .ForMember(dest => dest.ProviderStatus, opt => opt.Ignore())
-            
-            // TODO: Remove
-            .ForMember(dest => dest.Phone, opt => opt.Ignore())
-            .ForMember(dest => dest.Email, opt => opt.Ignore())
-            .ForMember(dest => dest.Website, opt => opt.Ignore())
-            .ForMember(dest => dest.Facebook, opt => opt.Ignore())
-            .ForMember(dest => dest.Instagram, opt => opt.Ignore())
-            .ForMember(dest => dest.Address, opt => opt.Ignore());
-
         // TODO: Remove when fully refactor addresses
         CreateMap<ContactsAddress, AddressDto>()
             .ForMember(dest => dest.Id, opt => opt.Ignore())
             .ForMember(dest => dest.CodeficatorAddressDto, opt => opt.MapFrom(src => src.CATOTTG));
-        
-        CreateMap<WorkshopCreateUpdateDto, IHasRating>();
 
         CreateMap<WorkshopDescriptionItem, WorkshopDescriptionItemDto>().ReverseMap();
 
@@ -294,8 +238,6 @@ public class MappingProfile : Profile
         CreateMap<SocialGroup, SocialGroupDto>()
             .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name));
 
-        CreateMap<SocialGroup, SocialGroupCreate>();
-
         CreateMap<SocialGroupCreate, SocialGroup>()
             .ForMember(dest => dest.IsDeleted, opt => opt.Ignore())
             .ForMember(dest => dest.Children, opt => opt.Ignore());
@@ -329,17 +271,6 @@ public class MappingProfile : Profile
             .IncludeBase<object, IHasRating>()
             .ForMember(dest => dest.ProviderSectionItems, opt => opt.MapFrom(src => src.ProviderSectionItems.Where(x => !x.IsDeleted)));
 
-        CreateSoftDeletedMap<ProviderDto, Provider>()
-            .Apply(IgnoreCommonProviderBaseDto2Provider)
-            .ForMember(dest => dest.Workshops, opt => opt.Ignore())
-            .ForMember(dest => dest.User, opt => opt.Ignore())
-            .ForMember(dest => dest.InstitutionStatus, opt => opt.Ignore())
-            .ForMember(dest => dest.Images, opt => opt.Ignore())
-            .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
-            .ForMember(dest => dest.Employees, opt => opt.Ignore())
-            .ForMember(dest => dest.Positions, opt => opt.Ignore())
-            .ForMember(dest => dest.WorkshopDrafts, opt => opt.Ignore());
-
         CreateSoftDeletedMap<ProviderUpdateDto, Provider>()
             .Apply(IgnoreCommonProviderBaseDto2Provider)
             .ForMember(dest => dest.Ownership, opt => opt.Ignore())
@@ -355,9 +286,6 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.Positions, opt => opt.Ignore())
             .ForMember(dest => dest.WorkshopDrafts, opt => opt.Ignore()); 
 
-        CreateMap<Provider, ProviderUpdateDto>()
-            .Apply(AddCommonProvider2ProviderBaseDto);
-
         CreateMap<Provider, ProviderCsvDto>()
             .ForMember(dest => dest.Ownership, opt => opt.MapFrom((dest, src) => dest.Ownership switch
             {
@@ -369,8 +297,6 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.License, opt => opt.MapFrom(src => string.IsNullOrWhiteSpace(src.License) ? "не вказано" : src.License))
             .ForMember(dest => dest.Settlement, opt => opt.MapFrom(src => CatottgAddressExtensions.GetSettlementName(src.LegalAddress.CATOTTG)))
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => $"{src.LegalAddress.Street}, {src.LegalAddress.BuildingNumber}"));
-
-        CreateMap<ProviderDto, ProviderUpdateDto>();
 
         CreateSoftDeletedMap<ProviderCreateDto, Provider>()
             .Apply(IgnoreCommonProviderBaseDto2Provider)
@@ -385,17 +311,6 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
             .ForMember(dest => dest.Positions, opt => opt.Ignore())
             .ForMember(dest => dest.WorkshopDrafts, opt => opt.Ignore());
-
-        CreateMap<Provider, ProviderCreateDto>()
-            .Apply(AddCommonProvider2ProviderBaseDto);
-
-        CreateMap<ProviderCreateDto, ProviderDto>()
-            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
-            .ForMember(dest => dest.BlockReason, opt => opt.Ignore())
-            .IncludeBase<object, IHasRating>()
-            .ForMember(dest => dest.BlockPhoneNumber, opt => opt.Ignore())
-            .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())
-            .ForMember(dest => dest.ImageIds, opt => opt.Ignore());
 
         CreateSoftDeletedMap<TeacherDTO, Teacher>()
             .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
@@ -471,6 +386,7 @@ public class MappingProfile : Profile
             .ForMember(c => c.Achievements, m => m.Ignore())
             .ForMember(c => c.SocialGroups, m => m.Ignore());
 
+        // TODO: Check this mapping
         CreateMap<Parent, ParentDTO>().ReverseMap();
 
         CreateMap<ParentCreateDto, Parent>()
@@ -533,6 +449,7 @@ public class MappingProfile : Profile
         CreateMap<Direction, DirectionDto>()
             .ForMember(dest => dest.WorkshopsCount, opt => opt.Ignore());
 
+        // TODO: Check this mapping
         CreateMap<CreateEmployeeDto, CreateProviderAdminRequest>()
             .ForMember(dest => dest.RequestId, opt => opt.Ignore())
             .ForMember(c => c.CreatingTime, m => m.MapFrom(c => Timestamp.FromDateTimeOffset(c.CreatingTime)))
@@ -540,6 +457,7 @@ public class MappingProfile : Profile
             .ForMember(c => c.ManagedWorkshopIds, m => m.MapFrom(src => src.ManagedWorkshopIds.Select(id => id.ToString()).ToList()))
             .ForMember(c => c.IsDeputy, m => m.Ignore()); // TODO: remove this property from CreateProviderAdminRequest (generated by GRPC)
 
+        // TODO: Check this mapping
         CreateMap<CreateProviderAdminReply, CreateEmployeeDto>()
             .ForMember(c => c.CreatingTime, m => m.MapFrom(c => c.CreatingTime.ToDateTimeOffset()))
             .ForMember(c => c.ProviderId, m => m.MapFrom(c => Guid.Parse(c.ProviderId)))
@@ -550,6 +468,7 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.DateOfBirth, opt => opt.Ignore())
             .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.MiddleName ?? string.Empty));
 
+        // TODO: Check this mapping
         CreateSoftDeletedMap<ShortUserDto, User>()
             .IncludeBase<BaseUserDto, User>()
             .ForMember(dest => dest.Email, opt => opt.Ignore());
@@ -857,9 +776,6 @@ public class MappingProfile : Profile
                     .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
                     .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
                     .ForMember(dest => dest.DeleteDate, opt => opt.Ignore());
-
-        CreateMap<Individual, UploadEmployeeRequestDto>()
-                    .ForMember(dest => dest.AssignedRole, opt => opt.Ignore());
 
         CreateMap<PositionCreateUpdateDto, Position>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/WorkshopRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/WorkshopRepository.cs
@@ -28,7 +28,17 @@ public class WorkshopRepository : SensitiveEntityRepositorySoftDeleted<Workshop>
             .Include(ws => ws.Teachers)
             .Include(ws => ws.DateTimeRanges)
             .Include(ws => ws.Images)
-            .Include(ws => ws.Tags);
+            .Include(ws => ws.Tags)
+            .Include(ws => ws.Contacts).ThenInclude(c => c.Emails)
+            .Include(ws => ws.Contacts).ThenInclude(c => c.Phones)
+            .Include(ws => ws.Contacts).ThenInclude(c => c.SocialNetworks)
+            .Include(ws => ws.Contacts)
+            .ThenInclude(c => c.Address)
+            .ThenInclude(a => a.CATOTTG)
+            .ThenInclude(c => c.Parent)
+            .ThenInclude(c => c.Parent)
+            .ThenInclude(c => c.Parent)
+            .ThenInclude(c => c.Parent);
 
         if (asNoTracking)
         {

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllersTests/ProviderControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ProviderControllersTests/ProviderControllerTests.cs
@@ -44,7 +44,7 @@ public class ProviderControllerTests
     [SetUp]
     public void Setup()
     {
-        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, TestMappingProfile, MappingProfile>();
         userId = Guid.NewGuid().ToString();
 
         providerService = new Mock<IProviderService>();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -72,7 +72,7 @@ public class WorkshopControllerTests
             .Returns(new Claim(ClaimTypes.NameIdentifier, userId));
         httpContextMoq.Setup(x => x.User.IsInRole("provider"))
             .Returns(true);
-        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, TestMappingProfile, MappingProfile>();
 
         workshops = WorkshopDtoGenerator.Generate(5);
         workshop = WorkshopDtoGenerator.Generate();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerV2Tests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerV2Tests.cs
@@ -66,7 +66,7 @@ public class WorkshopControllerV2Tests
             .Returns(new Claim(ClaimTypes.NameIdentifier, userId));
         httpContextMoq.Setup(x => x.User.IsInRole("provider"))
             .Returns(true);
-        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, TestMappingProfile, MappingProfile>();
         workshops = WorkshopV2DtoGenerator.Generate(5);
         provider = ProviderDtoGenerator.Generate();
         workshopCreateDto = WorkshopV2DtoGenerator.Generate();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -70,7 +70,7 @@ public class WorkshopServiceTests
         logger = new Mock<ILogger<WorkshopService>>();
         mapperMock = new Mock<IMapper>();
         workshopImagesMediator = new Mock<IImageDependentEntityImagesInteractionService<Workshop>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, ContactsProfile, MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, ContactsProfile, TestMappingProfile, MappingProfile>();
         providerAdminRepository = new Mock<IEmployeeRepository>();
         averageRatingServiceMock = new Mock<IAverageRatingService>();
         providerRepositoryMock = new Mock<IProviderRepository>();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServiceTests.cs
@@ -104,7 +104,7 @@ public class ProviderServiceTests
 
         var authorizationServerConfig = Options.Create(new AuthorizationServerConfig { Authority = new Uri("http://test.com") });
 
-        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, TestMappingProfile, MappingProfile>();
         var searchStringServiceMock = new Mock<ISearchStringService>();
 
         providerService = new ProviderService(

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServicesTests/ProviderServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServicesTests/ProviderServiceTests.cs
@@ -106,7 +106,7 @@ public class ProviderServiceTests
         workshopServicesCombinerMock = new Mock<IWorkshopServicesCombiner>();
 
         var authorizationServerConfig = Options.Create(new AuthorizationServerConfig { Authority = new Uri("http://test.com") });
-        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, TestMappingProfile, MappingProfile>();
         searchStringServiceMock = new Mock<ISearchStringService>();
 
         providerService = new ProviderService(

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServicesTests/ProviderServiceV2Tests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ProviderServicesTests/ProviderServiceV2Tests.cs
@@ -99,7 +99,7 @@ public class ProviderServiceV2Tests
         providerImagesService = new Mock<IImageDependentEntityImagesInteractionService<Provider>>();
 
         var authorizationServerConfig = Options.Create(new AuthorizationServerConfig { Authority = new Uri("http://test.com") });
-        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, TestMappingProfile, MappingProfile>();
         var searchStringServiceMock = new Mock<ISearchStringService>();
 
         providerService = new ProviderServiceV2(

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerTests.cs
@@ -42,7 +42,7 @@ public class WorkshopServicesCombinerTests
     {
         workshopService = new Mock<IWorkshopService>();
         elasticsearchSynchronizationService = new Mock<IElasticsearchSynchronizationService<IWorkshopService, Workshop>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, TestMappingProfile, MappingProfile>();
 
         favoriteRepository = new Mock<IEntityRepositorySoftDeleted<long, Favorite>>();
         applicationRepository = new Mock<IApplicationRepository>();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerV2Tests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopServicesCombinerV2Tests.cs
@@ -43,7 +43,7 @@ public class WorkshopServicesCombinerV2Tests
         var regionAdminService = new Mock<IRegionAdminService>();
         var codeficatorService = new Mock<ICodeficatorService>();
         var esProvider = new Mock<IElasticsearchProvider<WorkshopES, WorkshopFilterES>>();
-        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, MappingProfile>();
+        mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, TestMappingProfile, MappingProfile>();
 
         service = new WorkshopServicesCombinerV2(
             workshopService.Object,

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestHelper.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using NUnit.Framework;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
 using OutOfSchool.Common.Extensions;
 
 namespace OutOfSchool.Tests.Common;
@@ -36,6 +36,17 @@ public static class TestHelper
     {
         var config = new MapperConfiguration(cfg =>
             cfg.UseProfile<TProfile1>().UseProfile<TProfile2>().UseProfile<TProfile3>());
+        return config.CreateMapper();
+    }
+    
+    public static IMapper CreateMapperInstanceOfProfileTypes<TProfile1, TProfile2, TProfile3, TProfile4>()
+        where TProfile1 : Profile, new()
+        where TProfile2 : Profile, new()
+        where TProfile3 : Profile, new()
+        where TProfile4 : Profile, new()
+    {
+        var config = new MapperConfiguration(cfg =>
+            cfg.UseProfile<TProfile1>().UseProfile<TProfile2>().UseProfile<TProfile3>().UseProfile<TProfile4>());
         return config.CreateMapper();
     }
 

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestMappingProfile.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestMappingProfile.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Linq;
+using AutoMapper;
+using OutOfSchool.BusinessLogic.Models;
+using OutOfSchool.BusinessLogic.Models.Providers;
+using OutOfSchool.BusinessLogic.Models.Tag;
+using OutOfSchool.BusinessLogic.Models.Workshops;
+using OutOfSchool.Common;
+using OutOfSchool.Common.Extensions;
+using OutOfSchool.Common.Models;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Services.Models.Images;
+
+namespace OutOfSchool.Tests.Common;
+
+// This mapping profile is created to extract wrong mappings that were created to make testing easier
+// It does not include Elastic search mappings, need to review those separately
+// TODO: Need to refactor tests that use mappings in this file
+public class TestMappingProfile : Profile
+{
+    public TestMappingProfile()
+    {
+        // User in OutOfSchool.WebApi.IntegrationTests.ProviderServiceIntergrationTests.
+        // Used in OutOfSchool.WebApi.Tests.Controllers.ProviderControllersTests.ProviderControllerTests
+        // Used in OutOfSchool.WebApi.Tests.Services.ProviderServicesTests.ProviderServiceV2Tests
+        // Used in OutOfSchool.WebApi.Tests.Services.ProviderServicesTests.ProviderServiceTests
+        CreateMap<Provider, ProviderUpdateDto>()
+            .Apply(AddCommonProvider2ProviderBaseDto);
+        // Used in OutOfSchool.WebApi.Tests.Controllers.ProviderControllersTests.ProviderControllerTests
+        // Used in OutOfSchool.WebApi.Tests.Services.ProviderServicesTests.ProviderServiceV2Tests
+        // Used in OutOfSchool.WebApi.Tests.Services.ProviderServicesTests.ProviderServiceTests
+        CreateMap<Provider, ProviderCreateDto>()
+            .Apply(AddCommonProvider2ProviderBaseDto);
+        
+        // Used in OutOfSchool.WebApi.Tests.Controllers.WorkshopControllerV2Tests
+        CreateMap<Workshop, WorkshopV2CreateRequestDto>()
+            .IncludeBase<Workshop, WorkshopCreateRequestDto>()
+            .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())
+            .ForMember(dest => dest.CoverImage, opt => opt.Ignore());
+
+        // Used in OutOfSchool.WebApi.Tests.Controllers.WorkshopControllerTests
+        // Used in OutOfSchool.WebApi.Tests.Services.WorkshopServicesCombinerTests
+        CreateMap<Workshop, WorkshopCreateRequestDto>()
+            .ForMember(
+                dest => dest.Keywords,
+                opt => opt.MapFrom(src => src.Keywords.Split(Constants.MappingSeparator, StringSplitOptions.None)))
+            .ForMember(
+                dest => dest.DirectionIds,
+                opt => opt.MapFrom(
+                    src => src.InstitutionHierarchy.Directions.Where(x => !x.IsDeleted).Select(d => d.Id)))
+            .ForMember(dest => dest.InstitutionId, opt => opt.MapFrom(src => src.InstitutionHierarchy.InstitutionId))
+            .ForMember(dest => dest.Teachers, opt => opt.MapFrom(src => src.Teachers.Where(x => !x.IsDeleted)))
+            .ForMember(dest => dest.DateTimeRanges,
+                opt => opt.MapFrom(src => src.DateTimeRanges.Where(x => !x.IsDeleted)))
+            .ForMember(dest => dest.WorkshopDescriptionItems,
+                opt => opt.MapFrom(src => src.WorkshopDescriptionItems.Where(x => !x.IsDeleted)))
+            .ForMember(dest => dest.TagIds, opt => opt.MapFrom(src => src.Tags.Select(tag => tag.Id).ToList()));
+
+        // Used in OutOfSchool.WebApi.Tests.Services.WorkshopServicesCombinerTests
+        CreateMap<WorkshopCreateUpdateDto, IHasRating>();
+        
+        // Used in OutOfSchool.WebApi.Tests.Services.WorkshopServiceTests
+        CreateMap<Workshop, WorkshopCreateUpdateDto>()
+            .IncludeBase<Workshop, WorkshopBaseDto>()
+            .ForMember(dest => dest.TagIds, opt => opt.MapFrom(src => src.Tags.Select(tag => tag.Id).ToList()));
+        
+        // Used in OutOfSchool.WebApi.Tests.Services.WorkshopServicesCombinerTests
+        CreateMap<WorkshopCreateUpdateDto, WorkshopDto>()
+            .ForMember(dest => dest.Tags, opt => opt.MapFrom(src =>
+                src.TagIds.Select(id => new TagDto {Id = id}).ToList()))
+            .ForMember(dest => dest.TakenSeats, opt => opt.Ignore())
+            .ForMember(dest => dest.Rating, opt => opt.Ignore())
+            .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
+            .ForMember(dest => dest.ImageIds, opt => opt.Ignore())
+            .ForMember(dest => dest.NumberOfRatings, opt => opt.Ignore())
+            .ForMember(dest => dest.Status, opt => opt.Ignore())
+            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
+            .ForMember(dest => dest.ProviderOwnership, opt => opt.Ignore())
+            .ForMember(dest => dest.ProviderStatus, opt => opt.Ignore())
+        
+            // TODO: Remove
+            .ForMember(dest => dest.Phone, opt => opt.Ignore())
+            .ForMember(dest => dest.Email, opt => opt.Ignore())
+            .ForMember(dest => dest.Website, opt => opt.Ignore())
+            .ForMember(dest => dest.Facebook, opt => opt.Ignore())
+            .ForMember(dest => dest.Instagram, opt => opt.Ignore())
+            .ForMember(dest => dest.Address, opt => opt.Ignore());
+
+        // Used in OutOfSchool.WebApi.Tests.Services.ProviderServicesTests.ProviderServiceTests
+        // Used in OutOfSchool.WebApi.Tests.Services.ProviderServicesTests.ProviderServiceV2Tests
+        CreateSoftDeletedMap<ProviderDto, Provider>()
+            .Apply(IgnoreCommonProviderBaseDto2Provider)
+            .ForMember(dest => dest.Workshops, opt => opt.Ignore())
+            .ForMember(dest => dest.User, opt => opt.Ignore())
+            .ForMember(dest => dest.InstitutionStatus, opt => opt.Ignore())
+            .ForMember(dest => dest.Images, opt => opt.Ignore())
+            .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.Employees, opt => opt.Ignore())
+            .ForMember(dest => dest.Positions, opt => opt.Ignore())
+            .ForMember(dest => dest.WorkshopDrafts, opt => opt.Ignore());
+
+        // Used in OutOfSchool.WebApi.Tests.Services.ProviderServicesTests.ProviderServiceTests
+        // Used in OutOfSchool.WebApi.Tests.Services.ProviderServicesTests.ProviderServiceV2Tests
+        CreateMap<ProviderDto, ProviderUpdateDto>();
+
+        // Used in OutOfSchool.WebApi.Tests.Services.ProviderServicesTests.ProviderServiceTests
+        // Used in OutOfSchool.WebApi.Tests.Services.ProviderServicesTests.ProviderServiceV2Tests
+        CreateMap<ProviderCreateDto, ProviderDto>()
+            .ForMember(dest => dest.IsBlocked, opt => opt.Ignore())
+            .ForMember(dest => dest.BlockReason, opt => opt.Ignore())
+            .IncludeBase<object, IHasRating>()
+            .ForMember(dest => dest.BlockPhoneNumber, opt => opt.Ignore())
+            .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())
+            .ForMember(dest => dest.ImageIds, opt => opt.Ignore());
+        
+        // TODO: These impossible mappings are not used in tests. Leave commented for one PR
+        // TODO: Remove only if they are not used in real code
+        // CreateMap<Individual, UploadEmployeeRequestDto>()
+        //     .ForMember(dest => dest.AssignedRole, opt => opt.Ignore());
+        // CreateMap<SocialGroup, SocialGroupCreate>();
+        // CreateMap<WorkshopDto, WorkshopCreateUpdateDto>()
+        //     .ForMember(dest => dest.TagIds, opt => opt.MapFrom(src => src.Tags.Select(tag => tag.Id).ToList()));
+        // CreateMap<Workshop, WorkshopV2CreateRequestDto>()
+        //     .IncludeBase<Workshop, WorkshopCreateRequestDto>()
+        //     .ForMember(dest => dest.ImageIds,
+        //         opt => opt.MapFrom(src => src.Images.Select(w => w.ExternalStorageId).ToList()))
+        //     .ForMember(dest => dest.CoverImageId, opt => opt.MapFrom(src => src.CoverImageId))
+        //     .ForMember(dest => dest.ImageFiles, opt => opt.Ignore())
+        //     .ForMember(dest => dest.CoverImage, opt => opt.Ignore());
+        // CreateMap<WorkshopDto, Workshop>()
+        //     .IncludeBase<WorkshopBaseDto, Workshop>();
+        // CreateMap<WorkshopV2Dto, Workshop>()
+        //     .IncludeBase<WorkshopDto, Workshop>();
+    }
+
+    private IMappingExpression<Provider, T> AddCommonProvider2ProviderBaseDto<T>(
+        IMappingExpression<Provider, T> mappings)
+        where T : ProviderBaseDto
+        => mappings
+            .ForMember(dest => dest.ActualAddress, opt => opt.MapFrom(src => src.ActualAddress))
+            .ForMember(dest => dest.LegalAddress, opt => opt.MapFrom(src => src.LegalAddress))
+            .ForMember(dest => dest.Institution, opt => opt.MapFrom(src => src.Institution))
+            .Apply(IgnoreAllImages)
+            .Apply(MapImageIds);
+
+    private IMappingExpression<TSource, TDestination> IgnoreAllImages<TSource, TDestination>(
+        IMappingExpression<TSource, TDestination> mappings)
+        where TDestination : IHasCoverImage, IHasImages
+        => mappings
+            .ForMember(dest => dest.CoverImage, opt => opt.Ignore())
+            .ForMember(dest => dest.ImageFiles, opt => opt.Ignore());
+
+    private IMappingExpression<TSource, TDestination> MapImageIds<TSource, TDestination>(
+        IMappingExpression<TSource, TDestination> mappings)
+        where TSource : class, IHasEntityImages<TSource>
+        where TDestination : class, IHasImages
+        => mappings
+            .ForMember(dest => dest.ImageIds, opt => opt.MapFrom(src => src.Images.Select(x => x.ExternalStorageId)));
+
+    public IMappingExpression<TSource, TDestination> CreateSoftDeletedMap<TSource, TDestination>()
+        where TSource : class
+        where TDestination : class, ISoftDeleted
+        => CreateMap<TSource, TDestination>()
+            .ForMember(dest => dest.IsDeleted, opt => opt.Ignore());
+
+    private IMappingExpression<T, Provider> IgnoreCommonProviderBaseDto2Provider<T>(
+        IMappingExpression<T, Provider> mappings)
+        where T : ProviderBaseDto
+        => mappings
+            .ForMember(dest => dest.Institution, opt => opt.Ignore())
+            .ForMember(dest => dest.CoverImageId, opt => opt.Ignore())
+            .ForMember(dest => dest.Status, opt => opt.Ignore())
+            .ForMember(dest => dest.StatusReason, opt => opt.Ignore())
+            .ForMember(dest => dest.LicenseStatus, opt => opt.Ignore());
+}

--- a/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/ProviderServiceIntergrationTests/ProviderServiceUpdate.cs
+++ b/OutOfSchool/Tests/OutOfSchool.WebApi.IntegrationTests/ProviderServiceIntergrationTests/ProviderServiceUpdate.cs
@@ -19,13 +19,13 @@ using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.BusinessLogic.Util;
 using OutOfSchool.BusinessLogic.Util.Mapping;
 using OutOfSchool.Common.Communication.ICommunication;
-using OutOfSchool.Common.Extensions;
 using OutOfSchool.Services;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Repository;
 using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.Services.Repository.Base.Api;
 using OutOfSchool.Tests;
+using OutOfSchool.Tests.Common;
 using OutOfSchool.Tests.Common.DbContextTests;
 using OutOfSchool.Tests.Common.TestDataGenerators;
 
@@ -36,7 +36,7 @@ public class ProviderServiceUpdate
 {
     private IProviderService providerService;
 
-    private Mapper mapper;
+    private IMapper mapper;
     private DbContextOptions<OutOfSchoolDbContext> unitTestDbOptions;
 
     private TestOutOfSchoolDbContext GetContext() => new TestOutOfSchoolDbContext(this.unitTestDbOptions);
@@ -54,7 +54,7 @@ public class ProviderServiceUpdate
             await context.SaveChangesAsync();
         }
 
-        this.mapper = new Mapper(new MapperConfiguration(cfg => cfg.UseProfile<CommonProfile>().UseProfile<MappingProfile>()));
+        this.mapper = TestHelper.CreateMapperInstanceOfProfileTypes<CommonProfile, TestMappingProfile, MappingProfile>();
 
         var localizer = new Mock<IStringLocalizer<SharedResource>>();
         var logger = new Mock<ILogger<ProviderService>>();


### PR DESCRIPTION
Removed some mappings that should never be used in business logic and were created for testing purposes to dedicated testing mapper. Need to rethink the testing approach later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal data transformation logic for improved efficiency and maintainability.
  - Removed obsolete mapping configurations to simplify internal processes and reduce complexity.

- **Tests**
  - Enhanced test setups with an expanded configuration to ensure robust and consistent data handling during quality checks.
  - Updated test mappings to include a new profile for improved testing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->