### PR TITLE
fix(workshop): prevent EF tracking conflict when updating tags

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -376,19 +376,11 @@ public class WorkshopService : IWorkshopService, ISensitiveWorkshopsService
 
             if (!dto.TagIds.IsNullOrEmpty())
             {
-                var tags = new List<TagDto>();
-                foreach (var tagId in dto.TagIds)
-                {
-                    var tag = await tagService.GetById(tagId);
-                    if (tag != null)
-                    {
-                        var tagDto = mapper.Map<TagDto>(tag);
-                        tags.Add(tagDto);
-                    }
-                }
+                var tagEntities = await tagRepository
+                    .GetByFilter(t => dto.TagIds.Contains(t.Id));
 
                 currentWorkshop.Tags.Clear();
-                currentWorkshop.Tags.AddRange(tags.Select(tagDto => new Tag { Id = tagDto.Id }));
+                currentWorkshop.Tags.AddRange(tagEntities);
             }
 
             dto.AvailableSeats = dto.AvailableSeats.GetMaxValueIfNullOrZero();


### PR DESCRIPTION
Replaced manual TagDto mapping and `new Tag { Id }` instantiation with direct loading of tag entities from repository. This avoids EF Core tracking issues caused by duplicate entity instances with the same primary key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the workshop update process to streamline tag management, resulting in improved performance and responsiveness when updating workshop details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->