### PR TITLE
Fix of custom certificate validation issue

### DIFF
--- a/OutOfSchool/OutOfSchool.ExternalFileStore.Impl/Config/StorageOptions.cs
+++ b/OutOfSchool/OutOfSchool.ExternalFileStore.Impl/Config/StorageOptions.cs
@@ -171,6 +171,11 @@ public class AmazonS3Config
     /// Gets or sets the S3 service URL endpoint.
     /// </summary>
     public string ServiceUrl { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the self-signed certificate path.
+    /// </summary>
+    public string SslCertPath { get; set; }
 }
 
 /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/FileStorageExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/FileStorageExtensions.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using Google.Cloud.Storage.V1;
 using Minio;
 using OutOfSchool.ExternalFileStore;
@@ -55,12 +57,32 @@ public static class FileStorageExtensions
             }
             case StorageProviderType.AmazonS3:
             {
-                var storageClient = new MinioClient()
+                var minioBuilder = new MinioClient()
                     .WithEndpoint(options.Providers.AmazonS3.ServiceUrl)
                     .WithCredentials(options.Providers.AmazonS3.AccessKey, options.Providers.AmazonS3.SecretKey)
                     .WithRegion(options.Providers.AmazonS3.Region)
-                    .WithSSL()
-                    .Build();
+                    .WithSSL();
+
+                if (!options.Providers.AmazonS3.SslCertPath.IsNullOrEmpty())
+                {
+                    var caCert = new X509Certificate2(options.Providers.AmazonS3.SslCertPath);
+                    
+                    var handler = new HttpClientHandler
+                    {
+                        ServerCertificateCustomValidationCallback = (_, serverCert, chain, errors) =>
+                        {
+                            if ((errors & ~SslPolicyErrors.RemoteCertificateChainErrors) != 0)
+                                return false;
+                            
+                            chain.ChainPolicy.CustomTrustStore.Add(caCert);
+                            chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                            return chain.Build(serverCert);
+                        }
+                    };
+                    minioBuilder.WithHttpClient(new HttpClient(handler), true);
+                }
+                
+                var storageClient = minioBuilder.Build();
 
                 services.AddSingleton<IStorageContext<IMinioClient>, S3StorageContext>(_ =>
                     new S3StorageContext(storageClient, options.Containers.Images.BucketName));

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -97,7 +97,8 @@
         "AccessKey": "",
         "SecretKey": "",
         "Region": "us-east-1",
-        "ServiceUrl": ""
+        "ServiceUrl": "",
+        "SslCertPath": ""
       },
       "Fake": {
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a custom SSL certificate path for Amazon S3 file storage connections.
  - Enhanced configuration options to allow the use of self-signed SSL certificates when connecting to storage services.

- **Configuration**
  - Introduced a new "SslCertPath" setting in the configuration file for Amazon S3 storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->