### PR TITLE
Fix email job running every second instead of every minute

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Release.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.Release.json
@@ -118,7 +118,7 @@
   },
   "Quartz": {
     "CronSchedules": {
-      "EmailSenderCronScheduleString": "* 0/1 * * * ?"
+      "EmailSenderCronScheduleString": "0 0/1 * * * ?"
     }
   },
   "ElasticApm": {

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Release.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Release.json
@@ -126,7 +126,7 @@
       "NotificationsClearingCronScheduleString": "0 10 1 1/14 * ?",
       "AverageRatingCalculatingCronScheduleString": "0 0 4 * * ?",
       "LicenseApprovalNotificationCronScheduleString": "0 0 6 10 JAN ? *",
-      "EmailSenderCronScheduleString": "* 0/1 * * * ?"
+      "EmailSenderCronScheduleString": "0 0/1 * * * ?"
     }
   },
   "GeoCoding": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the scheduling of the automated email sender job to run once per minute instead of every second within a minute. This change improves timing consistency for scheduled email notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->