### PR TITLE
Apply default values for hidden Workshop fields

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/CommonWorkshopEsMapping.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/CommonWorkshopEsMapping.cs
@@ -1,6 +1,5 @@
 using AutoMapper;
 using OutOfSchool.BusinessLogic.Models.Workshops;
-using OutOfSchool.Common.Enums.Workshop;
 
 namespace OutOfSchool.BusinessLogic.Util.Mapping;
 
@@ -18,11 +17,6 @@ public static class CommonWorkshopEsMapping
             .ForMember(dest => dest.NumberOfRatings, opt => opt.MapFrom(src => src.NumberOfRatings))
             .ForMember(dest => dest.ProviderStatus, opt => opt.MapFrom(src => src.ProviderStatus))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status))
-            .ForMember(dest => dest.TakenSeats, opt => opt.MapFrom(src => src.TakenSeats))
-            .ForMember(dest => dest.IsSelfFinanced, opt => opt.MapFrom(_ => false))
-            .ForMember(dest => dest.IsInclusive, opt => opt.MapFrom(_ => false))
-            .ForMember(dest => dest.SpecialNeedsType, opt => opt.MapFrom(_ => SpecialNeedsType.None))
-            .ForMember(dest => dest.EducationalShift, opt => opt.MapFrom(_ => EducationalShift.First))
-            .ForMember(dest => dest.AgeComposition, opt => opt.MapFrom(_ => AgeComposition.SameAge));
+            .ForMember(dest => dest.TakenSeats, opt => opt.MapFrom(src => src.TakenSeats));
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/CommonWorkshopEsMapping.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/CommonWorkshopEsMapping.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using OutOfSchool.BusinessLogic.Models.Workshops;
+using OutOfSchool.Common.Enums.Workshop;
 
 namespace OutOfSchool.BusinessLogic.Util.Mapping;
 
@@ -17,6 +18,11 @@ public static class CommonWorkshopEsMapping
             .ForMember(dest => dest.NumberOfRatings, opt => opt.MapFrom(src => src.NumberOfRatings))
             .ForMember(dest => dest.ProviderStatus, opt => opt.MapFrom(src => src.ProviderStatus))
             .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status))
-            .ForMember(dest => dest.TakenSeats, opt => opt.MapFrom(src => src.TakenSeats));
+            .ForMember(dest => dest.TakenSeats, opt => opt.MapFrom(src => src.TakenSeats))
+            .ForMember(dest => dest.IsSelfFinanced, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.IsInclusive, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.SpecialNeedsType, opt => opt.MapFrom(_ => SpecialNeedsType.None))
+            .ForMember(dest => dest.EducationalShift, opt => opt.MapFrom(_ => EducationalShift.First))
+            .ForMember(dest => dest.AgeComposition, opt => opt.MapFrom(_ => AgeComposition.SameAge));
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/ElasticProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/ElasticProfile.cs
@@ -2,7 +2,6 @@ using Elastic.Clients.Elasticsearch;
 using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.Codeficator;
 using OutOfSchool.BusinessLogic.Models.Workshops;
-using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Models.ContactInfo;
 using OutOfSchool.Services.Models.CompetitiveEvents;
@@ -38,7 +37,8 @@ public class ElasticProfile : Profile
                     opt.MapFrom(src =>
                         src.Tags.Select(t => t.Name)))
             .ForMember(dest => dest.Address, opt => opt.MapFrom(src => src.Contacts.FirstOrDefault(c => c.IsDefault).Address))
-            .CommonFieldsMapping();
+            .CommonFieldsMapping()
+            .ApplyDefaultsForHiddenFields();
 
         CreateMap<AddressDto, AddressES>()
             .ForMember(

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/ElasticProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/ElasticProfile.cs
@@ -8,6 +8,7 @@ using OutOfSchool.Services.Models.ContactInfo;
 using OutOfSchool.Services.Models.CompetitiveEvents;
 using Profile = AutoMapper.Profile;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
+using OutOfSchool.Common.Enums.Workshop;
 
 namespace OutOfSchool.BusinessLogic.Util.Mapping;
 
@@ -75,7 +76,12 @@ public class ElasticProfile : Profile
 
         CreateMap<WorkshopFilter, WorkshopFilterES>()
             .ForMember(dest => dest.Workdays, opt => opt.MapFrom(src => string.Join(' ', src.Workdays)))
-            .ForMember(dest => dest.ElasticRadius, opt => opt.MapFrom(src => $"{src.RadiusKm * 1000}m"));
+            .ForMember(dest => dest.ElasticRadius, opt => opt.MapFrom(src => $"{src.RadiusKm * 1000}m"))
+            .ForMember(dest => dest.IsSelfFinanced, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.IsInclusive, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.SpecialNeedsType, opt => opt.MapFrom(_ => new List<SpecialNeedsType>()))
+            .ForMember(dest => dest.EducationalShift, opt => opt.MapFrom(_ => new List<EducationalShift>()))
+            .ForMember(dest => dest.AgeComposition, opt => opt.MapFrom(_ => new List<AgeComposition>()));
 
         CreateMap<WorkshopES, WorkshopCard>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(s => s.Id))

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/WorkshopDraftMappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/WorkshopDraftMappingProfile.cs
@@ -3,7 +3,6 @@ using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.WorkshopDraft;
 using OutOfSchool.BusinessLogic.Models.WorkshopDraft.TeacherDrafts;
 using OutOfSchool.BusinessLogic.Models.Workshops;
