### PR TITLE
Reviewed lazy/eager loading in ChildService and SocialGroupService

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Child/ChildBaseDTO.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Child/ChildBaseDTO.cs
@@ -31,7 +31,5 @@ public class ChildBaseDto
     [MaxLength(500)]
     public string PlaceOfStudy { get; set; } = string.Empty;
 
-    public Guid ParentId { get; set; } = default;
-
     public bool IsParent { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Child/ChildDTO.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Child/ChildDTO.cs
@@ -6,7 +6,7 @@ public class ChildDto : ChildBaseDto
 {
     public Guid Id { get; set; }
 
-    public Guid ParentId { get; set; } = default;
+    public Guid ParentId { get; set; } = Guid.Empty;
 
     public ParentDtoWithContactInfo Parent{ get; set; }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Child/ChildDTO.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Child/ChildDTO.cs
@@ -6,6 +6,8 @@ public class ChildDto : ChildBaseDto
 {
     public Guid Id { get; set; }
 
+    public Guid ParentId { get; set; } = default;
+
     public ParentDtoWithContactInfo Parent{ get; set; }
 
     public List<SocialGroupDto> SocialGroups { get; set; }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -155,13 +155,13 @@ public class ChildService : IChildService
             {
                 children.ChildrenCreationResults.Add(CreateChildResult(childCreateDto, false, ex.Message));
                 logger.LogDebug(
-                    "There is an error while creating a new child with {ParentId}:{Id}, {UserId}:{Id}: {ExceptionMessage}.", nameof(Child.ParentId), parent.Id, nameof(userId), userId, ex.Message);
+                    "There is an error while creating a new child with {ParentId}:{parentId}, {UserId}:{userId}: {ExceptionMessage}.", nameof(Child.ParentId), parent.Id, nameof(userId), userId, ex.Message);
             }
             catch (Exception ex)
             {
                 children.ChildrenCreationResults.Add(CreateChildResult(childCreateDto, false));
                 logger.LogDebug(
-                    "There is an error while creating a new child with {ParentId}:{Id}, {UserId}:{Id}: {ExceptionMessage}.", nameof(Child.ParentId), parent.Id, nameof(userId), userId, ex.Message);
+                    "There is an error while creating a new child with {ParentId}:{parentId}, {UserId}:{userId}: {ExceptionMessage}.", nameof(Child.ParentId), parent.Id, nameof(userId), userId, ex.Message);
             }
         }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -65,6 +65,7 @@ public class ChildService : IChildService
         logger.LogDebug(
             $"Started creation of a new child with {nameof(Child.ParentId)}:{childCreateDto.ParentId}, {nameof(userId)}:{userId}.");
 
+        // No nested entities in use – eager loading not required.
         var parent =
             (await parentRepository.GetByFilter(p => p.UserId == userId).ConfigureAwait(false)).SingleOrDefault()
             ?? throw new UnauthorizedAccessException(
@@ -109,6 +110,7 @@ public class ChildService : IChildService
     /// <inheritdoc/>
     public async Task<ChildrenCreationResultDto> CreateChildrenForUser(List<ChildCreateDto> childrenCreateDtos, string userId)
     {
+        // No nested entities in use – eager loading not required.
         var parent = (await parentRepository
             .GetByFilter(p => p.UserId == userId)
             .ConfigureAwait(false))
@@ -191,14 +193,14 @@ public class ChildService : IChildService
             { x => x.Id, SortDirection.Ascending },
         };
 
-        var includedFunc = (IQueryable<Child> p) => p.Include(p => p.SocialGroups)
-                                                     .Include(p => p.Parent).ThenInclude(p => p.User);
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.SocialGroups)
+                                                    .Include(c => c.Parent).ThenInclude(p => p.User);
 
         var children = await childRepository
             .Get(
                  skip: filter.From,
                  take: filter.Size,
-                 includeExpression: includedFunc,
+                 includeExpression: includeFunc,
                  whereExpression: filterPredicate,
                  orderBy: sortExpression,
                  asNoTracking: true)
@@ -230,6 +232,7 @@ public class ChildService : IChildService
             func = func.And(child => child.IsParent == isParent);
         }
 
+        // No nested entities in use – eager loading not required.
         var children = await childRepository.GetByFilter(func).ConfigureAwait(false);
         var result = mapper.Map<List<ShortEntityDto>>(children).OrderBy(entity => entity.Title).ToList();
 
@@ -243,8 +246,10 @@ public class ChildService : IChildService
 
         logger.LogDebug($"User:{userId} is trying to get the child with id: {id}.");
 
