### PR TITLE
Add GetWorkshopDraftIdByWorkshopId endpoint

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/IWorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/IWorkshopDraftService.cs
@@ -94,8 +94,17 @@ public interface IWorkshopDraftService
     /// </summary>
     /// <param name="workshopV2Dto">Dto containing information required to update the draft.</param>   
     /// <returns>
-    /// A <see cref="WorkshopV2Dto"/> containing the details of the updated workshop, 
-    /// including any results or status from image processing operations.
+    /// A <see cref="Task"/> representing the result of the asynchronous operation.
+    /// The task result contains <see cref="WorkshopV2Dto"/> containing the details of the updated workshop.
     /// </returns>
     Task<WorkshopV2Dto> UpdateWorkshop(WorkshopV2Dto workshopV2Dto);
+
+    /// <summary>
+    /// Get WorkshopDraft Id by Workshop Id.   
+    /// </summary>
+    /// <param name="workshopId">Workshop Id.</param>   
+    /// <returns>
+    /// A <see cref="Guid"/> representing the WorkshopDraft Id, or null if no matching WorkshopDraft exists.
+    /// </returns>
+    Task<Guid?> GetWorkshopDraftIdByWorkshopId(Guid workshopId);
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -463,6 +463,7 @@ public class WorkshopDraftService : IWorkshopDraftService, ISensitiveWorkshopDra
         return await MapWorkshopDraftWithDetails(draft);
     }
 
+    // <inheritdoc/> 
     public async Task<WorkshopV2Dto> UpdateWorkshop(WorkshopV2Dto workshopV2Dto)
     {
         logger.LogDebug("Workshop Update started. Workshop Id = {Id}.", workshopV2Dto.Id);
@@ -498,6 +499,20 @@ public class WorkshopDraftService : IWorkshopDraftService, ISensitiveWorkshopDra
         logger.LogDebug("Moderated fields was not changed. Workshop update initiated. Workshop Id = {Id}.", workshopV2Dto.Id);
 
         return (await workshopServicesCombinerV2.Update(workshopV2Dto)).Value.Workshop;
+    }
+
+    // <inheritdoc/> 
+    public async Task<Guid?> GetWorkshopDraftIdByWorkshopId(Guid workshopId)
+    {
+        var workshopDraft = await workshopDraftRepository.Get(
+            whereExpression: wd => wd.WorkshopId == workshopId).FirstOrDefaultAsync();
+
+        if (workshopDraft == null)
+        {
+            return null;
+        }
+
+        return workshopDraft.Id;
     }
 
     private async Task<WorkshopDraft> GetWorkshopDraftById(Guid id)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -458,7 +458,10 @@ public class WorkshopDraftService : IWorkshopDraftService, ISensitiveWorkshopDra
     {
         var draft = await GetWorkshopDraftById(id);
 
-        await currentUserService.UserHasRights(new ProviderRights(draft.ProviderId), new EmployeeRights(draft.ProviderId)).ConfigureAwait(false);
+        if (!currentUserService.IsAdmin())
+        {
+            await currentUserService.UserHasRights(new ProviderRights(draft.ProviderId), new EmployeeRights(draft.ProviderId)).ConfigureAwait(false);
+        }        
 
         return await MapWorkshopDraftWithDetails(draft);
     }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -549,4 +549,58 @@ public class WorkshopDraftServiceTests
         result.Should().NotBeNull();
     }
     #endregion
