### PR TITLE
hotfix(validation): update DateTimeRanges validation logic and message

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/TempSave/WorkshopMainRequiredPropertiesDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/TempSave/WorkshopMainRequiredPropertiesDto.cs
@@ -63,10 +63,10 @@ public class WorkshopMainRequiredPropertiesDto : IValidatableObject
         // TODO: Validate DateTimeRanges are not empty when frontend is ready
         foreach (var dateTimeRange in DateTimeRanges)
         {
-            if (dateTimeRange.StartTime > dateTimeRange.EndTime)
+            if (dateTimeRange.StartTime >= dateTimeRange.EndTime)
             {
                 yield return new ValidationResult(
-                    "End date can't be earlier that start date");
+                    "The end date cannot be equal to or earlier than the start date");
             }
 
             if (dateTimeRange.Workdays.IsNullOrEmpty() || dateTimeRange.Workdays.Any(workday => workday == DaysBitMask.None))

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -150,10 +150,10 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
         // TODO: Validate DateTimeRanges are not empty when frontend is ready
         foreach (var dateTimeRange in DateTimeRanges)
         {
-            if (dateTimeRange.StartTime > dateTimeRange.EndTime)
+            if (dateTimeRange.StartTime >= dateTimeRange.EndTime)
             {
                 yield return new ValidationResult(
-                    "End date can't be earlier that start date");
+                     "The end date cannot be equal to or earlier than the start date");
             }
 
             if (dateTimeRange.Workdays.IsNullOrEmpty() || dateTimeRange.Workdays.Any(workday => workday == DaysBitMask.None))


### PR DESCRIPTION
The validation logic for DateTimeRanges in WorkshopMainRequiredPropertiesDto and WorkshopBaseDto now checks if the start time is greater than or equal to the end time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for date ranges to prevent end dates from being equal to or earlier than start dates.
  - Updated error messages to clearly state that end dates cannot be equal to or earlier than start dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->