-        var child = (await childRepository.GetByFilter(child => child.Id == id, $"{nameof(Child.Parent)}")
-                        .ConfigureAwait(false)).SingleOrDefault()
+        var child = (await childRepository.GetByFilter(
+                        whereExpression: c => c.Id == id,
+                        includeExpression: (IQueryable<Child> c) => c.Include(c => c.Parent))
+                    .ConfigureAwait(false)).SingleOrDefault()
                     ?? throw new UnauthorizedAccessException(
                         $"User:{userId} is trying to get an unexisting child with id: {id}.");
 
@@ -278,7 +283,7 @@ public class ChildService : IChildService
             .Get(
                  skip: offsetFilter.From,
                  take: offsetFilter.Size,
-                 includeProperties: "SocialGroups", 
+                 includeExpression: (IQueryable<Child> c) => c.Include(c => c.SocialGroups),
                  whereExpression: x => x.ParentId == parentId,
                  orderBy: sortExpression)
             .ToListAsync()
@@ -319,11 +324,12 @@ public class ChildService : IChildService
             { x => x.FirstName, SortDirection.Ascending },
         };
 
+        // No nested entities in use – eager loading not required.
         var children = await childRepository
             .Get(
-                 skip: offsetFilter.From, 
+                 skip: offsetFilter.From,
                  take: offsetFilter.Size,
-                 whereExpression: predicate, 
+                 whereExpression: predicate,
                  orderBy: sortExpression)
             .ToListAsync()
             .ConfigureAwait(false);
@@ -349,6 +355,7 @@ public class ChildService : IChildService
         logger.LogDebug(
             $"Getting Children by WorkshopId: {workshopId} started. Amount of children to take: {offsetFilter.Size}, skip first: {offsetFilter.From}.");
 
+        // No nested entities in use – eager loading not required.
         var applications = await applicationRepository
             .GetByFilter(p => p.WorkshopId == workshopId && (p.Status == ApplicationStatus.Approved || p.Status == ApplicationStatus.StudyingForYears))
             .ConfigureAwait(false);
@@ -361,11 +368,12 @@ public class ChildService : IChildService
             { x => x.FirstName, SortDirection.Ascending },
         };
 
+        // No nested entities in use – eager loading not required.
         var children = await childRepository
             .Get(
-                 skip: offsetFilter.From, 
-                 take: offsetFilter.Size, 
-                 whereExpression: x => childrenGuids.Contains(x.Id), 
+                 skip: offsetFilter.From,
+                 take: offsetFilter.Size,
+                 whereExpression: x => childrenGuids.Contains(x.Id),
                  orderBy: sortExpression)
             .ToListAsync()
             .ConfigureAwait(false);
@@ -392,7 +400,9 @@ public class ChildService : IChildService
         logger.LogDebug($"Updating the child with Id: {childId} and {nameof(userId)}: {userId} started.");
 
         var child = (await childRepository
-                        .GetByFilter(c => c.Id == childId, $"{nameof(Child.Parent)},{nameof(Child.SocialGroups)}")
+                        .GetByFilter(
+                            whereExpression: c => c.Id == childId,
+                            includeExpression: (IQueryable<Child> c) => c.Include(c => c.Parent).Include(c => c.SocialGroups))
                         .ConfigureAwait(false)).SingleOrDefault()
                     ?? throw new InvalidOperationException(
                         $"User: {userId} is trying to update not existing Child (Id = {childId}).");
@@ -433,9 +443,11 @@ public class ChildService : IChildService
 
         logger.LogDebug($"Deleting the child with Id: {id} and {nameof(userId)}: {userId} started.");
 
-        var child = await childRepository.GetByFilterNoTracking(c => c.Id == id, $"{nameof(Child.Parent)}")
-                        .SingleOrDefaultAsync()
-                        .ConfigureAwait(false)
+        var child = await childRepository.GetByFilterNoTracking(
+                                            whereExpression: c => c.Id == id,
+                                            includeExpression: (IQueryable<Child> c) => c.Include(c => c.Parent))
+                                         .SingleOrDefaultAsync()
+                                         .ConfigureAwait(false)
                     ?? throw new UnauthorizedAccessException(
                         $"User: {userId} is trying to delete not existing Child (Id = {id}).");
 