-using OutOfSchool.Common.Enums.Workshop;
 using OutOfSchool.Services.Models.WorkshopDrafts;
 
 namespace OutOfSchool.BusinessLogic.Util.Mapping;
@@ -72,11 +71,7 @@ public class WorkshopDraftMappingProfile : Profile
             .ForMember(dest => dest.OwnershipType, opt => opt.MapFrom(src => src.ProviderOwnership))
             .ForMember(dest => dest.WorkshopStatus, opt => opt.MapFrom(src => src.Status))
             .ForMember(dest => dest.IncludedStudyGroupsIds, opt => opt.MapFrom(src => src.IncludedStudyGroups.Select(g => g.Id)))
-            .ForMember(dest => dest.IsSelfFinanced, opt => opt.MapFrom(_ => false))
-            .ForMember(dest => dest.IsInclusive, opt => opt.MapFrom(_ => false))
-            .ForMember(dest => dest.SpecialNeedsType, opt => opt.MapFrom(_ => SpecialNeedsType.None))
-            .ForMember(dest => dest.EducationalShift, opt => opt.MapFrom(_ => EducationalShift.First))
-            .ForMember(dest => dest.AgeComposition, opt => opt.MapFrom(_ => AgeComposition.SameAge));
+            .ApplyDefaultsForHiddenFields();
 
         CreateMap<WorkshopV2Dto, WorkshopDraft>()
             .ForPath(dest => dest.WorkshopDraftContent, opt => opt.MapFrom(src => src))

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/WorkshopDraftMappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/WorkshopDraftMappingProfile.cs
@@ -3,6 +3,7 @@ using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.WorkshopDraft;
 using OutOfSchool.BusinessLogic.Models.WorkshopDraft.TeacherDrafts;
 using OutOfSchool.BusinessLogic.Models.Workshops;
+using OutOfSchool.Common.Enums.Workshop;
 using OutOfSchool.Services.Models.WorkshopDrafts;
 
 namespace OutOfSchool.BusinessLogic.Util.Mapping;
@@ -70,7 +71,12 @@ public class WorkshopDraftMappingProfile : Profile
         CreateMap<WorkshopV2Dto, WorkshopDraftContent>()
             .ForMember(dest => dest.OwnershipType, opt => opt.MapFrom(src => src.ProviderOwnership))
             .ForMember(dest => dest.WorkshopStatus, opt => opt.MapFrom(src => src.Status))
-            .ForMember(dest => dest.IncludedStudyGroupsIds, opt => opt.MapFrom(src => src.IncludedStudyGroups.Select(g => g.Id)));          
+            .ForMember(dest => dest.IncludedStudyGroupsIds, opt => opt.MapFrom(src => src.IncludedStudyGroups.Select(g => g.Id)))
+            .ForMember(dest => dest.IsSelfFinanced, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.IsInclusive, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.SpecialNeedsType, opt => opt.MapFrom(_ => SpecialNeedsType.None))
+            .ForMember(dest => dest.EducationalShift, opt => opt.MapFrom(_ => EducationalShift.First))
+            .ForMember(dest => dest.AgeComposition, opt => opt.MapFrom(_ => AgeComposition.SameAge));
 
         CreateMap<WorkshopV2Dto, WorkshopDraft>()
             .ForPath(dest => dest.WorkshopDraftContent, opt => opt.MapFrom(src => src))

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -23,6 +23,7 @@ using OutOfSchool.BusinessLogic.Models.Tag;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.BusinessLogic.Util.CustomComparers;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Enums.Workshop;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Models.ChatWorkshop.ModelsForChatLists;
 using OutOfSchool.Services.Models.CompetitiveEvents;
