### PR TITLE
Remove APM provider type to be set at runtime

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Kubernetes.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Kubernetes.json
@@ -149,8 +149,7 @@
   "MySQLServerVersion": "8.0.32",
   "CheckConnectivityDelay": 5000,
   "ElasticApm": {
-    "Enabled": true,
-    "CloudProvider": "gcp"
+    "Enabled": true
   },
   "FeatureManagement": {
     "PasswordLogin": true

--- a/OutOfSchool/OutOfSchool.Encryption/appsettings.Kubernetes.jsonc
+++ b/OutOfSchool/OutOfSchool.Encryption/appsettings.Kubernetes.jsonc
@@ -27,7 +27,6 @@
     ]
   },
   "ElasticApm": {
-    "Enabled": true,
-    "CloudProvider": "gcp"
+    "Enabled": true
   }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Kubernetes.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Kubernetes.json
@@ -115,8 +115,7 @@
     "Enabled": true
   },
   "ElasticApm": {
-    "Enabled": true,
-    "CloudProvider": "gcp"
+    "Enabled": true
   },
   "GeoCoding": {
     "UseFakeGeocoder": true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined monitoring configurations by removing the explicit cloud provider setting, while keeping the monitoring functionality active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->