@@ -538,6 +550,7 @@ public class ChildService : IChildService
         {
             if (!new HashSet<long>(child.SocialGroups.Select(x => x.Id)).SetEquals(socialGroupIds))
             {
+                // No nested entities in use – eager loading not required.
                 var socialGroups = (await socialGroupRepository
                     .GetByFilter(x => socialGroupIds.Contains(x.Id))).ToList();
                 if (socialGroupIds.Count != socialGroups.Count)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -274,6 +274,8 @@ public class ChildService : IChildService
 
         var totalAmount = await childRepository.Count(x => x.ParentId == parentId).ConfigureAwait(false);
 
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.SocialGroups);
+
         var sortExpression = new Dictionary<Expression<Func<Child, object>>, SortDirection>
         {
             { x => x.FirstName, SortDirection.Ascending },
@@ -283,7 +285,7 @@ public class ChildService : IChildService
             .Get(
                  skip: offsetFilter.From,
                  take: offsetFilter.Size,
-                 includeExpression: (IQueryable<Child> c) => c.Include(c => c.SocialGroups),
+                 includeExpression: includeFunc,
                  whereExpression: x => x.ParentId == parentId,
                  orderBy: sortExpression)
             .ToListAsync()

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -322,6 +322,9 @@ public class ChildService : IChildService
             predicate = predicate.And(x => !x.IsParent);
         }
 
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.SocialGroups)
+                                                    .Include(c => c.Parent).ThenInclude(p => p.User);
+
         var totalAmount = await childRepository.Count(predicate).ConfigureAwait(false);
 
         var sortExpression = new Dictionary<Expression<Func<Child, object>>, SortDirection>
@@ -335,6 +338,7 @@ public class ChildService : IChildService
                  skip: offsetFilter.From,
                  take: offsetFilter.Size,
                  whereExpression: predicate,
+                 includeExpression: includeFunc,
                  orderBy: sortExpression)
             .ToListAsync()
             .ConfigureAwait(false);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -246,9 +246,11 @@ public class ChildService : IChildService
 
         logger.LogDebug($"User:{userId} is trying to get the child with id: {id}.");
 
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.Parent);
+
         var child = (await childRepository.GetByFilter(
                         whereExpression: c => c.Id == id,
-                        includeExpression: (IQueryable<Child> c) => c.Include(c => c.Parent))
+                        includeExpression: includeFunc)
                     .ConfigureAwait(false)).SingleOrDefault()
                     ?? throw new UnauthorizedAccessException(
                         $"User:{userId} is trying to get an unexisting child with id: {id}.");
@@ -401,10 +403,12 @@ public class ChildService : IChildService
 
         logger.LogDebug($"Updating the child with Id: {childId} and {nameof(userId)}: {userId} started.");
 
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.Parent).Include(c => c.SocialGroups);
+
         var child = (await childRepository
                         .GetByFilter(
                             whereExpression: c => c.Id == childId,
-                            includeExpression: (IQueryable<Child> c) => c.Include(c => c.Parent).Include(c => c.SocialGroups))
+                            includeExpression: includeFunc)
                         .ConfigureAwait(false)).SingleOrDefault()
                     ?? throw new InvalidOperationException(
                         $"User: {userId} is trying to update not existing Child (Id = {childId}).");