@@ -53,6 +54,7 @@ public class MappingProfile : Profile
 
         CreateSoftDeletedMap<WorkshopBaseDto, Workshop>()
             .Apply(this.IgnoreContactsFromDto)
+            .Apply(this.ApplyDefaultsForHiddenFields)
             .ForMember(
                 dest => dest.Keywords,
                 opt => opt.MapFrom(src => string.Join(Constants.MappingSeparator, src.Keywords.Distinct())))
@@ -104,6 +106,7 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.ProviderTitleEn, opt => opt.Ignore());
 
         CreateSoftDeletedMap<WorkshopCreateRequestDto, Workshop>()
+            .Apply(this.ApplyDefaultsForHiddenFields)
             .ForMember(
                 dest => dest.Keywords,
                 opt => opt.MapFrom(src => string.Join(Constants.MappingSeparator, src.Keywords.Distinct())))
@@ -755,7 +758,12 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.StatusReason, opt => opt.MapFrom(src => string.Empty));
 
         CreateMap<WorkshopFilter, WorkshopFilterWithSettlements>()
-            .ForMember(dest => dest.SettlementsIds, opt => opt.Ignore());
+            .ForMember(dest => dest.SettlementsIds, opt => opt.Ignore())
+            .ForMember(dest => dest.IsSelfFinanced, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.IsInclusive, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.SpecialNeedsType, opt => opt.MapFrom(_ => new List<SpecialNeedsType>()))
+            .ForMember(dest => dest.EducationalShift, opt => opt.MapFrom(_ => new List<EducationalShift>()))
+            .ForMember(dest => dest.AgeComposition, opt => opt.MapFrom(_ => new List<AgeComposition>()));
 
         CreateMap<CompetitiveEvent, CompetitiveEventDto>()
             .ForMember(dest => dest.InstitutionHierarchy, opt => opt.MapFrom(src => src.InstitutionHierarchy.Title))
@@ -928,4 +936,15 @@ public class MappingProfile : Profile
         where TDestination : BusinessEntity, IHasContacts
         => mappings
             .ForMember(dest => dest.Contacts, opt => opt.Ignore());
+
+    private IMappingExpression<TSource, Workshop> ApplyDefaultsForHiddenFields<TSource>(
+    IMappingExpression<TSource, Workshop> map)
+    {
+        return map
+            .ForMember(dest => dest.IsSelfFinanced, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.IsInclusive, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.SpecialNeedsType, opt => opt.MapFrom(_ => SpecialNeedsType.None))
+            .ForMember(dest => dest.EducationalShift, opt => opt.MapFrom(_ => EducationalShift.First))
+            .ForMember(dest => dest.AgeComposition, opt => opt.MapFrom(_ => AgeComposition.SameAge));
+    }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -54,7 +54,7 @@ public class MappingProfile : Profile
 
         CreateSoftDeletedMap<WorkshopBaseDto, Workshop>()
             .Apply(this.IgnoreContactsFromDto)
-            .Apply(this.ApplyDefaultsForHiddenFields)
+            .ApplyDefaultsForHiddenFields()
             .ForMember(
                 dest => dest.Keywords,
                 opt => opt.MapFrom(src => string.Join(Constants.MappingSeparator, src.Keywords.Distinct())))
@@ -106,7 +106,7 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.ProviderTitleEn, opt => opt.Ignore());
 
         CreateSoftDeletedMap<WorkshopCreateRequestDto, Workshop>()
-            .Apply(this.ApplyDefaultsForHiddenFields)
+            .ApplyDefaultsForHiddenFields()
             .ForMember(
                 dest => dest.Keywords,
                 opt => opt.MapFrom(src => string.Join(Constants.MappingSeparator, src.Keywords.Distinct())))
@@ -936,15 +936,4 @@ public class MappingProfile : Profile
         where TDestination : BusinessEntity, IHasContacts
         => mappings
             .ForMember(dest => dest.Contacts, opt => opt.Ignore());
-
-    private IMappingExpression<TSource, Workshop> ApplyDefaultsForHiddenFields<TSource>(
-    IMappingExpression<TSource, Workshop> map)
-    {
-        return map
-            .ForMember(dest => dest.IsSelfFinanced, opt => opt.MapFrom(_ => false))
-            .ForMember(dest => dest.IsInclusive, opt => opt.MapFrom(_ => false))
-            .ForMember(dest => dest.SpecialNeedsType, opt => opt.MapFrom(_ => SpecialNeedsType.None))
-            .ForMember(dest => dest.EducationalShift, opt => opt.MapFrom(_ => EducationalShift.First))
-            .ForMember(dest => dest.AgeComposition, opt => opt.MapFrom(_ => AgeComposition.SameAge));
-    }
 }

