### PR TITLE
fix(mapping): properly map NoAgeRestrictions from DTO to draft content

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -169,16 +169,16 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
                 yield return new ValidationResult(
                     "Workdays contain duplications");
             }
+        }
 
-            if (NoAgeRestrictions)
-            {
-                MinAge = 0;
-                MaxAge = 120;
-            }
-            else if (MinAge.HasValue && MaxAge.HasValue && MinAge > MaxAge)
-            {
-                yield return new ValidationResult("Min age should be less than or equal to Max age", new[] { nameof(MinAge), nameof(MaxAge) });
-            }
+        if (NoAgeRestrictions)
+        {
+            MinAge = 0;
+            MaxAge = 120;
+        }
+        else if (MinAge.HasValue && MaxAge.HasValue && MinAge > MaxAge)
+        {
+            yield return new ValidationResult("Min age should be less than or equal to Max age", new[] { nameof(MinAge), nameof(MaxAge) });
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/WorkshopDraftMappingProfile.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mapping/WorkshopDraftMappingProfile.cs
@@ -138,7 +138,7 @@ public class WorkshopDraftMappingProfile : Profile
             .ForMember(dest => dest.ParentWorkshop, opt => opt.Ignore())
             .ForMember(dest => dest.Tags, opt => opt.Ignore())
             .ForMember(dest => dest.DirectionIds, opt => opt.Ignore())
-            .ForMember(dest => dest.NoAgeRestrictions, opt => opt.Ignore());
+            .ForMember(dest => dest.NoAgeRestrictions, opt => opt.MapFrom(src => src.WorkshopDraftContent.NoAgeRestrictions));
 
         CreateMap<WorkshopDraftContent, WorkshopV2CreateRequestDto>()
             .ForMember(dest => dest.Id, opt => opt.Ignore())

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDrafts/WorkshopDraftContent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDrafts/WorkshopDraftContent.cs
@@ -14,6 +14,7 @@ namespace OutOfSchool.Services.Models.WorkshopDrafts;
 public class WorkshopDraftContent :
     IHasContacts, IHasHiddenFields
 {
+    public bool NoAgeRestrictions { get; set; } = false;
     public int MinAge { get; set; }
 
     public int MaxAge { get; set; }


### PR DESCRIPTION
NoAgeRestrictions field was previously ignored during mapping between WorkshopV2Dto and WorkshopDraftContent. As a result, even when true was sent from frontend, the saved draft had false with MinAge=0, MaxAge=120. Mapping configuration was updated to fix the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workshop drafts now support a configurable age restrictions option. Users can clearly indicate if a workshop draft should be free of age limitations, ensuring that eligibility criteria are accurately maintained across workflows.
  - This update delivers enhanced accuracy and consistency in workshop setup, providing a more reliable experience for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->