@@ -445,9 +449,11 @@ public class ChildService : IChildService
 
         logger.LogDebug($"Deleting the child with Id: {id} and {nameof(userId)}: {userId} started.");
 
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.Parent);
+
         var child = await childRepository.GetByFilterNoTracking(
                                             whereExpression: c => c.Id == id,
-                                            includeExpression: (IQueryable<Child> c) => c.Include(c => c.Parent))
+                                            includeExpression: includeFunc)
                                          .SingleOrDefaultAsync()
                                          .ConfigureAwait(false)
                     ?? throw new UnauthorizedAccessException(

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -104,7 +104,17 @@ public class ChildService : IChildService
         logger.LogDebug(
             $"Child with Id:{newChild.Id} ({nameof(Child.ParentId)}:{newChild.ParentId}, {nameof(userId)}:{userId}) was created successfully.");
 
-        return mapper.Map<ChildDto>(newChild);
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.SocialGroups)
+                                                    .Include(c => c.Parent).ThenInclude(p => p.User);
+
+        var newChildWithDetails = (await childRepository.GetByFilter(
+                                    whereExpression: c => c.Id == newChild.Id,
+                                    includeExpression: includeFunc)
+                                .ConfigureAwait(false)).SingleOrDefault()
+                                ?? throw new UnauthorizedAccessException(
+                                    $"User:{userId} is trying to get an unexisting child with id: {newChild.Id}.");
+
+        return mapper.Map<ChildDto>(newChildWithDetails);
     }
 
     /// <inheritdoc/>

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -155,13 +155,13 @@ public class ChildService : IChildService
             {
                 children.ChildrenCreationResults.Add(CreateChildResult(childCreateDto, false, ex.Message));
                 logger.LogDebug(
-                    $"There is an error while creating a new child with {nameof(Child.ParentId)}:{parent.Id}, {nameof(userId)}:{userId}: {ex.Message}.");
+                    "There is an error while creating a new child with {ParentId}:{Id}, {UserId}:{Id}: {ExceptionMessage}.", nameof(Child.ParentId), parent.Id, nameof(userId), userId, ex.Message);
             }
             catch (Exception ex)
             {
                 children.ChildrenCreationResults.Add(CreateChildResult(childCreateDto, false));
                 logger.LogDebug(
-                    $"There is an error while creating a new child with {nameof(Child.ParentId)}:{parent.Id}, {nameof(userId)}:{userId}: {ex.Message}.");
+                    "There is an error while creating a new child with {ParentId}:{Id}, {UserId}:{Id}: {ExceptionMessage}.", nameof(Child.ParentId), parent.Id, nameof(userId), userId, ex.Message);
             }
         }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -246,7 +246,8 @@ public class ChildService : IChildService
 
         logger.LogDebug($"User:{userId} is trying to get the child with id: {id}.");
 
-        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.Parent);
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.SocialGroups)
+                                                    .Include(c => c.Parent).ThenInclude(p => p.User);
 
         var child = (await childRepository.GetByFilter(
                         whereExpression: c => c.Id == id,

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -332,7 +332,6 @@ public class ChildService : IChildService
             { x => x.FirstName, SortDirection.Ascending },
         };
 
-        // No nested entities in use – eager loading not required.
         var children = await childRepository
             .Get(
                  skip: offsetFilter.From,
@@ -372,17 +371,20 @@ public class ChildService : IChildService
 
         var totalAmount = childrenGuids.Count;
 
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.SocialGroups)
+                                                    .Include(c => c.Parent).ThenInclude(p => p.User);
+
         var sortExpression = new Dictionary<Expression<Func<Child, object>>, SortDirection>
         {
             { x => x.FirstName, SortDirection.Ascending },
         };
 
-        // No nested entities in use – eager loading not required.
         var children = await childRepository
             .Get(
                  skip: offsetFilter.From,
                  take: offsetFilter.Size,
                  whereExpression: x => childrenGuids.Contains(x.Id),
+                 includeExpression: includeFunc,
                  orderBy: sortExpression)
             .ToListAsync()
             .ConfigureAwait(false);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -421,8 +421,8 @@ public class ChildService : IChildService
 
         logger.LogDebug($"Updating the child with Id: {childId} and {nameof(userId)}: {userId} started.");
 
-        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.Parent).Include(c => c.SocialGroups);
-
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.SocialGroups)
+                                                    .Include(c => c.Parent).ThenInclude(p => p.User);
         var child = (await childRepository
                         .GetByFilter(
                             whereExpression: c => c.Id == childId,

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -63,20 +63,13 @@ public class ChildService : IChildService
         ValidateUserId(userId);
 
         logger.LogDebug(
-            $"Started creation of a new child with {nameof(Child.ParentId)}:{childCreateDto.ParentId}, {nameof(userId)}:{userId}.");
+            $"Started creation of a new child with {nameof(userId)}:{userId}.");
 
         // No nested entities in use – eager loading not required.
         var parent =
             (await parentRepository.GetByFilter(p => p.UserId == userId).ConfigureAwait(false)).SingleOrDefault()
             ?? throw new UnauthorizedAccessException(
                 $"Trying to create a new child the Parent with {nameof(userId)}:{userId} was not found.");
-
-        if (childCreateDto.ParentId != parent.Id)
-        {
-            logger.LogWarning(
-                $"Prevented action! User:{userId} with {nameof(Child.ParentId)}:{parent.Id} was trying to create a new child with not his own {nameof(Child.ParentId)}:{childCreateDto.ParentId}.");
-            childCreateDto.ParentId = parent.Id;
-        }
 
         if (childCreateDto.IsParent)
         {
@@ -87,6 +80,7 @@ public class ChildService : IChildService
         {
             var child = mapper.Map<Child>(childCreateDto);
             child.Id = default;
+            child.ParentId = parent.Id;
             child.SocialGroups = new List<SocialGroup>();
 
             var newChild = await childRepository.Create(child).ConfigureAwait(false);
@@ -150,7 +144,7 @@ public class ChildService : IChildService
                         .Add(CreateChildResult(
                             childCreateDto,
                             false,
-                            $"Refused to create a new child with {nameof(Child.ParentId)}:{childCreateDto.ParentId}, {nameof(userId)}:{userId}: " +
+                            $"Refused to create a new child with {nameof(Child.ParentId)}:{parent.Id}, {nameof(userId)}:{userId}: " +
                             $"the limit ({parentConfig.Value.ChildrenMaxNumber}) of the children for parents was reached."));
                 }
             }
@@ -161,13 +155,13 @@ public class ChildService : IChildService
             {
                 children.ChildrenCreationResults.Add(CreateChildResult(childCreateDto, false, ex.Message));
                 logger.LogDebug(
-                    $"There is an error while creating a new child with {nameof(Child.ParentId)}:{childCreateDto.ParentId}, {nameof(userId)}:{userId}: {ex.Message}.");
+                    $"There is an error while creating a new child with {nameof(Child.ParentId)}:{parent.Id}, {nameof(userId)}:{userId}: {ex.Message}.");
             }
             catch (Exception ex)
             {
                 children.ChildrenCreationResults.Add(CreateChildResult(childCreateDto, false));
                 logger.LogDebug(
-                    $"There is an error while creating a new child with {nameof(Child.ParentId)}:{childCreateDto.ParentId}, {nameof(userId)}:{userId}: {ex.Message}.");
+                    $"There is an error while creating a new child with {nameof(Child.ParentId)}:{parent.Id}, {nameof(userId)}:{userId}: {ex.Message}.");
             }
         }
 