--- a/OutOfSchool/OutOfSchool.Common/Extensions/MappingExtensions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Extensions/MappingExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using AutoMapper;
+using OutOfSchool.Common.Enums.Workshop;
+using OutOfSchool.Common.Models;
 
 namespace OutOfSchool.Common.Extensions;
 
@@ -18,5 +20,18 @@ public static class MappingExtensions
     {
         cfg.AddProfile<T>();
         return cfg;
+    }
+
+    public static IMappingExpression<TSource, TDestination> ApplyDefaultsForHiddenFields<TSource, TDestination>(
+        this IMappingExpression<TSource, TDestination> map)
+        where TSource : class
+        where TDestination : class, IHasHiddenFields
+    {
+        return map
+            .ForMember(dest => dest.IsSelfFinanced, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.IsInclusive, opt => opt.MapFrom(_ => false))
+            .ForMember(dest => dest.SpecialNeedsType, opt => opt.MapFrom(_ => SpecialNeedsType.None))
+            .ForMember(dest => dest.EducationalShift, opt => opt.MapFrom(_ => EducationalShift.First))
+            .ForMember(dest => dest.AgeComposition, opt => opt.MapFrom(_ => AgeComposition.SameAge));
     }
 }

--- a/OutOfSchool/OutOfSchool.Common/Models/IHasHiddenFields.cs
+++ b/OutOfSchool/OutOfSchool.Common/Models/IHasHiddenFields.cs
@@ -1,0 +1,12 @@
+﻿using OutOfSchool.Common.Enums.Workshop;
+
+namespace OutOfSchool.Common.Models;
+
+public interface IHasHiddenFields
+{
+    bool IsSelfFinanced { get; set; }
+    bool IsInclusive { get; set; }
+    SpecialNeedsType SpecialNeedsType { get; set; }
+    EducationalShift EducationalShift { get; set; }
+    AgeComposition AgeComposition { get; set; }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using OutOfSchool.Common;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Enums.Workshop;
+using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Models.ChatWorkshop;
 using OutOfSchool.Services.Models.ContactInfo;
 using OutOfSchool.Services.Models.Images;
@@ -15,7 +16,7 @@ namespace OutOfSchool.Services.Models;
 // TODO:
 // - Add educational disciplines (many ED to 1 workshop)
 // - Add language
-public class Workshop : BusinessEntity, IImageDependentEntity<Workshop>, IHasEntityImages<Workshop>, IHasContacts
+public class Workshop : BusinessEntity, IImageDependentEntity<Workshop>, IHasEntityImages<Workshop>, IHasContacts, IHasHiddenFields
 {
     #region Required fields
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDrafts/WorkshopDraftContent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDrafts/WorkshopDraftContent.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Enums.Workshop;
+using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Models.ContactInfo;
 
 namespace OutOfSchool.Services.Models.WorkshopDrafts;
@@ -11,7 +12,7 @@ namespace OutOfSchool.Services.Models.WorkshopDrafts;
 ///     This entity is specific to the draft and can be hard-deleted if the draft is removed.
 /// </summary>
 public class WorkshopDraftContent :
-    IHasContacts
+    IHasContacts, IHasHiddenFields
 {
     public int MinAge { get; set; }
 

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/Models/WorkshopES.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/Models/WorkshopES.cs
@@ -6,7 +6,7 @@ using OutOfSchool.Common.Models;
 
 namespace OutOfSchool.ElasticsearchData.Models;
 
- public class WorkshopES : IHasRating
+ public class WorkshopES : IHasRating, IHasHiddenFields
 {
     public const string KeywordSuffix = "keyword";
     public const string SortSuffix = "sort";


### PR DESCRIPTION
Set default values for fields that will be hidden on the frontend:

- IsSelfFinanced  
- IsInclusive  
- SpecialNeedsType  
- EducationalShift  
- AgeComposition  

Ensured that incoming values from DTOs are ignored and defaults are enforced during mapping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced workshop configurations with consistent default settings for additional attributes, ensuring reliable behavior across workshop listings and drafts.

- **Refactor**
  - Streamlined the data processing logic to uniformly apply these default settings, improving overall data integrity and consistency in displayed workshop information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->