### PR TITLE
update provider title length according to production data

### DIFF
--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -156,7 +156,7 @@ public static class Constants
     /// <summary>
     /// Maximum length of provider full title.
     /// </summary>
-    public const int MaxProviderFullTitleLength = 60;
+    public const int MaxProviderFullTitleLength = 256;
 
     /// <summary>
     /// Minimum length of provider short title.

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250408110236_IncreaseProviderTitleLength.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250408110236_IncreaseProviderTitleLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
@@ -11,9 +12,11 @@ using OutOfSchool.Services;
 namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250408110236_IncreaseProviderTitleLength")]
+    partial class IncreaseProviderTitleLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250408110236_IncreaseProviderTitleLength.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250408110236_IncreaseProviderTitleLength.cs
@@ -1,0 +1,118 @@
+﻿#nullable disable
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+{
+    /// <inheritdoc />
+    public partial class IncreaseProviderTitleLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderTitleEn",
+                table: "Workshops",
+                type: "varchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderTitle",
+                table: "Workshops",
+                type: "varchar(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FullTitleEn",
+                table: "Providers",
+                type: "varchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FullTitle",
+                table: "Providers",
+                type: "varchar(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderTitleEn",
+                table: "Workshops",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderTitle",
+                table: "Workshops",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(256)",
+                oldMaxLength: 256)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FullTitleEn",
+                table: "Providers",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FullTitle",
+                table: "Providers",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(256)",
+                oldMaxLength: 256)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the maximum provider title length from 60 to 256 characters, enabling support for longer provider names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->