@@ -440,13 +434,6 @@ public class ChildService : IChildService
         if (child.IsParent || childUpdateDto.IsParent)
         {
             throw new ArgumentException($"Forbidden to update child which related to the parent.");
-        }
-
-        if (childUpdateDto.ParentId != child.ParentId)
-        {
-            logger.LogWarning(
-                $"Prevented action! User:{userId} with {nameof(Child.ParentId)}:{child.ParentId} was trying to update his child with not his own {nameof(Child.ParentId)}:{childUpdateDto.ParentId}.");
-            childUpdateDto.ParentId = child.ParentId;
         }
 
         mapper.Map(childUpdateDto, child);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChildService.cs
@@ -276,7 +276,8 @@ public class ChildService : IChildService
 
         var totalAmount = await childRepository.Count(x => x.ParentId == parentId).ConfigureAwait(false);
 
-        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.SocialGroups);
+        var includeFunc = (IQueryable<Child> c) => c.Include(c => c.SocialGroups)
+                                                    .Include(c => c.Parent).ThenInclude(p => p.User);
 
         var sortExpression = new Dictionary<Expression<Func<Child, object>>, SortDirection>
         {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SocialGroupService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SocialGroupService.cs
@@ -9,6 +9,7 @@ namespace OutOfSchool.BusinessLogic.Services;
 /// <summary>
 /// Implements the interface with CRUD functionality for for SocialGroup entity.
 /// </summary>
+// No nested entities in use – eager loading not required.
 public class SocialGroupService : ISocialGroupService
 {
     private readonly IEntityRepositorySoftDeleted<long, SocialGroup> repository;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -378,13 +378,15 @@ public class MappingProfile : Profile
             .ForMember(c => c.Id, m => m.Ignore())
             .ForMember(c => c.Parent, m => m.Ignore())
             .ForMember(c => c.Achievements, m => m.Ignore())
-            .ForMember(c => c.SocialGroups, m => m.Ignore());
+            .ForMember(c => c.SocialGroups, m => m.Ignore())
+            .ForMember(c => c.ParentId, m => m.Ignore());
 
         CreateSoftDeletedMap<ChildUpdateDto, Child>()
             .ForMember(c => c.Id, m => m.Ignore())
             .ForMember(c => c.Parent, m => m.Ignore())
             .ForMember(c => c.Achievements, m => m.Ignore())
-            .ForMember(c => c.SocialGroups, m => m.Ignore());
+            .ForMember(c => c.SocialGroups, m => m.Ignore())
+            .ForMember(c => c.ParentId, m => m.Ignore());
 
         // TODO: Check this mapping
         CreateMap<Parent, ParentDTO>().ReverseMap();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
@@ -290,7 +290,7 @@ public class ChildServiceTests
         childRepositoryMock
             .Setup(m => m.GetByFilterNoTracking(
                 It.IsAny<Expression<Func<Child, bool>>>(),
-                nameof(Child.Parent),
+                "",
                 It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>()))
             .Returns(childList);
 
@@ -315,7 +315,7 @@ public class ChildServiceTests
         childRepositoryMock
             .Setup(m => m.GetByFilterNoTracking(
                 It.IsAny<Expression<Func<Child, bool>>>(),
-                nameof(Child.Parent),
+                "",
                 It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>()))
             .Returns(childList);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using AutoMapper;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MockQueryable.Moq;
@@ -358,8 +359,8 @@ public class ChildServiceTests
         // Arrange
         childRepositoryMock
             .Setup(m => m.Get(
-                It.IsAny<int>(), 
-                It.IsAny<int>(), 
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<string>(),
                 It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>(),
                 It.IsAny<Expression<Func<Child, bool>>>(),
@@ -440,11 +441,69 @@ public class ChildServiceTests
             .Verifiable(Times.Once);
 
         // Act
-        var result = await childService.GetByUserId(parent.UserId,true, offsetFilter);
+        var result = await childService.GetByUserId(parent.UserId, true, offsetFilter);
 
         // Assert
         Assert.IsNotNull(result);
         Assert.AreEqual(children.Count, result.TotalAmount);
         Mock.VerifyAll();
+    }
+
+    [Test]
+    public async Task GetByIdAndUserId_GetChild()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var child = new Child()
+        {
+            Id = Guid.NewGuid(),
+            Parent = new Parent() { UserId = userId.ToString() },
+        };
+        var childList = new List<Child> { child }.BuildMock();
+        childRepositoryMock
+            .Setup(m => m.GetByFilter(
+                It.IsAny<Expression<Func<Child, bool>>>(),
+                "",
+                It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>()))
+            .ReturnsAsync(childList.AsEnumerable());
+        mapperMock.Setup(mapper => mapper.Map<ChildDto>(It.IsAny<Child>()))
+            .Returns(new ChildDto())
+            .Verifiable(Times.Once);
+
+        // Act
+        var result = await childService.GetByIdAndUserId(child.Id, userId.ToString());
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOf<ChildDto>(result);
+        Mock.VerifyAll();
+    }
+
+    [Test]
+    public async Task GetByIdAndUserId_ThrowUnauthorizedAccessException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var child = new Child()
+        {
+            Id = Guid.NewGuid(),
+            Parent = new Parent() { UserId = Guid.NewGuid().ToString() },
+        };
+        var childList = new List<Child> { child }.BuildMock();
+        childRepositoryMock
+            .Setup(m => m.GetByFilter(
+                It.IsAny<Expression<Func<Child, bool>>>(),
+                "",
+                It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>()))
+            .ReturnsAsync(childList.AsEnumerable());
+        mapperMock.Setup(mapper => mapper.Map<ChildDto>(It.IsAny<Child>()))
+            .Returns(new ChildDto())
+            .Verifiable(Times.Never);
+
+        // Act & Assert
+        await childService
+            .Invoking(x => x.GetByIdAndUserId(child.Id, userId.ToString()))
+            .Should()
+            .ThrowAsync<UnauthorizedAccessException>();
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
@@ -569,4 +569,128 @@ public class ChildServiceTests
             .ThrowAsync<InvalidOperationException>();
         Mock.VerifyAll();
     }
+
+    [Test]
+    public async Task CreateChildForUser_ParentIsNotExisting_ThrowInvalidOperationException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var childCreateDto = new ChildCreateDto();
+        var parentList = new List<Parent>().BuildMock();
+
+        parentRepositoryMock
+            .Setup(m => m.GetByFilter(
+                It.IsAny<Expression<Func<Parent, bool>>>(),
+                "",
+                null))
+            .ReturnsAsync(parentList.AsEnumerable())
+            .Verifiable(Times.Once);
+
+        // Act & Assert
+        await childService
+            .Invoking(x => x.CreateChildForUser(childCreateDto, userId))
+            .Should()
+            .ThrowAsync<UnauthorizedAccessException>();
+        Mock.VerifyAll();
+    }
+
+    [Test]
+    public async Task CreateChildForUser_ChildRelatedToParent_ThrowArgumentException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var childCreateDto = new ChildCreateDto()
+        {
+            IsParent = true,
+        };
+        var parent = new Parent()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId
+        };
+        var parentList = new List<Parent>() { parent }.BuildMock();
+
+        parentRepositoryMock
+            .Setup(m => m.GetByFilter(
+                It.IsAny<Expression<Func<Parent, bool>>>(),
+                "",
+                null))
+            .ReturnsAsync(parentList.AsEnumerable())
+            .Verifiable(Times.Once);
+
+        // Act & Assert
+        await childService
+            .Invoking(x => x.CreateChildForUser(childCreateDto, userId))
+            .Should()
+            .ThrowAsync<ArgumentException>();
+        Mock.VerifyAll();
+    }
+
+    [Test]
+    public async Task CreateChildForUser_ProperChild_ThrowArgumentException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var childCreateDto = new ChildCreateDto()
+        {
+            IsParent = false,
+            SocialGroupIds = new List<long>()
+        };        
+        var child = new Child()
+        {
+            Id = Guid.NewGuid(),
+            Parent = new Parent() { UserId = Guid.NewGuid().ToString() },
+        };
+        var childList = new List<Child> { child }.BuildMock();
+
+        var parent = new Parent()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId
+        };
+        var parentList = new List<Parent>() { parent }.BuildMock();
+
+        parentRepositoryMock
+            .Setup(m => m.GetByFilter(
+                It.IsAny<Expression<Func<Parent, bool>>>(),
+                "",
+                null))
+            .ReturnsAsync(parentList.AsEnumerable())
+            .Verifiable(Times.Once);
+
+        childRepositoryMock.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<Child>>>()))
+            .Returns((Func<Task<Child>> f) => f.Invoke())
+            .Verifiable(Times.Once);
+
+        mapperMock.Setup(mapper => mapper.Map<Child>(/*It.IsAny<ChildCreateDto>()*/childCreateDto))
+            .Returns(child)
+            .Verifiable(Times.Once);
+
+        childRepositoryMock.Setup(r => r.Create(child))
+            .ReturnsAsync(child)
+            .Verifiable(Times.Once);
+
+        childRepositoryMock.Setup(r => r.SaveChangesAsync(true, default))
+            .Verifiable(Times.Once);
+
+        childRepositoryMock
+            .Setup(m => m.GetByFilter(
+                It.IsAny<Expression<Func<Child, bool>>>(),
+                "",
+                It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>()))
+            .ReturnsAsync(childList.AsEnumerable())
+            .Verifiable(Times.Once);
+
+        mapperMock.Setup(mapper => mapper.Map<ChildDto>(It.IsAny<Child>()))
+            .Returns(new ChildDto())
+            .Verifiable(Times.Once);
+
+        // Act
+        var result = await childService.CreateChildForUser(childCreateDto, userId);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOf<ChildDto>(result);
+        Mock.VerifyAll();
+    }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using AutoMapper;
-using Elastic.Clients.Elasticsearch;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using AutoMapper;
+using Elastic.Clients.Elasticsearch;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -540,6 +541,33 @@ public class ChildServiceTests
 
         // Assert
         Assert.IsNotNull(result);