+
+    #region GetWorkshopDraftIdByWorkshopId
+    [Test]
+    public async Task GetWorkshopDraftIdByWorkshopId_WhenWorkshopDraftExists_ShouldReturnId()
+    {
+        // Arrange
+        var workshop = WorkshopGenerator.Generate();
+        var workshopV2Dto = mapper.Map<WorkshopV2Dto>(workshop);
+
+        var workshopDrafts = new List<WorkshopDraft>()
+        {
+            mapper.Map<WorkshopDraft>(workshopV2Dto)
+        };
+
+        workshopDraftRepoMoq.Setup(x =>
+            x.Get(It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Expression<Func<WorkshopDraft, bool>>>(),
+                    It.IsAny<Dictionary<Expression<Func<WorkshopDraft, object>>, SortDirection>>()))
+            .Returns(workshopDrafts.AsQueryable().BuildMock()).Verifiable(Times.Once);
+
+        // Act
+        var result = await service.GetWorkshopDraftIdByWorkshopId(workshop.Id).ConfigureAwait(false);
+
+        // Assert
+        workshopDraftRepoMoq.VerifyAll();
+
+        result.Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task GetWorkshopDraftIdByWorkshopId_WhenWorkshopDraftDoesntExist_ShouldReturnNull()
+    {
+        // Arrange
+        var workshop = WorkshopGenerator.Generate();
+
+        var workshopDrafts = new List<WorkshopDraft>();
+
+        workshopDraftRepoMoq.Setup(x =>
+            x.Get(It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Expression<Func<WorkshopDraft, bool>>>(),
+                    It.IsAny<Dictionary<Expression<Func<WorkshopDraft, object>>, SortDirection>>()))
+            .Returns(workshopDrafts.AsQueryable().BuildMock()).Verifiable(Times.Once);
+
+        // Act
+        var result = await service.GetWorkshopDraftIdByWorkshopId(workshop.Id).ConfigureAwait(false);
+
+        // Assert
+        workshopDraftRepoMoq.VerifyAll();
+
+        result.Should().BeNull();
+    }
+    #endregion
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
@@ -75,7 +75,7 @@ public class WorkshopDraftController : ControllerBase
             new { id = result.WorkshopDraft.WorkshopDraftId },
             result);
     }
-    
+
     [HasPermission(Permissions.WorkshopEdit)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(WorkshopDraftResultDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -188,7 +188,7 @@ public class WorkshopDraftController : ControllerBase
             return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
         }
     }
-          
+
     [HasPermission(Permissions.WorkshopApprove)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -222,11 +222,11 @@ public class WorkshopDraftController : ControllerBase
     [HttpGet("provider/{id}/drafts")]
     public async Task<IActionResult> GetByProviderId(Guid id, [FromQuery] ExcludeIdFilter filter) =>
         await workshopDraftService.GetByProviderId(id, filter).ProtectAndMap(this.SearchResultToOkOrNoContent);
-    
+
     private async Task<IActionResult> ValidateProvider(Guid providerId)
     {
         var isBlocked = await providerService.IsBlocked(providerId).ConfigureAwait(false);
-        
+
         // null means Provider does not exist
         if (!isBlocked.HasValue)
         {
@@ -255,5 +255,16 @@ public class WorkshopDraftController : ControllerBase
     {
         var responseDto = await workshopDraftService.GetWorkshopDraftByIdMapped(id);
         return responseDto is not null ? Ok(responseDto) : NotFound();
+    }
+
+    [HasPermission(Permissions.WorkshopEdit)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SearchResult<WorkshopDraftResponseDto>))]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [HttpGet("{workshopId}")]
+    public async Task<IActionResult> GetWorkshopDraftIdByWorkshopId(Guid workshopId)
+    {
+        return Ok(await workshopDraftService.GetWorkshopDraftIdByWorkshopId(workshopId));
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
@@ -258,13 +258,14 @@ public class WorkshopDraftController : ControllerBase
     }
 
     [HasPermission(Permissions.WorkshopEdit)]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SearchResult<WorkshopDraftResponseDto>))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(Guid?))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [HttpGet("{workshopId}")]
     public async Task<IActionResult> GetWorkshopDraftIdByWorkshopId(Guid workshopId)
     {
-        return Ok(await workshopDraftService.GetWorkshopDraftIdByWorkshopId(workshopId));
+        var result = await workshopDraftService.GetWorkshopDraftIdByWorkshopId(workshopId);
+        return result.HasValue ? Ok(result) : NoContent();
     }
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API capability that allows retrieval of a workshop draft’s unique identifier using a workshop’s ID, with appropriate responses when no matching draft is available.
  
- **Bug Fixes**
  - Improved user rights verification logic, allowing admins to bypass certain checks.

- **Documentation**
  - Enhanced descriptions for asynchronous operations to provide clearer insight into the outcomes of workshop updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->