### PR TITLE
hotfix(workshop): reset price to 0 when isPaid is false

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/MappingProfile.cs
@@ -105,6 +105,7 @@ public class MappingProfile : Profile
 
         CreateSoftDeletedMap<WorkshopCreateRequestDto, Workshop>()
             .ApplyDefaultsForHiddenFields()
+            .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src.IsPaid ? src.Price : 0))
             .ForMember(
                 dest => dest.Keywords,
                 opt => opt.MapFrom(src => string.Join(Constants.MappingSeparator, src.Keywords.Distinct())))


### PR DESCRIPTION
Previously, when isPaid was false and a non-zero price was provided, the workshop was still saved as paid.
This mapping fix ensures that Price is forcibly set to 0 if isPaid is false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the workshop creation process to dynamically assign pricing based on the paid status. For paid workshops, the specified price is applied; for unpaid ones, the price automatically defaults to zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->