+        Mock.VerifyAll();
+    }
+
+    [Test]
+    public async Task UpdateChildCheckingItsUserIdProperty_ChildIsNotExisting_ThrowInvalidOperationException()
+    {
+        // Arrange
+        var childUpdateDto = new ChildUpdateDto() { DateOfBirth = DateTime.Now - TimeSpan.FromDays(1000) };
+        var userId = Guid.NewGuid().ToString();
+        var childId = Guid.NewGuid();
+        var childList = new List<Child>().BuildMock();
+        childRepositoryMock
+            .Setup(m => m.GetByFilter(
+                It.IsAny<Expression<Func<Child, bool>>>(),
+                "",
+                It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>()))
+            .ReturnsAsync(childList.AsEnumerable())
+            .Verifiable(Times.Once);
+        mapperMock.Setup(mapper => mapper.Map<ChildDto>(It.IsAny<Child>()))
+            .Returns(new ChildDto())
+            .Verifiable(Times.Never);
+
+        // Act & Assert
+        await childService
+            .Invoking(x => x.UpdateChildCheckingItsUserIdProperty(childUpdateDto, childId, userId.ToString()))
+            .Should()
+            .ThrowAsync<InvalidOperationException>();
         Mock.VerifyAll();
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ChildServiceTests.cs
@@ -361,7 +361,7 @@ public class ChildServiceTests
             .Setup(m => m.Get(
                 It.IsAny<int>(),
                 It.IsAny<int>(),
-                It.IsAny<string>(),
+                "",
                 It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>(),
                 It.IsAny<Expression<Func<Child, bool>>>(),
                 It.IsAny<Dictionary<Expression<Func<Child, object>>, SortDirection>>(),
@@ -393,7 +393,7 @@ public class ChildServiceTests
             .Setup(m => m.Get(
                 It.IsAny<int>(),
                 It.IsAny<int>(),
-                It.IsAny<string>(),
+                "",
                 It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>(),
                 It.IsAny<Expression<Func<Child, bool>>>(),
                 It.IsAny<Dictionary<Expression<Func<Child, object>>, SortDirection>>(),
@@ -465,7 +465,8 @@ public class ChildServiceTests
                 It.IsAny<Expression<Func<Child, bool>>>(),
                 "",
                 It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>()))
-            .ReturnsAsync(childList.AsEnumerable());
+            .ReturnsAsync(childList.AsEnumerable())
+            .Verifiable(Times.Once);
         mapperMock.Setup(mapper => mapper.Map<ChildDto>(It.IsAny<Child>()))
             .Returns(new ChildDto())
             .Verifiable(Times.Once);
@@ -495,7 +496,8 @@ public class ChildServiceTests
                 It.IsAny<Expression<Func<Child, bool>>>(),
                 "",
                 It.IsAny<Func<IQueryable<Child>, IQueryable<Child>>>()))
-            .ReturnsAsync(childList.AsEnumerable());
+            .ReturnsAsync(childList.AsEnumerable())
+            .Verifiable(Times.Once);
         mapperMock.Setup(mapper => mapper.Map<ChildDto>(It.IsAny<Child>()))
             .Returns(new ChildDto())
             .Verifiable(Times.Never);
@@ -505,5 +507,39 @@ public class ChildServiceTests
             .Invoking(x => x.GetByIdAndUserId(child.Id, userId.ToString()))
             .Should()
             .ThrowAsync<UnauthorizedAccessException>();
+        Mock.VerifyAll();
+    }
+
+    [Test]
+    public async Task GetChildrenListByParentId_GetChildren()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var child = new Child()
+        {
+            Id = Guid.NewGuid(),
+            FirstName = "TestFirstName",
+            LastName = "TestLastName",
+            MiddleName = "TestMiddleName",
+            Parent = new Parent() { UserId = userId.ToString() },
+        };
+        var childList = new List<Child> { child }.BuildMock();
+        childRepositoryMock
+            .Setup(m => m.GetByFilter(
+                It.IsAny<Expression<Func<Child, bool>>>(),
+                "",
+                null))
+            .ReturnsAsync(childList.AsEnumerable())
+            .Verifiable(Times.Once);
+        mapperMock.Setup(mapper => mapper.Map<List<ShortEntityDto>>(childList))
+            .Returns(new List<ShortEntityDto>() { })
+            .Verifiable(Times.Once);
+
+        // Act
+        var result = await childService.GetChildrenListByParentId(child.ParentId, false);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Mock.VerifyAll();
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ChildController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ChildController.cs
@@ -151,8 +151,8 @@ public class ChildController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [HttpGet("/api/v{version:apiVersion}/workshops/{id}/children/approved")]
-    public async Task<IActionResult> GetApprovedByWorkshopId(Guid workshopId, [FromQuery] OffsetFilter offsetFilter)
+    [HttpGet("/api/v{version:apiVersion}/workshops/{workshopId}/children/approved")]
+    public async Task<IActionResult> GetApprovedByWorkshopId([FromRoute] Guid workshopId, [FromQuery] OffsetFilter offsetFilter)
     {
         var isWorkshopExists = await combinedWorkshopService.Exists(workshopId).ConfigureAwait(false);
 


### PR DESCRIPTION
1) Reviewed lazy/eager loading in ChildService;
2) Reviewed lazy/eager loading in SocialGroupService; 
3) Fixed tests for DeleteChildCheckingItsUserIdProperty() method of ChildService class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved clarity in data handling by adding comments regarding eager loading requirements.
  - Standardized naming conventions for functions related to including related entities in queries.
  - Updated method signatures to clarify parameter sources and enhance readability.
  - Removed `ParentId` property from `ChildBaseDto` and added it to `ChildDto`, ensuring proper association of children with parents.

- **Tests**
  - Expanded test coverage with new scenarios for child retrieval and authorization checks.
  - Updated existing test methods to align with new filtering criteria.

These enhancements improve system reliability and ensure that only authorized users can access specific records, enhancing the overall user experience without changing existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->