### PR TITLE
Fix swagger security definitions for prod and test

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/SwaggerExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/SwaggerExtensions.cs
@@ -29,7 +29,7 @@ public static class SwaggerExtensions
 
                 c.SchemaFilter<ExcludeClrTypesFilter>(new List<Assembly> {typeof(OutOfSchoolDbContext).Assembly});
                 c.DocumentFilter<SwaggerFeatureGateFilter>();
-                c.OperationFilter<AuthorizeCheckOperationFilter>();
+                c.OperationFilter<AuthorizeCheckOperationFilter>(config.SecurityDefinitions.Title);
                 c.AddSecurityDefinition(config.SecurityDefinitions.Title, new OpenApiSecurityScheme
                 {
                     Description = config.SecurityDefinitions.Description,

--- a/OutOfSchool/OutOfSchool.WebApi/Util/AuthorizeCheckOperationFilter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/AuthorizeCheckOperationFilter.cs
@@ -3,7 +3,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace OutOfSchool.WebApi.Util;
 
-public class AuthorizeCheckOperationFilter : IOperationFilter
+public class AuthorizeCheckOperationFilter(string authorizationName) : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
@@ -15,14 +15,14 @@ public class AuthorizeCheckOperationFilter : IOperationFilter
         {
             operation.Security = new List<OpenApiSecurityRequirement>
             {
-                new OpenApiSecurityRequirement
+                new()
                 {
                     [
                         new OpenApiSecurityScheme {
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.SecurityScheme,
-                                Id = "Authorization server",
+                                Id = authorizationName,
                             },
                         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved configurability of authorization handling in API documentation by allowing the security scheme name to be set dynamically, rather than using a fixed value. This enhances flexibility for environments with custom security definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->