### PR TITLE
Implement Quartz.NET monitoring API for TechAdmin

### DIFF
--- a/OutOfSchool/Directory.Packages.props
+++ b/OutOfSchool/Directory.Packages.props
@@ -15,14 +15,20 @@
   </PropertyGroup>
   <ItemGroup>
     <!--Basic Microsoft Packages-->
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(BaseVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(BaseVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(BaseVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(DIAbstractions)" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+    <PackageVersion Include="Quartz" Version="3.14.0" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.14.0" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.8.31" />
     <!-- Needed for EUSign Library -->
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <!--MVC-->
@@ -77,8 +83,8 @@
     <PackageVersion Include="AutoMapper" Version="$(AutoMapVersion)" />
     <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="$(AutoMapVersion)" />
     <!--Quartz-->
-    <PackageVersion Include="Quartz.AspNetCore" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.AspNetCore" Version="3.14.0" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.14.0" />
     <PackageVersion Include="Quartz.Plugins.TimeZoneConverter" Version="$(QuartzVersion)" />
     <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
     <!--Image processing-->

--- a/OutOfSchool/Directory.Packages.props
+++ b/OutOfSchool/Directory.Packages.props
@@ -6,7 +6,7 @@
     <EFCoreVersion>8.0.13</EFCoreVersion>
     <OpenIdDictVersion>6.1.1</OpenIdDictVersion>
     <SwaggerVersion>6.9.0</SwaggerVersion>
-    <QuartzVersion>3.13.1</QuartzVersion>
+    <QuartzVersion>3.14.0</QuartzVersion>
     <RedisVersion>6.0.21</RedisVersion>
     <AutoMapVersion>12.0.1</AutoMapVersion>
     <ElasticApmVersion>1.28.6</ElasticApmVersion>
@@ -15,11 +15,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!--Basic Microsoft Packages-->
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.15" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(BaseVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(BaseVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(BaseVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(DIAbstractions)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
@@ -81,12 +79,12 @@
     <PackageVersion Include="AutoMapper" Version="$(AutoMapVersion)" />
     <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="$(AutoMapVersion)" />
     <!--Quartz-->
-    <PackageVersion Include="Quartz.AspNetCore" Version="3.14.0" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.14.0" />
+    <PackageVersion Include="Quartz.AspNetCore" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="$(QuartzVersion)" />
     <PackageVersion Include="Quartz.Plugins.TimeZoneConverter" Version="$(QuartzVersion)" />
     <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
-    <PackageVersion Include="Quartz" Version="3.14.0" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.14.0" />
+    <PackageVersion Include="Quartz" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="$(QuartzVersion)" />
     <!--Image processing-->
     <PackageVersion Include="SkiaSharp" Version="2.88.6" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />

--- a/OutOfSchool/Directory.Packages.props
+++ b/OutOfSchool/Directory.Packages.props
@@ -26,9 +26,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
-    <PackageVersion Include="Quartz" Version="3.14.0" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.14.0" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.8.31" />
     <!-- Needed for EUSign Library -->
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <!--MVC-->
@@ -57,6 +54,7 @@
     <!--Redis-->
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="$(RedisVersion)" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.8.31" />
     <!--Identity-->
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.1" />
     <PackageVersion Include="IdentityModel" Version="6.1.0" />
@@ -87,6 +85,8 @@
     <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.14.0" />
     <PackageVersion Include="Quartz.Plugins.TimeZoneConverter" Version="$(QuartzVersion)" />
     <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="$(QuartzVersion)" />
+    <PackageVersion Include="Quartz" Version="3.14.0" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.14.0" />
     <!--Image processing-->
     <PackageVersion Include="SkiaSharp" Version="2.88.6" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Extensions/EmailSenderExtension.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Extensions/EmailSenderExtension.cs
@@ -15,12 +15,16 @@ public static class EmailSenderExtension
 
         var emailSenderJobKey = new JobKey(EmailSenderConstants.EmailJob, EmailSenderConstants.EmailGroup);
 
-        quartz.AddJob<EmailSenderJob>(j => j.WithIdentity(emailSenderJobKey));
+        quartz.AddJob<EmailSenderJob>(j => j
+            .WithIdentity(emailSenderJobKey)
+            .WithDescription("Sends a single email with expiration check using data passed to the job"));
+
         quartz.AddTrigger(t => t
             .WithIdentity(EmailSenderConstants.EmailSenderJobTrigger, EmailSenderConstants.EmailGroup)
             .StartNow()
             .WithCronSchedule(quartzConfig.CronSchedules.EmailSenderCronScheduleString)
-            .ForJob(emailSenderJobKey));
+            .ForJob(emailSenderJobKey)
+            .WithDescription($"Runs by schedule: {quartzConfig.CronSchedules.EmailSenderCronScheduleString}"));
 
         quartz.AddJobListener<EmailSenderJobListener>(GroupMatcher<JobKey>.GroupEquals(EmailSenderConstants.EmailGroup));
     }

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/OutOfSchool.AuthorizationServer.csproj
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/OutOfSchool.AuthorizationServer.csproj
@@ -47,5 +47,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\OutOfSchool.AuthCommon\OutOfSchool.AuthCommon.csproj" />
+        <ProjectReference Include="..\OutOfSchool.QuartzJobs.Api\OutOfSchool.QuartzJobs.Api.csproj" />
     </ItemGroup>
 </Project>

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Startup.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Startup.cs
@@ -18,6 +18,7 @@ using OutOfSchool.AuthorizationServer.KeyManagement;
 using OutOfSchool.AuthorizationServer.Services;
 using OutOfSchool.Common.Validators;
 using OutOfSchool.EmailSender.Services;
+using OutOfSchool.QuartzJobs.Api.Extensions;
 using SameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode;
 
 namespace OutOfSchool.AuthorizationServer;
@@ -47,7 +48,13 @@ public static class Startup
         services.AddDefaultQuartz(
             config,
             quartzConfig.ConnectionStringKey,
-            t => t.AddEmailSender(quartzConfig));
+            quartz =>
+            {
+                quartz.AddQuartzMonitoringListener();
+                quartz.AddEmailSender(quartzConfig);
+            });
+
+        services.AddQuartzMonitoring(config);
 
         var connectionString = config.GetMySqlConnectionString<AuthorizationConnectionOptions>(
             "DefaultConnection",

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.json
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/appsettings.json
@@ -220,5 +220,15 @@
     "ClientId": "",
     "ClientSecret": "",
     "TokenEndpoint": ""
+  },
+
+  "QuartzMonitoring": {
+    "Enabled": true,
+    "Redis": {
+      "Server": "localhost",
+      "Port": 6379,
+      "Password": "",
+      "HistoryLength": 10
+    }
   }
 }

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/ApplicationStatusChangingExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/ApplicationStatusChangingExtensions.cs
@@ -21,11 +21,15 @@ public static class ApplicationStatusChangingExtensions
 
         var applicationStatusChangingJobKey = new JobKey(JobConstants.ApplicationStatusChanging, GroupConstants.ApplicationStatusChange);
 
-        quartz.AddJob<ApplicationStatusChangingJob>(j => j.WithIdentity(applicationStatusChangingJobKey));
+        quartz.AddJob<ApplicationStatusChangingJob>(j => j
+            .WithIdentity(applicationStatusChangingJobKey)
+            .WithDescription("Changes all Approved applications to StudyingForYears status automatically by schedule."));
+
         quartz.AddTrigger(t => t
             .WithIdentity(JobTriggerConstants.ApplicationStatusChanging, GroupConstants.ApplicationStatusChange)
             .ForJob(applicationStatusChangingJobKey)
             .StartNow()
-            .WithCronSchedule(quartzConfig.CronSchedules.ApplicationStatusChangingCronScheduleString));
+            .WithCronSchedule(quartzConfig.CronSchedules.ApplicationStatusChangingCronScheduleString)
+            .WithDescription($"Runs by schedule: {quartzConfig.CronSchedules.ApplicationStatusChangingCronScheduleString}"));
     }
 }

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/AverageRatingExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/AverageRatingExtensions.cs
@@ -28,11 +28,16 @@ public static class AverageRatingExtensions
 
         var averageRatingCalculatingJobKey = new JobKey(JobConstants.AverageRatingCalculating, GroupConstants.AverageRating);
 
-        quartz.AddJob<AverageRatingQuartzJob>(j => j.WithIdentity(averageRatingCalculatingJobKey));
+        quartz.AddJob<AverageRatingQuartzJob>(j => j
+            .WithIdentity(averageRatingCalculatingJobKey)
+            .WithDescription("Calculates average ratings for all workshops and providers."));
+
         quartz.AddTrigger(t => t
             .WithIdentity(JobTriggerConstants.AverageRatingCalculating, GroupConstants.AverageRating)
             .ForJob(averageRatingCalculatingJobKey)
             .StartNow()
-            .WithCronSchedule(quartzConfig.CronSchedules.AverageRatingCalculatingCronScheduleString));
+            .WithCronSchedule(quartzConfig.CronSchedules.AverageRatingCalculatingCronScheduleString)
+            .WithDescription($"Runs by schedule: {quartzConfig.CronSchedules.AverageRatingCalculatingCronScheduleString}"));
+
     }
 }

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/ElasticsearchSynchronizationExtension.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/ElasticsearchSynchronizationExtension.cs
@@ -49,26 +49,32 @@ public static class ElasticsearchSynchronizationExtension
 
         var workshopSyncJobKey = new JobKey(JobConstants.ElasticSearchWorkshopSynchronization, GroupConstants.ElasticSearch);
 
-        quartz.AddJob<ElasticsearchWorkshopSynchronizationQuartzJob>(j => j.WithIdentity(workshopSyncJobKey));
+        quartz.AddJob<ElasticsearchWorkshopSynchronizationQuartzJob>(j => j
+            .WithIdentity(workshopSyncJobKey)
+            .WithDescription("Synchronizes workshop data to Elasticsearch index."));
         // TODO: rewrite as a cron trigger
         quartz.AddTrigger(t => t
             .WithIdentity(JobTriggerConstants.ElasticSearchWorkshopSynchronization, GroupConstants.ElasticSearch)
             .ForJob(workshopSyncJobKey)
             .StartNow()
             .WithSimpleSchedule(x =>
-                x.WithInterval(TimeSpan.FromMilliseconds(elasticSynchronizationSchedulerConfig
-                    .DelayBetweenTasksInMilliseconds)).RepeatForever()));
+                x.WithInterval(TimeSpan.FromMilliseconds(elasticSynchronizationSchedulerConfig.DelayBetweenTasksInMilliseconds))
+                 .RepeatForever())
+            .WithDescription($"Runs repeatedly every {elasticSynchronizationSchedulerConfig.DelayBetweenTasksInMilliseconds} ms."));
 
         var competitiveEventSyncJobKey = new JobKey(JobConstants.ElasticSearchCompetitiveEventSynchronization, GroupConstants.ElasticSearch);
 
-        quartz.AddJob<ElasticsearchCompetitiveEventSynchronizationQuartzJob>(j => j.WithIdentity(competitiveEventSyncJobKey));
+        quartz.AddJob<ElasticsearchCompetitiveEventSynchronizationQuartzJob>(j => j
+            .WithIdentity(competitiveEventSyncJobKey)
+            .WithDescription("Synchronizes competitive event data to Elasticsearch index."));
         // TODO: rewrite as a cron trigger
         quartz.AddTrigger(t => t
             .WithIdentity(JobTriggerConstants.ElasticSearchCompetitiveEventSynchronization, GroupConstants.ElasticSearch)
             .ForJob(competitiveEventSyncJobKey)
             .StartNow()
             .WithSimpleSchedule(x =>
-                x.WithInterval(TimeSpan.FromMilliseconds(elasticSynchronizationSchedulerConfig
-                    .DelayBetweenTasksInMilliseconds)).RepeatForever()));
+                x.WithInterval(TimeSpan.FromMilliseconds(elasticSynchronizationSchedulerConfig.DelayBetweenTasksInMilliseconds))
+                 .RepeatForever())
+            .WithDescription($"Runs repeatedly every {elasticSynchronizationSchedulerConfig.DelayBetweenTasksInMilliseconds} ms."));
     }
 }

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/EmailSenderExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/EmailSenderExtensions.cs
@@ -22,12 +22,16 @@ public static class EmailSenderExtensions
 
         var emailSenderJobKey = new JobKey(JobConstants.EmailSender, GroupConstants.Emails);
 
-        quartz.AddJob<EmailSenderJob>(j => j.WithIdentity(emailSenderJobKey));
+        quartz.AddJob<EmailSenderJob>(j => j
+            .WithIdentity(emailSenderJobKey)
+            .WithDescription("Sends a single email based on parameters from JobDataMap with expiration time check."));
+
         quartz.AddTrigger(t => t
             .WithIdentity(JobTriggerConstants.EmailSender, GroupConstants.Emails)
             .ForJob(emailSenderJobKey)
             .StartNow()
-            .WithCronSchedule(quartzConfig.CronSchedules.EmailSenderCronScheduleString));
+            .WithCronSchedule(quartzConfig.CronSchedules.EmailSenderCronScheduleString)
+            .WithDescription($"Runs by schedule: {quartzConfig.CronSchedules.EmailSenderCronScheduleString}"));
 
         quartz.AddJobListener<EmailSenderJobListener>(GroupMatcher<JobKey>.GroupEquals(GroupConstants.Emails));
     }

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/NotificationExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/NotificationExtensions.cs
@@ -29,12 +29,16 @@ public static class NotificationExtensions
 
         var notificationsClearingJobKey = new JobKey(JobConstants.NotificationsClearing, GroupConstants.Notifications);
 
-        quartz.AddJob<NotificationsClearingQuartsJob>(j => j.WithIdentity(notificationsClearingJobKey));
+        quartz.AddJob<NotificationsClearingQuartsJob>(j => j
+            .WithIdentity(notificationsClearingJobKey)
+            .WithDescription("Clears old notifications from the system."));
+
         quartz.AddTrigger(t => t
             .WithIdentity(JobTriggerConstants.NotificationsClearing, GroupConstants.Notifications)
             .ForJob(notificationsClearingJobKey)
             .StartNow()
-            .WithCronSchedule(quartzConfig.CronSchedules.NotificationsClearingCronScheduleString));
+            .WithCronSchedule(quartzConfig.CronSchedules.NotificationsClearingCronScheduleString)
+            .WithDescription($"Runs by schedule: {quartzConfig.CronSchedules.NotificationsClearingCronScheduleString}"));
     }
 
     /// <summary>
@@ -56,12 +60,16 @@ public static class NotificationExtensions
 
         var licenseApprovalNotificationJobKey = new JobKey(JobConstants.LicenseApprovalNotification, GroupConstants.Notifications);
 
-        quartz.AddJob<LicenseApprovalNotificationQuartzJob>(j => j.WithIdentity(licenseApprovalNotificationJobKey));
+        quartz.AddJob<LicenseApprovalNotificationQuartzJob>(j => j
+            .WithIdentity(licenseApprovalNotificationJobKey)
+            .WithDescription("Generates license approval notifications for providers."));
+
         quartz.AddTrigger(t => t
             .WithIdentity(JobTriggerConstants.LicenseApprovalNotification, GroupConstants.Notifications)
             .ForJob(licenseApprovalNotificationJobKey)
             .StartNow()
-            .WithCronSchedule(quartzConfig.CronSchedules.LicenseApprovalNotificationCronScheduleString));
+            .WithCronSchedule(quartzConfig.CronSchedules.LicenseApprovalNotificationCronScheduleString)
+            .WithDescription($"Runs by schedule: {quartzConfig.CronSchedules.LicenseApprovalNotificationCronScheduleString}"));
     }
 
 }

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/ObjectStorageSynchronizationExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/ObjectStorageSynchronizationExtensions.cs
@@ -45,11 +45,15 @@ public static class ObjectStorageSynchronizationExtensions
 
         var gcpImagesJobKey = new JobKey(JobConstants.GcpImagesSynchronization, GroupConstants.Gcp);
 
-        quartz.AddJob<ObjectStorageSynchronizationQuartzJob>(j => j.WithIdentity(gcpImagesJobKey));
+        quartz.AddJob<ObjectStorageSynchronizationQuartzJob>(j => j
+            .WithIdentity(gcpImagesJobKey)
+            .WithDescription("Synchronizes object storage files with database records."));
+
         quartz.AddTrigger(t => t
             .WithIdentity(JobTriggerConstants.GcpImagesSynchronization, GroupConstants.Gcp)
             .ForJob(gcpImagesJobKey)
             .StartNow()
-            .WithCronSchedule(quartzConfig.CronSchedules.GcpImagesSyncCronScheduleString));
+            .WithCronSchedule(quartzConfig.CronSchedules.GcpImagesSyncCronScheduleString)
+            .WithDescription($"Runs by schedule: {quartzConfig.CronSchedules.GcpImagesSyncCronScheduleString}"));
     }
 }

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/StatisticReportExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/StatisticReportExtensions.cs
@@ -28,11 +28,15 @@ public static class StatisticReportExtensions
 
         var statisticReportsMakingJobKey = new JobKey(JobConstants.StatisticReportsMaking, GroupConstants.StatisticReports);
 
-        quartz.AddJob<StatisticReportsMakingQuartsJob>(j => j.WithIdentity(statisticReportsMakingJobKey));
+        quartz.AddJob<StatisticReportsMakingQuartsJob>(j => j
+            .WithIdentity(statisticReportsMakingJobKey)
+            .WithDescription("Generates statistic reports and saves them to the database."));
+
         quartz.AddTrigger(t => t
             .WithIdentity(JobTriggerConstants.StatisticReportsMaking, GroupConstants.StatisticReports)
             .ForJob(statisticReportsMakingJobKey)
             .StartNow()
-            .WithCronSchedule(quartzConfig.CronSchedules.StatisticReportsMakingCronScheduleString));
+            .WithCronSchedule(quartzConfig.CronSchedules.StatisticReportsMakingCronScheduleString)
+            .WithDescription($"Runs by schedule: {quartzConfig.CronSchedules.StatisticReportsMakingCronScheduleString}"));
     }
 }

--- a/OutOfSchool/OutOfSchool.EmailSender/Services/EmailSenderService.cs
+++ b/OutOfSchool/OutOfSchool.EmailSender/Services/EmailSenderService.cs
@@ -36,13 +36,15 @@ public class EmailSenderService : IEmailSenderService
 
         var job = JobBuilder
             .Create<EmailSenderJob>()
-            .WithIdentity($"emailSenderJob_{Guid.NewGuid()}", "emails")
+            .WithIdentity($"sendEmailTo_{email}_{Guid.NewGuid()}", "emails")
+            .WithDescription($"Send email to {email} with subject '{subject}'")
             .UsingJobData(jobData)
             .Build();
 
         var trigger = TriggerBuilder
             .Create()
             .StartAt(sendGridAccessibilityService.GetAccessibilityTime(DateTimeOffset.Now))
+            .WithDescription($"Send email to {email}")
             .Build();
 
         await scheduler.ScheduleJob(job, trigger);

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Configuration/QuartzMonitoringOptions.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Configuration/QuartzMonitoringOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace OutOfSchool.QuartzJobs.Api.Configuration;
+
+public class QuartzMonitoringOptions
+{
+    public bool Enabled { get; set; } = true;
+    public RedisConfig? Redis { get; set; }
+
+    public class RedisConfig
+    {
+        public string? Server { get; set; }
+        public int Port { get; set; }
+        public string? Password { get; set; }
+        public int HistoryLength { get; set; }
+    }
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Extensions/QuartzMonitoringEndpoints.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Extensions/QuartzMonitoringEndpoints.cs
@@ -67,7 +67,7 @@ public static class QuartzMonitoringEndpoints
         .WithDescription("Returns only failed execution logs for a specific job.");
 
 
-        group.MapGet("/jobs/next", async (IQuartzMonitoringService service) =>
+        group.MapGet("/jobs/scheduled", async (IQuartzMonitoringService service) =>
         {
             var result = await service.GetNextExecutionsForAllJobsAsync();
             return Results.Ok(result);
@@ -76,7 +76,7 @@ public static class QuartzMonitoringEndpoints
         .WithDescription("Returns the next planned execution times for all jobs and their triggers.");
 
 
-        group.MapGet("/jobs/{jobName}/next", async (string jobName, IQuartzMonitoringService service) =>
+        group.MapGet("/jobs/{jobName}/scheduled", async (string jobName, IQuartzMonitoringService service) =>
         {
             var result = await service.GetNextExecutionsForJobAsync(jobName);
             return result.Any() 

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Extensions/QuartzMonitoringEndpoints.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Extensions/QuartzMonitoringEndpoints.cs
@@ -22,7 +22,7 @@ public static class QuartzMonitoringEndpoints
             return Results.Ok(jobs);
         })
         .WithSummary("Get all jobs with their current status.")
-        .WithDescription("Returns a list of all jobs with their details and calculated status: Active, Paused, Running, Mixed or Unknown.");
+        .WithDescription("Returns a list of all jobs with their details and calculated status: Scheduled, Paused, Running, Mixed or Unknown.");
 
 
         group.MapGet("/jobs/running", async (IQuartzMonitoringService service) =>

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Extensions/QuartzMonitoringEndpoints.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Extensions/QuartzMonitoringEndpoints.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using OutOfSchool.QuartzJobs.Api.Services;
+
+namespace OutOfSchool.QuartzJobs.Api.Extensions;
+
+public static class QuartzMonitoringEndpoints
+{
+    /// <summary>
+    /// Maps Quartz monitoring API endpoints for jobs information, history, errors, and upcoming executions.
+    /// </summary>
+    /// <param name="endpoints">The route builder.</param>
+    /// <returns>The updated endpoint route builder.</returns>
+    public static RouteGroupBuilder MapQuartzMonitoringApi(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/quartz").WithTags("Quartz Jobs");
+
+        group.MapGet("/jobs", async (IQuartzMonitoringService service) =>
+        {
+            var jobs = await service.GetAllJobsAsync();
+            return Results.Ok(jobs);
+        })
+        .WithSummary("Get all jobs with their current status.")
+        .WithDescription("Returns a list of all jobs with their details and calculated status: Active, Paused, Running, Mixed or Unknown.");
+
+
+        group.MapGet("/jobs/running", async (IQuartzMonitoringService service) =>
+        {
+            var jobs = await service.GetRunningJobsAsync();
+            return Results.Ok(jobs);
+        })
+        .WithSummary("Get currently running jobs.")
+        .WithDescription("Returns all jobs that are currently being executed, including their start time and trigger information.");
+
+
+        group.MapGet("/jobs/{jobName}", async (string jobName, IQuartzMonitoringService service) =>
+        {
+            var job = await service.GetJobDetailsAsync(jobName);
+            return job is not null 
+                ? Results.Ok(job) 
+                : Results.NotFound($"Job with name '{jobName}' was not found.");
+        })
+        .WithSummary("Get detailed information about a specific job.")
+        .WithDescription("Returns job details, trigger keys, and upcoming execution times for a specific job by name.");
+
+
+        group.MapGet("/jobs/{jobName}/history", async (string jobName, IQuartzMonitoringService service) =>
+        {
+            var history = await service.GetJobHistoryAsync(jobName);
+            return history.Any() 
+                ? Results.Ok(history) 
+                : Results.NotFound($"Job with name '{jobName}' was not found.");
+        })
+        .WithSummary("Get execution history of a specific job.")
+        .WithDescription("Returns execution history (success and failure logs) for a specific job.");
+
+
+        group.MapGet("/jobs/{jobName}/errors", async (string jobName, IQuartzMonitoringService service) =>
+        {
+            var failed = await service.GetFailedJobsAsync(jobName);
+            return failed.Any() 
+                ? Results.Ok(failed) 
+                : Results.NotFound($"Job with name '{jobName}' was not found.");
+        })
+        .WithSummary("Get failed execution history of a specific job.")
+        .WithDescription("Returns only failed execution logs for a specific job.");
+
+
+        group.MapGet("/jobs/next", async (IQuartzMonitoringService service) =>
+        {
+            var result = await service.GetNextExecutionsForAllJobsAsync();
+            return Results.Ok(result);
+        })
+        .WithSummary("Get upcoming execution times for all jobs.")
+        .WithDescription("Returns the next planned execution times for all jobs and their triggers.");
+
+
+        group.MapGet("/jobs/{jobName}/next", async (string jobName, IQuartzMonitoringService service) =>
+        {
+            var result = await service.GetNextExecutionsForJobAsync(jobName);
+            return result.Any() 
+                ? Results.Ok(result) 
+                : Results.NotFound($"Job with name '{jobName}' was not found.");
+        })
+        .WithSummary("Get upcoming execution times for a specific job.")
+        .WithDescription("Returns the next planned execution times for all triggers of a specific job by name.");
+
+        return group;
+    }
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Extensions/QuartzMonitoringExtensions.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Extensions/QuartzMonitoringExtensions.cs
@@ -1,30 +1,40 @@
-﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OutOfSchool.QuartzJobs.Api.Configuration;
 using OutOfSchool.QuartzJobs.Api.Listeners;
 using OutOfSchool.QuartzJobs.Api.Logging;
+using OutOfSchool.QuartzJobs.Api.Services;
 using Quartz;
-using Quartz.Impl.Matchers;
 using StackExchange.Redis;
 
 namespace OutOfSchool.QuartzJobs.Api.Extensions;
 
+/// <summary>
+/// Provides extension methods to register Quartz monitoring services and endpoints.
+/// </summary>
 public static class QuartzMonitoringExtensions
 {
+    /// <summary>
+    /// Registers the job execution listener for monitoring Quartz jobs.
+    /// </summary>
+    /// <param name="quartz">Quartz service configurator.</param>
     public static void AddQuartzMonitoringListener(this IServiceCollectionQuartzConfigurator quartz)
     {
         quartz.AddJobListener<JobMonitoringListener>();
     }
 
+    /// <summary>
+    /// Registers Quartz monitoring services, configuration, Redis connection, and logger.
+    /// </summary>
+    /// <param name="services">Service collection.</param>
+    /// <param name="configuration">Application configuration.</param>
+    /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddQuartzMonitoring(this IServiceCollection services, IConfiguration configuration)
     {
         // Add QuartzMonitoring configuration
         services.Configure<QuartzMonitoringOptions>(configuration.GetSection("QuartzMonitoring"));
+        services.AddSingleton<IQuartzMonitoringService, QuartzMonitoringService>();
 
         // Register Logger and Listener for Quartz  
         services.AddSingleton<IJobExecutionLogger, RedisJobExecutionLogger>();
@@ -48,114 +58,6 @@ public static class QuartzMonitoringExtensions
         });
 
         return services;
-    }
-
-    public static IEndpointRouteBuilder MapQuartzMonitoringApi(this IEndpointRouteBuilder endpoints)
-    {
-        var group = endpoints.MapGroup("/monitoring")
-            .WithTags("Quartz Monitoring");
-
-        group.MapGet("/jobs", async ([FromServices] ISchedulerFactory schedulerFactory) =>
-        {
-            var scheduler = await schedulerFactory.GetScheduler();
-
-            var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
-            var jobs = new List<object>();
-
-            foreach (var jobKey in jobKeys)
-            {
-                var detail = await scheduler.GetJobDetail(jobKey);
-                jobs.Add(new
-                {
-                    jobKey.Name,
-                    jobKey.Group,
-                    detail.Description,
-                    JobType = detail.JobType.FullName
-                });
-            }
-
-            return Results.Ok(jobs);
-        });
-
-        endpoints.MapGet("/jobs/{jobName}", async (string jobName, [FromServices] ISchedulerFactory schedulerFactory) =>
-        {
-            var scheduler = await schedulerFactory.GetScheduler();
-
-            var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
-            var jobKey = jobKeys.FirstOrDefault(k => k.Name == jobName);
-            if (jobKey is null)
-                return Results.NotFound();
-
-            var detail = await scheduler.GetJobDetail(jobKey);
-            var triggers = await scheduler.GetTriggersOfJob(jobKey);
-
-            return Results.Ok(new
-            {
-                jobKey.Name,
-                jobKey.Group,
-                detail.Description,
-                JobType = detail.JobType.FullName,
-                Triggers = triggers.Select(t => new {
-                    TriggerKey = t.Key,
-                    NextFireTimeUtc = t.GetNextFireTimeUtc(),
-                    Cron = t is ICronTrigger cron ? cron.CronExpressionString : null
-                })
-            });
-        })
-        .WithName("GetJobDetails");
-
-
-        group.MapGet("/jobs/{jobName}/history", async (string jobName, IJobExecutionLogger logger) =>
-        {
-            var history = await logger.GetHistoryAsync(jobName);
-            return Results.Ok(history);
-        });
-
-        group.MapGet("/jobs/{jobName}/errors", async (string jobName, IJobExecutionLogger logger) =>
-        {
-            var failed = await logger.GetFailedAsync(jobName);
-            return Results.Ok(failed);
-        });
-
-        group.MapGet("/jobs/{jobName}/next", async (string jobName, [FromServices] ISchedulerFactory schedulerFactory) =>
-        {
-            var scheduler = await schedulerFactory.GetScheduler();
-
-            var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
-            var jobKey = jobKeys.FirstOrDefault(k => k.Name == jobName);
-            if (jobKey is null)
-                return Results.NotFound();
-
-            var triggers = await scheduler.GetTriggersOfJob(jobKey);
-            var upcoming = triggers
-                .Select(t => new {
-                    Trigger = t.Key,
-                    NextFireTimeUtc = t.GetNextFireTimeUtc(),
-                    Cron = t is ICronTrigger cron ? cron.CronExpressionString : null
-                });
-
-            return Results.Ok(upcoming);
-        });
-
-        group.MapGet("/jobs/status", async ([FromServices] ISchedulerFactory schedulerFactory) =>
-        {
-            var scheduler = await schedulerFactory.GetScheduler();
-
-            var currentlyExecuting = await scheduler.GetCurrentlyExecutingJobs();
-
-            var status = currentlyExecuting.Select(ctx => new
-            {
-                Job = ctx.JobDetail.Key.Name,
-                ctx.JobDetail.Key.Group,
-                StartedAt = ctx.FireTimeUtc,
-                Trigger = ctx.Trigger.Key.Name,
-                TriggerGroup = ctx.Trigger.Key.Group
-            });
-
-            return Results.Ok(status);
-        });
-
-        return endpoints;
     }
 }
 

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Extensions/QuartzMonitoringExtensions.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Extensions/QuartzMonitoringExtensions.cs
@@ -1,0 +1,161 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OutOfSchool.QuartzJobs.Api.Configuration;
+using OutOfSchool.QuartzJobs.Api.Listeners;
+using OutOfSchool.QuartzJobs.Api.Logging;
+using Quartz;
+using Quartz.Impl.Matchers;
+using StackExchange.Redis;
+
+namespace OutOfSchool.QuartzJobs.Api.Extensions;
+
+public static class QuartzMonitoringExtensions
+{
+    public static void AddQuartzMonitoringListener(this IServiceCollectionQuartzConfigurator quartz)
+    {
+        quartz.AddJobListener<JobMonitoringListener>();
+    }
+
+    public static IServiceCollection AddQuartzMonitoring(this IServiceCollection services, IConfiguration configuration)
+    {
+        // Add QuartzMonitoring configuration
+        services.Configure<QuartzMonitoringOptions>(configuration.GetSection("QuartzMonitoring"));
+
+        // Register Logger and Listener for Quartz  
+        services.AddSingleton<IJobExecutionLogger, RedisJobExecutionLogger>();
+        services.AddSingleton<IJobListener, JobMonitoringListener>();
+
+        // Redis connection
+        services.AddSingleton<IConnectionMultiplexer>(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<QuartzMonitoringOptions>>().Value;
+
+            var redis = options.Redis!;
+
+            var configurationOptions = new ConfigurationOptions
+            {
+                EndPoints = { $"{redis.Server}:{redis.Port}" },
+                Password = string.IsNullOrWhiteSpace(redis.Password) ? null : redis.Password,
+                AbortOnConnectFail = false
+            };
+
+            return ConnectionMultiplexer.Connect(configurationOptions);
+        });
+
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapQuartzMonitoringApi(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/monitoring")
+            .WithTags("Quartz Monitoring");
+
+        group.MapGet("/jobs", async ([FromServices] ISchedulerFactory schedulerFactory) =>
+        {
+            var scheduler = await schedulerFactory.GetScheduler();
+
+            var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
+            var jobs = new List<object>();
+
+            foreach (var jobKey in jobKeys)
+            {
+                var detail = await scheduler.GetJobDetail(jobKey);
+                jobs.Add(new
+                {
+                    jobKey.Name,
+                    jobKey.Group,
+                    detail.Description,
+                    JobType = detail.JobType.FullName
+                });
+            }
+
+            return Results.Ok(jobs);
+        });
+
+        endpoints.MapGet("/jobs/{jobName}", async (string jobName, [FromServices] ISchedulerFactory schedulerFactory) =>
+        {
+            var scheduler = await schedulerFactory.GetScheduler();
+
+            var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
+            var jobKey = jobKeys.FirstOrDefault(k => k.Name == jobName);
+            if (jobKey is null)
+                return Results.NotFound();
+
+            var detail = await scheduler.GetJobDetail(jobKey);
+            var triggers = await scheduler.GetTriggersOfJob(jobKey);
+
+            return Results.Ok(new
+            {
+                jobKey.Name,
+                jobKey.Group,
+                detail.Description,
+                JobType = detail.JobType.FullName,
+                Triggers = triggers.Select(t => new {
+                    TriggerKey = t.Key,
+                    NextFireTimeUtc = t.GetNextFireTimeUtc(),
+                    Cron = t is ICronTrigger cron ? cron.CronExpressionString : null
+                })
+            });
+        })
+        .WithName("GetJobDetails");
+
+
+        group.MapGet("/jobs/{jobName}/history", async (string jobName, IJobExecutionLogger logger) =>
+        {
+            var history = await logger.GetHistoryAsync(jobName);
+            return Results.Ok(history);
+        });
+
+        group.MapGet("/jobs/{jobName}/errors", async (string jobName, IJobExecutionLogger logger) =>
+        {
+            var failed = await logger.GetFailedAsync(jobName);
+            return Results.Ok(failed);
+        });
+
+        group.MapGet("/jobs/{jobName}/next", async (string jobName, [FromServices] ISchedulerFactory schedulerFactory) =>
+        {
+            var scheduler = await schedulerFactory.GetScheduler();
+
+            var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
+            var jobKey = jobKeys.FirstOrDefault(k => k.Name == jobName);
+            if (jobKey is null)
+                return Results.NotFound();
+
+            var triggers = await scheduler.GetTriggersOfJob(jobKey);
+            var upcoming = triggers
+                .Select(t => new {
+                    Trigger = t.Key,
+                    NextFireTimeUtc = t.GetNextFireTimeUtc(),
+                    Cron = t is ICronTrigger cron ? cron.CronExpressionString : null
+                });
+
+            return Results.Ok(upcoming);
+        });
+
+        group.MapGet("/jobs/status", async ([FromServices] ISchedulerFactory schedulerFactory) =>
+        {
+            var scheduler = await schedulerFactory.GetScheduler();
+
+            var currentlyExecuting = await scheduler.GetCurrentlyExecutingJobs();
+
+            var status = currentlyExecuting.Select(ctx => new
+            {
+                Job = ctx.JobDetail.Key.Name,
+                ctx.JobDetail.Key.Group,
+                StartedAt = ctx.FireTimeUtc,
+                Trigger = ctx.Trigger.Key.Name,
+                TriggerGroup = ctx.Trigger.Key.Group
+            });
+
+            return Results.Ok(status);
+        });
+
+        return endpoints;
+    }
+}
+

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Listeners/JobMonitoringListener.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Listeners/JobMonitoringListener.cs
@@ -36,6 +36,10 @@ public class JobMonitoringListener : IJobListener
         return Task.CompletedTask;
     }
 
+    // TODO: Investigate adding logic to populate RetryCount and job/trigger parameters inside the jobs themselves.
+    // Currently, these values are either null or empty in Redis logs, because jobs do not explicitly handle or expose them.
+    // Consider extending job implementations to provide meaningful retry info and execution parameters for monitoring purposes.
+
     /// <summary>
     /// Called after the job has been executed (successfully or not).
     /// Logs the job execution details to the configured logger.

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Listeners/JobMonitoringListener.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Listeners/JobMonitoringListener.cs
@@ -15,6 +15,10 @@ public class JobMonitoringListener : IJobListener
 
     public string Name => nameof(JobMonitoringListener);
 
+    /// <summary>
+    /// Called before the job is executed.
+    /// Saves the current UTC time to the job context for later duration calculation.
+    /// </summary>
     public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         // Save start time to context
@@ -22,23 +26,27 @@ public class JobMonitoringListener : IJobListener
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Called if the job execution was vetoed and did not run.
+    /// No logging is performed in this case.
+    /// </summary>
     public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         // If the job was blocked — do not log anything
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Called after the job has been executed (successfully or not).
+    /// Logs the job execution details to the configured logger.
+    /// </summary>
     public Task JobWasExecuted(
-        IJobExecutionContext context,
-        JobExecutionException? jobException,
-        CancellationToken cancellationToken = default)
+    IJobExecutionContext context,
+    JobExecutionException? jobException,
+    CancellationToken cancellationToken = default)
     {
         var startTime = context.MergedJobDataMap.Get("__StartTime") as DateTime? ?? DateTime.UtcNow;
         var endTime = DateTime.UtcNow;
-
-        var triggerType = context.Trigger.GetType().Name;
-        var cronTrigger = context.Trigger as ICronTrigger;
-        var simpleTrigger = context.Trigger as ISimpleTrigger;
 
         var info = new JobExecutionInfo
         {
@@ -46,19 +54,17 @@ public class JobMonitoringListener : IJobListener
             JobGroup = context.JobDetail.Key.Group,
             TriggerName = context.Trigger.Key.Name,
             TriggerGroup = context.Trigger.Key.Group,
-            StartTime = startTime,
-            EndTime = endTime,
+            StartTime = startTime.ToLocalTime(),
+            EndTime = endTime.ToLocalTime(),
             Duration = context.JobRunTime,
-            WasSuccessful = jobException == null,
+            WasSuccessful = jobException is null,
             RetryCount = context.RefireCount,
-            TriggerType = triggerType,
-            CronExpression = cronTrigger?.CronExpressionString,
-            RepeatInterval = simpleTrigger?.RepeatInterval.ToString(),
+            TriggerType = context.Trigger.GetType().Name,
             ErrorMessage = jobException?.Message,
             StackTrace = jobException?.InnerException?.ToString(),
             Parameters = context.MergedJobDataMap
-        .Where(kv => kv.Key != "__StartTime")
-        .ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? "null")
+                .Where(kv => kv.Key != "__StartTime")
+                .ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? "null")
         };
 
         return logger.LogAsync(info);

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Listeners/JobMonitoringListener.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Listeners/JobMonitoringListener.cs
@@ -1,0 +1,66 @@
+﻿using OutOfSchool.QuartzJobs.Api.Logging;
+using OutOfSchool.QuartzJobs.Api.Models;
+using Quartz;
+
+namespace OutOfSchool.QuartzJobs.Api.Listeners;
+
+public class JobMonitoringListener : IJobListener
+{
+    private readonly IJobExecutionLogger logger;
+
+    public JobMonitoringListener(IJobExecutionLogger logger)
+    {
+        this.logger = logger;
+    }
+
+    public string Name => nameof(JobMonitoringListener);
+
+    public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        // Save start time to context
+        context.MergedJobDataMap.Put("__StartTime", DateTime.UtcNow);
+        return Task.CompletedTask;
+    }
+
+    public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        // If the job was blocked — do not log anything
+        return Task.CompletedTask;
+    }
+
+    public Task JobWasExecuted(
+        IJobExecutionContext context,
+        JobExecutionException? jobException,
+        CancellationToken cancellationToken = default)
+    {
+        var startTime = context.MergedJobDataMap.Get("__StartTime") as DateTime? ?? DateTime.UtcNow;
+        var endTime = DateTime.UtcNow;
+
+        var triggerType = context.Trigger.GetType().Name;
+        var cronTrigger = context.Trigger as ICronTrigger;
+        var simpleTrigger = context.Trigger as ISimpleTrigger;
+
+        var info = new JobExecutionInfo
+        {
+            JobName = context.JobDetail.Key.Name,
+            JobGroup = context.JobDetail.Key.Group,
+            TriggerName = context.Trigger.Key.Name,
+            TriggerGroup = context.Trigger.Key.Group,
+            StartTime = startTime,
+            EndTime = endTime,
+            Duration = context.JobRunTime,
+            WasSuccessful = jobException == null,
+            RetryCount = context.RefireCount,
+            TriggerType = triggerType,
+            CronExpression = cronTrigger?.CronExpressionString,
+            RepeatInterval = simpleTrigger?.RepeatInterval.ToString(),
+            ErrorMessage = jobException?.Message,
+            StackTrace = jobException?.InnerException?.ToString(),
+            Parameters = context.MergedJobDataMap
+        .Where(kv => kv.Key != "__StartTime")
+        .ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? "null")
+        };
+
+        return logger.LogAsync(info);
+    }
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Listeners/JobMonitoringListener.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Listeners/JobMonitoringListener.cs
@@ -60,8 +60,8 @@ public class JobMonitoringListener : IJobListener
             WasSuccessful = jobException is null,
             RetryCount = context.RefireCount,
             TriggerType = context.Trigger.GetType().Name,
-            ErrorMessage = jobException?.Message,
-            StackTrace = jobException?.InnerException?.ToString(),
+            ErrorMessage = jobException?.Message ?? "No error message available",
+            StackTrace = jobException?.ToString() ?? "No exception details available",
             Parameters = context.MergedJobDataMap
                 .Where(kv => kv.Key != "__StartTime")
                 .ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? "null")

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Logging/IJobExecutionLogger.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Logging/IJobExecutionLogger.cs
@@ -2,22 +2,29 @@
 
 namespace OutOfSchool.QuartzJobs.Api.Logging;
 
+/// <summary>
+/// Provides methods for logging and retrieving job execution information.
+/// </summary>
 public interface IJobExecutionLogger
 {
     /// <summary>
-    /// Logs last job execution info to the storage.
+    /// Logs the latest job execution information to the storage.
     /// </summary>
-    /// <param name="info"></param>
-    /// <returns></returns>
+    /// <param name="info">The job execution information to log.</param>
+    /// <returns>A completed task.</returns>
     Task LogAsync(JobExecutionInfo info);
 
     /// <summary>
-    /// Returns last job execution info.
+    /// Retrieves the latest execution history for the specified job.
     /// </summary>
+    /// <param name="jobName">The name of the job.</param>
+    /// <returns>A list of job execution records, including both successful and failed executions.</returns>
     Task<IReadOnlyList<JobExecutionInfo>> GetHistoryAsync(string jobName);
 
     /// <summary>
-    /// Returns only failed job executions.
+    /// Retrieves only failed execution records for the specified job.
     /// </summary>
+    /// <param name="jobName">The name of the job.</param>
+    /// <returns>A list of failed job execution records.</returns>
     Task<IReadOnlyList<JobExecutionInfo>> GetFailedAsync(string jobName);
 }

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Logging/IJobExecutionLogger.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Logging/IJobExecutionLogger.cs
@@ -1,0 +1,23 @@
+﻿using OutOfSchool.QuartzJobs.Api.Models;
+
+namespace OutOfSchool.QuartzJobs.Api.Logging;
+
+public interface IJobExecutionLogger
+{
+    /// <summary>
+    /// Logs last job execution info to the storage.
+    /// </summary>
+    /// <param name="info"></param>
+    /// <returns></returns>
+    Task LogAsync(JobExecutionInfo info);
+
+    /// <summary>
+    /// Returns last job execution info.
+    /// </summary>
+    Task<IReadOnlyList<JobExecutionInfo>> GetHistoryAsync(string jobName);
+
+    /// <summary>
+    /// Returns only failed job executions.
+    /// </summary>
+    Task<IReadOnlyList<JobExecutionInfo>> GetFailedAsync(string jobName);
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Logging/RedisJobExecutionLogger.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Logging/RedisJobExecutionLogger.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Extensions.Options;
+using OutOfSchool.QuartzJobs.Api.Configuration;
+using OutOfSchool.QuartzJobs.Api.Models;
+using StackExchange.Redis;
+using System.Text.Json;
+
+namespace OutOfSchool.QuartzJobs.Api.Logging;
+
+public class RedisJobExecutionLogger : IJobExecutionLogger
+{
+    private readonly IDatabase redis;
+    private readonly int historyLength;
+
+    public RedisJobExecutionLogger(IConnectionMultiplexer connection, IOptions<QuartzMonitoringOptions> options)
+    {
+        redis = connection.GetDatabase();
+        historyLength = options.Value.Redis?.HistoryLength ?? 10;
+    }
+
+    public async Task LogAsync(JobExecutionInfo info)
+    {
+        var key = GetKey(info.JobName);
+        var json = JsonSerializer.Serialize(info);
+
+        await redis.ListLeftPushAsync(key, json);
+        await redis.ListTrimAsync(key, 0, historyLength - 1);
+    }
+
+    public async Task<IReadOnlyList<JobExecutionInfo>> GetHistoryAsync(string jobName)
+    {
+        var key = GetKey(jobName);
+        var items = await redis.ListRangeAsync(key);
+
+        return items
+            .Select(x => JsonSerializer.Deserialize<JobExecutionInfo>(x!)!)
+            .Where(x => x != null)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<JobExecutionInfo>> GetFailedAsync(string jobName)
+    {
+        var all = await GetHistoryAsync(jobName);
+        return all.Where(x => !x.WasSuccessful).ToList();
+    }
+
+    private static string GetKey(string jobName) =>
+        $"monitoring:jobs:{jobName}:history";
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Logging/RedisJobExecutionLogger.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Logging/RedisJobExecutionLogger.cs
@@ -17,6 +17,12 @@ public class RedisJobExecutionLogger : IJobExecutionLogger
         historyLength = options.Value.Redis?.HistoryLength ?? 10;
     }
 
+    /// <summary>
+    /// Logs job execution information into Redis.
+    /// Keeps only the latest N records for each job.
+    /// </summary>
+    /// <param name="info">Job execution information to log.</param>
+    /// <returns>A completed task.</returns>
     public async Task LogAsync(JobExecutionInfo info)
     {
         var key = GetKey(info.JobName);
@@ -26,6 +32,11 @@ public class RedisJobExecutionLogger : IJobExecutionLogger
         await redis.ListTrimAsync(key, 0, historyLength - 1);
     }
 
+    /// <summary>
+    /// Retrieves the execution history of a specific job from Redis.
+    /// </summary>
+    /// <param name="jobName">The name of the job.</param>
+    /// <returns>A list of job execution records (both successful and failed).</returns>
     public async Task<IReadOnlyList<JobExecutionInfo>> GetHistoryAsync(string jobName)
     {
         var key = GetKey(jobName);
@@ -37,6 +48,11 @@ public class RedisJobExecutionLogger : IJobExecutionLogger
             .ToList();
     }
 
+    /// <summary>
+    /// Retrieves only failed execution records of a specific job from Redis.
+    /// </summary>
+    /// <param name="jobName">The name of the job.</param>
+    /// <returns>A list of failed job execution records.</returns>
     public async Task<IReadOnlyList<JobExecutionInfo>> GetFailedAsync(string jobName)
     {
         var all = await GetHistoryAsync(jobName);

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobDetailsDto.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobDetailsDto.cs
@@ -1,0 +1,15 @@
+﻿namespace OutOfSchool.QuartzJobs.Api.Models;
+
+/// <summary>
+/// Represents detailed information about a specific Quartz job,
+/// including its triggers and status.
+/// </summary>
+public record JobDetailsDto
+{
+    public string Name { get; set; } = default!;
+    public string Group { get; set; } = default!;
+    public string JobType { get; set; } = default!;
+    public string Status { get; set; } = default!;
+    public string? Description { get; set; }
+    public List<JobTriggerDto> Triggers { get; set; } = new();
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobExecutionInfo.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobExecutionInfo.cs
@@ -1,0 +1,27 @@
+﻿namespace OutOfSchool.QuartzJobs.Api.Models;
+
+public class JobExecutionInfo
+{
+    public string JobName { get; set; } = string.Empty;
+    public string? JobGroup { get; set; }
+    public string? TriggerName { get; set; }
+    public string? TriggerGroup { get; set; }
+
+    public int RetryCount { get; set; }
+
+    public DateTime StartTime { get; set; }
+    public DateTime EndTime { get; set; }
+    public TimeSpan Duration { get; set; }
+
+    public bool WasSuccessful { get; set; }
+
+    public string TriggerType { get; set; }
+    public string? CronExpression { get; set; }
+    public string? RepeatInterval { get; set; }
+
+    public string? ErrorMessage { get; set; }
+    public string? StackTrace { get; set; }
+    public Dictionary<string, string>? Parameters { get; set; }
+
+    public int? TotalRuns { get; set; }
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobExecutionInfo.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobExecutionInfo.cs
@@ -1,5 +1,8 @@
 ﻿namespace OutOfSchool.QuartzJobs.Api.Models;
 
+/// <summary>
+/// Represents information about a job execution, including runtime, result, and parameters.
+/// </summary>
 public class JobExecutionInfo
 {
     public string JobName { get; set; } = string.Empty;
@@ -15,13 +18,9 @@ public class JobExecutionInfo
 
     public bool WasSuccessful { get; set; }
 
-    public string TriggerType { get; set; }
-    public string? CronExpression { get; set; }
-    public string? RepeatInterval { get; set; }
+    public string? TriggerType { get; set; }
 
     public string? ErrorMessage { get; set; }
     public string? StackTrace { get; set; }
     public Dictionary<string, string>? Parameters { get; set; }
-
-    public int? TotalRuns { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobInfoDto.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobInfoDto.cs
@@ -1,0 +1,13 @@
+﻿namespace OutOfSchool.QuartzJobs.Api.Models;
+
+/// <summary>
+/// Represents summarized information about a registered Quartz job.
+/// </summary>
+public record JobInfoDto
+{
+    public string Name { get; init; } = default!;
+    public string Group { get; init; } = default!;
+    public string JobType { get; init; } = default!;
+    public string Status { get; init; } = default!;
+    public string? Description { get; init; }
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobNextExecutionDto.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobNextExecutionDto.cs
@@ -1,0 +1,11 @@
+﻿namespace OutOfSchool.QuartzJobs.Api.Models;
+
+/// <summary>
+/// Represents the upcoming executions for a specific job and its triggers.
+/// </summary>
+public record JobNextExecutionDto
+{
+    public string JobName { get; set; } = default!;
+    public string JobGroup { get; set; } = default!;
+    public List<TriggerExecutionDto> NextExecutions { get; set; } = new();
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobTriggerDto.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/JobTriggerDto.cs
@@ -1,0 +1,10 @@
+﻿namespace OutOfSchool.QuartzJobs.Api.Models;
+
+/// <summary>
+/// Describes a trigger assigned to a job, including its upcoming execution times.
+/// </summary>
+public record JobTriggerDto
+{
+    public string TriggerKey { get; set; } = default!;
+    public List<DateTimeOffset> NextExecutions { get; set; } = new();
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/RunningJobDto.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/RunningJobDto.cs
@@ -1,0 +1,13 @@
+﻿namespace OutOfSchool.QuartzJobs.Api.Models;
+
+/// <summary>
+/// Represents a currently executing Quartz job instance.
+/// </summary>
+public record RunningJobDto
+{
+    public string JobName { get; init; } = default!;
+    public string Group { get; init; } = default!;
+    public DateTimeOffset? StartedAt { get; init; }
+    public string Trigger { get; init; } = default!;
+    public string TriggerGroup { get; init; } = default!;
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/TriggerExecutionDto.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Models/TriggerExecutionDto.cs
@@ -1,0 +1,11 @@
+﻿namespace OutOfSchool.QuartzJobs.Api.Models;
+
+/// <summary>
+/// Represents the upcoming execution times for a specific trigger.
+/// </summary>
+public record TriggerExecutionDto
+{
+    public string TriggerName { get; set; } = default!;
+    public string TriggerGroup { get; set; } = default!;
+    public List<DateTimeOffset> NextExecutions { get; set; } = new();
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/OutOfSchool.QuartzJobs.Api.csproj
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/OutOfSchool.QuartzJobs.Api.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+	<OutputType>Library</OutputType>
+	<ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+	
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="Quartz" />
+    <PackageReference Include="Quartz.Extensions.DependencyInjection" />
+    <PackageReference Include="Quartz.Extensions.Hosting" />
+	<PackageReference Include="StackExchange.Redis" />
+  </ItemGroup>
+
+</Project>

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Services/IQuartzMonitoringService.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Services/IQuartzMonitoringService.cs
@@ -1,0 +1,53 @@
+﻿using OutOfSchool.QuartzJobs.Api.Models;
+
+namespace OutOfSchool.QuartzJobs.Api.Services;
+
+/// Provides operations for retrieving monitoring information about Quartz jobs.
+public interface IQuartzMonitoringService
+{
+    /// <summary>
+    /// Retrieves information about all registered jobs with their current status.
+    /// </summary>
+    /// <returns>A read-only list of job summaries.</returns>
+    Task<IReadOnlyList<JobInfoDto>> GetAllJobsAsync();
+
+    /// <summary>
+    /// Retrieves information about currently running jobs.
+    /// </summary>
+    /// <returns>A read-only list of running jobs with execution details.</returns>
+    Task<IReadOnlyList<RunningJobDto>> GetRunningJobsAsync();
+
+    /// <summary>
+    /// Returns job details, trigger keys, and upcoming execution times for a specific job by name.
+    /// </summary>
+    /// <param name="jobName">The name of the job.</param>
+    /// <returns>Detailed job information if found; otherwise, null.</returns>
+    Task<JobDetailsDto?> GetJobDetailsAsync(string jobName);
+
+    /// <summary>
+    /// Retrieves execution history (success and failed executions) of a specific job.
+    /// </summary>
+    /// <param name="jobName">The name of the job.</param>
+    /// <returns>A read-only list of job execution records.</returns>
+    Task<IReadOnlyList<JobExecutionInfo>> GetJobHistoryAsync(string jobName);
+
+    /// <summary>
+    /// Retrieves only failed execution records of a specific job.
+    /// </summary>
+    /// <param name="jobName">The name of the job.</param>
+    /// <returns>A read-only list of failed job execution records.</returns>
+    Task<IReadOnlyList<JobExecutionInfo>> GetFailedJobsAsync(string jobName);
+
+    /// <summary>
+    /// Retrieves the next planned execution times for all jobs and their triggers.
+    /// </summary>
+    /// <returns>A read-only list of upcoming executions for all jobs.</returns>
+    Task<IReadOnlyList<JobNextExecutionDto>> GetNextExecutionsForAllJobsAsync();
+
+    /// <summary>
+    /// Retrieves the next planned execution times for a specific job and its triggers.
+    /// </summary>
+    /// <param name="jobName">The name of the job.</param>
+    /// <returns>A read-only list of upcoming executions for the specified job.</returns>
+    Task<IReadOnlyList<JobNextExecutionDto>> GetNextExecutionsForJobAsync(string jobName);
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Services/QuartzMonitoringService.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Services/QuartzMonitoringService.cs
@@ -1,0 +1,203 @@
+﻿using OutOfSchool.QuartzJobs.Api.Logging;
+using Quartz.Impl.Matchers;
+using Quartz;
+using OutOfSchool.QuartzJobs.Api.Models;
+using OutOfSchool.QuartzJobs.Api.Util;
+
+namespace OutOfSchool.QuartzJobs.Api.Services;
+
+/// <inheritdoc />
+public class QuartzMonitoringService : IQuartzMonitoringService
+{
+    private readonly ISchedulerFactory schedulerFactory;
+    private readonly IJobExecutionLogger logger;
+    private const int DefaultExecutionCount = 5;
+
+    public QuartzMonitoringService(ISchedulerFactory schedulerFactory, IJobExecutionLogger logger)
+    {
+        this.schedulerFactory = schedulerFactory;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<JobInfoDto>> GetAllJobsAsync()
+    {
+        var scheduler = await schedulerFactory.GetScheduler();
+        var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
+
+        var jobs = new List<JobInfoDto>();
+
+        foreach (var jobKey in jobKeys)
+        {
+            var detail = await scheduler.GetJobDetail(jobKey);
+            var status = await GetJobStatus(scheduler, jobKey);
+
+            jobs.Add(new JobInfoDto
+            {
+                Name = jobKey.Name,
+                Group = jobKey.Group,
+                JobType = detail.JobType.FullName,
+                Status = status.ToString(),
+                Description = detail.Description
+            });
+        }
+
+        return jobs;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<RunningJobDto>> GetRunningJobsAsync()
+    {
+        var scheduler = await schedulerFactory.GetScheduler();
+        var executing = await scheduler.GetCurrentlyExecutingJobs();
+
+        return executing.Select(context => new RunningJobDto
+        {
+            JobName = context.JobDetail.Key.Name,
+            Group = context.JobDetail.Key.Group,
+            StartedAt = context.FireTimeUtc.ToLocalTime(),
+            Trigger = context.Trigger.Key.Name,
+            TriggerGroup = context.Trigger.Key.Group
+        }).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<JobDetailsDto?> GetJobDetailsAsync(string jobName)
+    {
+        var scheduler = await schedulerFactory.GetScheduler();
+        var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
+        var jobKey = jobKeys.FirstOrDefault(k => k.Name == jobName);
+        if (jobKey is null)
+            return null;
+
+        var detail = await scheduler.GetJobDetail(jobKey);
+        var status = await GetJobStatus(scheduler, jobKey);
+        var triggers = await scheduler.GetTriggersOfJob(jobKey);
+
+        return new JobDetailsDto
+        {
+            Name = jobKey.Name,
+            Group = jobKey.Group,
+            Description = detail.Description,
+            JobType = detail.JobType.FullName,
+            Status = status.ToString(),
+            Triggers = triggers.Select(t => new JobTriggerDto
+            {
+                TriggerKey = t.Key.ToString(),
+                NextExecutions = t is ICronTrigger cronTrigger
+                ? CronHelper.GetUpcomingExecutions(cronTrigger.CronExpressionString, DefaultExecutionCount)
+                : new List<DateTimeOffset> { t.GetNextFireTimeUtc()?.ToLocalTime() ?? DateTimeOffset.MinValue }
+            }).ToList()
+        };
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<JobExecutionInfo>> GetJobHistoryAsync(string jobName) =>
+        logger.GetHistoryAsync(jobName);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<JobExecutionInfo>> GetFailedJobsAsync(string jobName) =>
+        logger.GetFailedAsync(jobName);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<JobNextExecutionDto>> GetNextExecutionsForAllJobsAsync()
+    {
+        var scheduler = await schedulerFactory.GetScheduler();
+        var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
+        var result = new List<JobNextExecutionDto>();
+
+        foreach (var jobKey in jobKeys)
+        {
+            var triggers = await scheduler.GetTriggersOfJob(jobKey);
+            result.Add(new JobNextExecutionDto
+            {
+                JobName = jobKey.Name,
+                JobGroup = jobKey.Group,
+                NextExecutions = triggers.Select(t => new TriggerExecutionDto
+                {
+                    TriggerName = t.Key.Name,
+                    TriggerGroup = t.Key.Group,
+                    NextExecutions = t is ICronTrigger cronTrigger
+                    ? CronHelper.GetUpcomingExecutions(cronTrigger.CronExpressionString, DefaultExecutionCount)
+                    : new List<DateTimeOffset> { t.GetNextFireTimeUtc()?.ToLocalTime() ?? DateTimeOffset.MinValue }
+                }).ToList()
+            });
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<JobNextExecutionDto>> GetNextExecutionsForJobAsync(string jobName)
+    {
+        var scheduler = await schedulerFactory.GetScheduler();
+        var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
+        var jobKey = jobKeys.FirstOrDefault(k => k.Name == jobName);
+        if (jobKey is null)
+            return new List<JobNextExecutionDto>();
+
+        var triggers = await scheduler.GetTriggersOfJob(jobKey);
+
+        return new List<JobNextExecutionDto>
+        {
+            new JobNextExecutionDto
+            {
+                JobName = jobKey.Name,
+                JobGroup = jobKey.Group,
+                NextExecutions = triggers.Select(t => new TriggerExecutionDto
+            {
+                TriggerName = t.Key.Name,
+                TriggerGroup = t.Key.Group,
+                NextExecutions = t is ICronTrigger cronTrigger
+                    ? CronHelper.GetUpcomingExecutions(cronTrigger.CronExpressionString, DefaultExecutionCount)
+                    : new List<DateTimeOffset> { t.GetNextFireTimeUtc()?.ToLocalTime() ?? DateTimeOffset.MinValue }
+            }).ToList()
+            }
+        };
+    }
+
+    /// <summary>
+    /// Retrieves the current status of the specified job, based on its triggers and execution state.
+    /// </summary>
+    /// <param name="scheduler">Quartz scheduler.</param>
+    /// <param name="jobKey">Job key to check.</param>
+    /// <returns>The calculated job status.</returns>
+    private static async Task<QuartzJobStatus> GetJobStatus(IScheduler scheduler, JobKey jobKey)
+    {
+        var triggers = await scheduler.GetTriggersOfJob(jobKey);
+        var states = await Task.WhenAll(triggers.Select(t => scheduler.GetTriggerState(t.Key)));
+
+        var runningJobs = await scheduler.GetCurrentlyExecutingJobs();
+        var isRunning = runningJobs.Any(x =>
+            x.JobDetail.Key.Name == jobKey.Name &&
+            x.JobDetail.Key.Group == jobKey.Group);
+
+        return GetJobStatus(states, isRunning);
+    }
+
+    /// <summary>
+    /// Determines the job status based on trigger states and whether the job is currently running.
+    /// </summary>
+    /// <param name="states">Trigger states for the job.</param>
+    /// <param name="isRunning">Indicates if the job is currently running.</param>
+    private static QuartzJobStatus GetJobStatus(TriggerState[] states, bool isRunning)
+    {
+        if (isRunning)
+            return QuartzJobStatus.Running;
+
+        if (states.Length == 0)
+            return QuartzJobStatus.Unknown;
+
+        return states.Distinct().Count() switch
+        {
+            1 => states[0] switch
+            {
+                TriggerState.Paused => QuartzJobStatus.Paused,
+                TriggerState.Normal => QuartzJobStatus.Active,
+                _ => QuartzJobStatus.Unknown,
+            },
+            > 1 => QuartzJobStatus.Mixed,
+            _ => QuartzJobStatus.Unknown,
+        };
+    }
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Services/QuartzMonitoringService.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Services/QuartzMonitoringService.cs
@@ -36,9 +36,9 @@ public class QuartzMonitoringService : IQuartzMonitoringService
             {
                 Name = jobKey.Name,
                 Group = jobKey.Group,
-                JobType = detail.JobType.FullName,
+                JobType = detail?.JobType?.FullName ?? "Unknown",
                 Status = status.ToString(),
-                Description = detail.Description
+                Description = detail?.Description
             });
         }
 
@@ -78,15 +78,15 @@ public class QuartzMonitoringService : IQuartzMonitoringService
         {
             Name = jobKey.Name,
             Group = jobKey.Group,
-            Description = detail.Description,
-            JobType = detail.JobType.FullName,
+            Description = detail?.Description,
+            JobType = detail?.JobType?.FullName ?? "Unknown",
             Status = status.ToString(),
             Triggers = triggers.Select(t => new JobTriggerDto
             {
                 TriggerKey = t.Key.ToString(),
                 NextExecutions = t is ICronTrigger cronTrigger
-                ? CronHelper.GetUpcomingExecutions(cronTrigger.CronExpressionString, DefaultExecutionCount)
-                : new List<DateTimeOffset> { t.GetNextFireTimeUtc()?.ToLocalTime() ?? DateTimeOffset.MinValue }
+                    ? CronHelper.GetUpcomingExecutions(cronTrigger.CronExpressionString, DefaultExecutionCount)
+                    : new List<DateTimeOffset> { t.GetNextFireTimeUtc()?.ToLocalTime() ?? DateTimeOffset.MinValue }
             }).ToList()
         };
     }

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Services/QuartzMonitoringService.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Services/QuartzMonitoringService.cs
@@ -193,7 +193,7 @@ public class QuartzMonitoringService : IQuartzMonitoringService
             1 => states[0] switch
             {
                 TriggerState.Paused => QuartzJobStatus.Paused,
-                TriggerState.Normal => QuartzJobStatus.Active,
+                TriggerState.Normal => QuartzJobStatus.Scheduled,
                 _ => QuartzJobStatus.Unknown,
             },
             > 1 => QuartzJobStatus.Mixed,

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Util/CronHelper.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Util/CronHelper.cs
@@ -1,0 +1,27 @@
+﻿using Quartz;
+
+namespace OutOfSchool.QuartzJobs.Api.Util;
+public static class CronHelper
+{
+    public static List<DateTimeOffset> GetUpcomingExecutions(string cron, int count)
+    {
+        var result = new List<DateTimeOffset>();
+        var now = DateTimeOffset.UtcNow;
+
+        if (!CronExpression.IsValidExpression(cron))
+            return result;
+
+        var expression = new CronExpression(cron);
+
+        for (int i = 0; i < count; i++)
+        {
+            var next = expression.GetNextValidTimeAfter(now);
+            if (next is null) break;
+
+            result.Add(next.Value.ToLocalTime());
+            now = next.Value;
+        }
+
+        return result;
+    }
+}

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Util/QuartzJobStatus.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Util/QuartzJobStatus.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public enum QuartzJobStatus
 {
-    Active,  // The job is active (at least one trigger is active and not paused).
+    Scheduled,  // The job has active triggers and is waiting for execution.
     Paused,  // The job is paused (all triggers associated with the job are paused).
     Running, // The job is currently running (at least one trigger is firing).
     Mixed,   // The job has mixed states (some triggers are active, some are paused).

--- a/OutOfSchool/OutOfSchool.QuartzJobs.Api/Util/QuartzJobStatus.cs
+++ b/OutOfSchool/OutOfSchool.QuartzJobs.Api/Util/QuartzJobStatus.cs
@@ -1,0 +1,13 @@
+﻿namespace OutOfSchool.QuartzJobs.Api.Util;
+
+/// <summary>
+/// Represents the status of a Quartz job.
+/// </summary>
+public enum QuartzJobStatus
+{
+    Active,  // The job is active (at least one trigger is active and not paused).
+    Paused,  // The job is paused (all triggers associated with the job are paused).
+    Running, // The job is currently running (at least one trigger is firing).
+    Mixed,   // The job has mixed states (some triggers are active, some are paused).
+    Unknown  // The job status is unknown (e.g., no triggers or unable to determine the state).
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Filters/TechAdminAccessFilterTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Filters/TechAdminAccessFilterTests.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using NUnit.Framework;
+using OutOfSchool.BusinessLogic.Services;
+using OutOfSchool.WebApi.Filters;
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OutOfSchool.WebApi.Tests.Filters;
+[TestFixture]
+public class TechAdminAccessFilterTests
+{
+    private Mock<ICurrentUserService> currentUserServiceMock;
+    private TechAdminAccessFilter filter;
+    private EndpointFilterInvocationContext context;
+
+    [SetUp]
+    public void SetUp()
+    {
+        currentUserServiceMock = new Mock<ICurrentUserService>();
+    }
+
+    private static EndpointFilterInvocationContext CreateFakeContext()
+    {
+        return new DefaultEndpointFilterInvocationContext(new DefaultHttpContext(), Array.Empty<object>());
+    }
+
+    [Test]
+    public async Task InvokeAsync_WhenUserIsTechAdmin_ShouldCallNext()
+    {
+        // Arrange
+        currentUserServiceMock.Setup(s => s.IsTechAdmin()).Returns(true);
+        filter = new TechAdminAccessFilter(currentUserServiceMock.Object);
+        context = CreateFakeContext();
+
+        var wasCalled = false;
+
+        // Act
+        var result = await filter.InvokeAsync(context, ctx =>
+        {
+            wasCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok("Success"));
+        });
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<Ok<string>>());
+        Assert.That(wasCalled, Is.True);
+    }
+
+    [Test]
+    public async Task InvokeAsync_WhenUserIsNotTechAdmin_ShouldReturn403()
+    {
+        // Arrange
+        currentUserServiceMock.Setup(s => s.IsTechAdmin()).Returns(false);
+        filter = new TechAdminAccessFilter(currentUserServiceMock.Object);
+        context = CreateFakeContext();
+
+        // create a fake HttpContext and DI container
+        var httpContext = new DefaultHttpContext();
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+        serviceCollection.AddMvc();
+        httpContext.RequestServices = serviceCollection.BuildServiceProvider();
+
+        var result = await filter.InvokeAsync(context, ctx => ValueTask.FromResult<object?>(null));
+
+        // Act
+        await (result as IResult)!.ExecuteAsync(httpContext);
+
+        // Assert
+        Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/OutOfSchool.WebApi.Tests.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/OutOfSchool.WebApi.Tests.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="MockQueryable.EntityFrameworkCore" />
 	<PackageReference Include="FluentAssertions" />
 	<PackageReference Include="IdentityModel" />

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/QuartzJobs/Monitoring/CronHelperTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/QuartzJobs/Monitoring/CronHelperTests.cs
@@ -1,0 +1,275 @@
+﻿using NUnit.Framework;
+using OutOfSchool.QuartzJobs.Api.Util;
+using System;
+
+namespace OutOfSchool.WebApi.Tests.QuartzJobs.Monitoring;
+
+[TestFixture]
+public class CronHelperTests
+{
+    [Test]
+    public void GetUpcomingExecutions_WithInvalidCronExpression_ReturnsEmptyList()
+    {
+        // Arrange
+        var invalidCron = "invalid cron";
+        var count = 5;
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(invalidCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void GetUpcomingExecutions_WithValidCronExpression_ReturnsCorrectNumberOfExecutions()
+    {
+        // Arrange
+        var validCron = "0 0 12 * * ?"; // Noon every day
+        var count = 5;
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(validCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(count));
+    }
+
+    [Test]
+    public void GetUpcomingExecutions_WithZeroCount_ReturnsEmptyList()
+    {
+        // Arrange
+        var validCron = "0 0 12 * * ?"; // Noon every day
+        var count = 0;
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(validCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void GetUpcomingExecutions_WithNegativeCount_ReturnsEmptyList()
+    {
+        // Arrange
+        var validCron = "0 0 12 * * ?"; // Noon every day
+        var count = -1;
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(validCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void GetUpcomingExecutions_WithDailyCron_ReturnsCorrectSequentialDates()
+    {
+        // Arrange
+        var dailyCron = "0 0 12 * * ?"; // Noon every day
+        var count = 3;
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(dailyCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(count));
+
+        // Check that dates are sequential with 1 day difference
+        for (int i = 1; i < result.Count; i++)
+        {
+            var difference = result[i].Date - result[i - 1].Date;
+            Assert.That(difference.Days, Is.EqualTo(1),
+                $"Expected 1 day difference between {result[i - 1]} and {result[i]}");
+        }
+
+        // Check that all times are at noon in local time
+        foreach (var date in result)
+        {
+            Assert.That(date.Hour, Is.EqualTo(12), "Hour should be 12 (noon)");
+            Assert.That(date.Minute, Is.EqualTo(0), "Minute should be 0");
+            Assert.That(date.Second, Is.EqualTo(0), "Second should be 0");
+        }
+    }
+
+    [Test]
+    public void GetUpcomingExecutions_WithHourlyCron_ReturnsCorrectSequentialHours()
+    {
+        // Arrange
+        var hourlyCron = "0 0 * * * ?"; // Every hour at minute 0
+        var count = 5;
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(hourlyCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(count));
+
+        // Check that times are sequential with 1 hour difference
+        for (int i = 1; i < result.Count; i++)
+        {
+            var difference = result[i] - result[i - 1];
+            Assert.That(Math.Round(difference.TotalHours), Is.EqualTo(1),
+                $"Expected 1 hour difference between {result[i - 1]} and {result[i]}");
+        }
+
+        // Check that all times are at minute 0, second 0
+        foreach (var date in result)
+        {
+            Assert.That(date.Minute, Is.EqualTo(0), "Minute should be 0");
+            Assert.That(date.Second, Is.EqualTo(0), "Second should be 0");
+        }
+    }
+
+    [Test]
+    public void GetUpcomingExecutions_WithWeeklyCron_ReturnsCorrectWeeklyDates()
+    {
+        // Arrange
+        var weeklyCron = "0 0 12 ? * MON"; // Noon every Monday
+        var count = 3;
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(weeklyCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(count));
+
+        // Check that all dates are Mondays
+        foreach (var date in result)
+        {
+            Assert.That(date.DayOfWeek, Is.EqualTo(DayOfWeek.Monday), "Day should be Monday");
+            Assert.That(date.Hour, Is.EqualTo(12), "Hour should be 12 (noon)");
+            Assert.That(date.Minute, Is.EqualTo(0), "Minute should be 0");
+            Assert.That(date.Second, Is.EqualTo(0), "Second should be 0");
+        }
+
+        // Check that dates are sequential with 7 days difference
+        for (int i = 1; i < result.Count; i++)
+        {
+            var difference = result[i].Date - result[i - 1].Date;
+            Assert.That(difference.Days, Is.EqualTo(7),
+                $"Expected 7 days difference between {result[i - 1]} and {result[i]}");
+        }
+    }
+
+    [Test]
+    public void GetUpcomingExecutions_WithMonthlyLastDayCron_ReturnsLastDaysOfMonths()
+    {
+        // Arrange - Cron for noon on the last day of each month
+        var monthlyCron = "0 0 12 L * ?";
+        var count = 3;
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(monthlyCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(count));
+
+        // Check that all dates are the last day of their month
+        foreach (var date in result)
+        {
+            var lastDayOfMonth = DateTime.DaysInMonth(date.Year, date.Month);
+            Assert.That(date.Day, Is.EqualTo(lastDayOfMonth),
+                $"Expected last day of month ({lastDayOfMonth}) for {date}");
+            Assert.That(date.Hour, Is.EqualTo(12), "Hour should be 12 (noon)");
+            Assert.That(date.Minute, Is.EqualTo(0), "Minute should be 0");
+            Assert.That(date.Second, Is.EqualTo(0), "Second should be 0");
+        }
+    }
+
+    [Test]
+    public void GetUpcomingExecutions_WithComplexCron_ReturnsCorrectDates()
+    {
+        // Arrange - 15th of each month at 10:30 AM
+        var complexCron = "0 30 10 15 * ?";
+        var count = 4;
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(complexCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(count), "Expected to get exactly 4 execution times");
+
+        // Check that all times are at 10:30
+        foreach (var date in result)
+        {
+            Assert.That(date.Hour, Is.EqualTo(10), "Hour should be 10");
+            Assert.That(date.Minute, Is.EqualTo(30), "Minute should be 30");
+            Assert.That(date.Second, Is.EqualTo(0), "Second should be 0");
+            Assert.That(date.Day, Is.EqualTo(15), "Day should be 15th of month");
+        }
+    
+        // Check that the dates are consecutive with a difference of 1 month
+        for (int i = 1; i < result.Count; i++)
+        {
+            var difference = result[i].Month - result[i - 1].Month;
+            // Taking into account the transition between years
+            if (difference < 0)
+                difference += 12;
+            
+            Assert.That(difference, Is.EqualTo(1), 
+                $"Expected 1 month difference between {result[i-1]} and {result[i]}");
+        }
+    }
+
+    [Test]
+    public void GetUpcomingExecutions_WithNoMoreExecutions_ReturnsPartialList()
+    {
+        // Arrange - Cron for specific past dates that won't have enough future occurrences
+        // This is a contrived example to demonstrate behavior when there aren't enough occurrences
+        // 12:00 on February 29th (leap day)
+        var specificCron = "0 0 12 29 2 ? 2024"; // Only valid for Feb 29, 2024
+        var count = 5; // We ask for 5 but expect fewer
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(specificCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+
+        // The result count will depend on when the test is run:
+        // - If run before Feb 29, 2024: expect 1 result
+        // - If run after Feb 29, 2024: expect 0 results
+
+        // Instead of time-dependent logic, we'll just verify each result makes sense
+        foreach (var date in result)
+        {
+            Assert.That(date.Day, Is.EqualTo(29), "Day should be 29");
+            Assert.That(date.Month, Is.EqualTo(2), "Month should be February (2)");
+            Assert.That(date.Year, Is.EqualTo(2024), "Year should be 2024");
+            Assert.That(date.Hour, Is.EqualTo(12), "Hour should be 12");
+            Assert.That(date.Minute, Is.EqualTo(0), "Minute should be 0");
+            Assert.That(date.Second, Is.EqualTo(0), "Second should be 0");
+        }
+    }
+
+    [Test]
+    public void GetUpcomingExecutions_ReturnedDatesAreInLocalTimeZone()
+    {
+        // Arrange
+        var dailyCron = "0 0 12 * * ?"; // Noon every day
+        var count = 1;
+
+        // Act
+        var result = CronHelper.GetUpcomingExecutions(dailyCron, count);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(count));
+
+        // Verify the result is in local time by comparing offset with local offset
+        var localOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow);
+        Assert.That(result[0].Offset, Is.EqualTo(localOffset),
+            "The DateTimeOffset should have the local timezone offset");
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/QuartzJobs/Monitoring/JobMonitoringListenerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/QuartzJobs/Monitoring/JobMonitoringListenerTests.cs
@@ -1,0 +1,190 @@
+﻿using Moq;
+using NUnit.Framework;
+using OutOfSchool.QuartzJobs.Api.Listeners;
+using OutOfSchool.QuartzJobs.Api.Logging;
+using OutOfSchool.QuartzJobs.Api.Models;
+using Quartz;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+
+namespace OutOfSchool.WebApi.Tests.QuartzJobs.Monitoring;
+
+[TestFixture]
+public class JobMonitoringListenerTests
+{
+    private Mock<IJobExecutionLogger> _loggerMock;
+    private JobMonitoringListener _listener;
+    private Mock<IJobExecutionContext> _contextMock;
+
+    [SetUp]
+    public void Setup()
+    {
+        _loggerMock = new Mock<IJobExecutionLogger>();
+        _listener = new JobMonitoringListener(_loggerMock.Object);
+
+        var mergedJobDataMap = new JobDataMap();
+
+        _contextMock = new Mock<IJobExecutionContext>();
+        _contextMock.Setup(c => c.MergedJobDataMap).Returns(mergedJobDataMap);
+
+        var jobDetailMock = new Mock<IJobDetail>();
+        jobDetailMock.Setup(j => j.Key).Returns(new JobKey("TestJob", "TestGroup"));
+        _contextMock.Setup(c => c.JobDetail).Returns(jobDetailMock.Object);
+
+        var triggerMock = new Mock<ITrigger>();
+        triggerMock.Setup(t => t.Key).Returns(new TriggerKey("TestTrigger", "TestTriggerGroup"));
+        _contextMock.Setup(c => c.Trigger).Returns(triggerMock.Object);
+
+        _contextMock.Setup(c => c.RefireCount).Returns(0);
+        _contextMock.Setup(c => c.JobRunTime).Returns(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public void Name_ShouldReturnCorrectName()
+    {
+        // Assert
+        Assert.That(_listener.Name, Is.EqualTo("JobMonitoringListener"));
+    }
+
+    [Test]
+    public async Task JobToBeExecuted_ShouldSaveStartTimeToContext()
+    {
+        // Arrange
+        DateTime beforeCall = DateTime.UtcNow;
+
+        // Act
+        await _listener.JobToBeExecuted(_contextMock.Object, CancellationToken.None);
+
+        // Assert
+        Assert.IsTrue(_contextMock.Object.MergedJobDataMap.ContainsKey("__StartTime"));
+        DateTime savedTime = (DateTime)_contextMock.Object.MergedJobDataMap["__StartTime"];
+        Assert.That(savedTime, Is.GreaterThanOrEqualTo(beforeCall));
+        Assert.That(savedTime, Is.LessThanOrEqualTo(DateTime.UtcNow));
+    }
+
+    [Test]
+    public async Task JobExecutionVetoed_ShouldDoNothing()
+    {
+        // Act
+        await _listener.JobExecutionVetoed(_contextMock.Object, CancellationToken.None);
+
+        // Assert - no interactions should occur
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task JobWasExecuted_WithoutException_ShouldLogSuccessfulExecution()
+    {
+        // Arrange
+        var startTime = DateTime.UtcNow.AddSeconds(-1);
+        _contextMock.Object.MergedJobDataMap.Put("__StartTime", startTime);
+        _contextMock.Object.MergedJobDataMap.Put("TestParam", "TestValue");
+
+        var concreteTrigger = new Mock<ISimpleTrigger>();
+        concreteTrigger.Setup(t => t.Key).Returns(new TriggerKey("TestTrigger", "TestTriggerGroup"));
+        _contextMock.Setup(c => c.Trigger).Returns(concreteTrigger.Object);
+
+        JobExecutionInfo capturedInfo = null;
+        _loggerMock.Setup(l => l.LogAsync(It.IsAny<JobExecutionInfo>()))
+            .Callback<JobExecutionInfo>(info => capturedInfo = info)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _listener.JobWasExecuted(_contextMock.Object, null, CancellationToken.None);
+
+        // Assert
+        _loggerMock.Verify(l => l.LogAsync(It.IsAny<JobExecutionInfo>()), Times.Once);
+
+        Assert.That(capturedInfo, Is.Not.Null);
+        Assert.That(capturedInfo.JobName, Is.EqualTo("TestJob"));
+        Assert.That(capturedInfo.JobGroup, Is.EqualTo("TestGroup"));
+        Assert.That(capturedInfo.TriggerName, Is.EqualTo("TestTrigger"));
+        Assert.That(capturedInfo.TriggerGroup, Is.EqualTo("TestTriggerGroup"));
+        Assert.That(capturedInfo.WasSuccessful, Is.True);
+        Assert.That(capturedInfo.RetryCount, Is.EqualTo(0));
+        Assert.That(capturedInfo.TriggerType, Is.Not.Null);
+        Assert.That(capturedInfo.ErrorMessage, Is.EqualTo("No error message available"));
+        Assert.That(capturedInfo.StackTrace, Is.EqualTo("No exception details available"));
+        Assert.That(capturedInfo.Parameters, Does.ContainKey("TestParam"));
+        Assert.That(capturedInfo.Parameters["TestParam"], Is.EqualTo("TestValue"));
+        Assert.That(capturedInfo.Parameters, Does.Not.ContainKey("__StartTime"));
+    }
+
+    [Test]
+    public async Task JobWasExecuted_WithException_ShouldLogFailedExecution()
+    {
+        // Arrange
+        var startTime = DateTime.UtcNow.AddSeconds(-1);
+        _contextMock.Object.MergedJobDataMap.Put("__StartTime", startTime);
+
+        var exception = new JobExecutionException("Test exception");
+
+        JobExecutionInfo capturedInfo = null;
+        _loggerMock.Setup(l => l.LogAsync(It.IsAny<JobExecutionInfo>()))
+            .Callback<JobExecutionInfo>(info => capturedInfo = info)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _listener.JobWasExecuted(_contextMock.Object, exception, CancellationToken.None);
+
+        // Assert
+        _loggerMock.Verify(l => l.LogAsync(It.IsAny<JobExecutionInfo>()), Times.Once);
+
+        Assert.That(capturedInfo, Is.Not.Null);
+        Assert.That(capturedInfo.WasSuccessful, Is.False);
+        Assert.That(capturedInfo.ErrorMessage, Is.EqualTo("Test exception"));
+        Assert.That(capturedInfo.StackTrace, Does.Contain("Test exception"));
+    }
+
+    [Test]
+    public async Task JobWasExecuted_WithoutStartTime_ShouldUseCurrentTime()
+    {
+        // Arrange
+        DateTime beforeCall = DateTime.UtcNow;
+
+        JobExecutionInfo capturedInfo = null;
+        _loggerMock.Setup(l => l.LogAsync(It.IsAny<JobExecutionInfo>()))
+            .Callback<JobExecutionInfo>(info => capturedInfo = info)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _listener.JobWasExecuted(_contextMock.Object, null, CancellationToken.None);
+
+        // Assert
+        _loggerMock.Verify(l => l.LogAsync(It.IsAny<JobExecutionInfo>()), Times.Once);
+
+        Assert.That(capturedInfo, Is.Not.Null);
+        // Start time should be current time (converted to local)
+        Assert.That(capturedInfo.StartTime.ToUniversalTime(), Is.GreaterThanOrEqualTo(beforeCall));
+    }
+
+    [Test]
+    public async Task JobWasExecuted_WithParameters_ShouldLogParameters()
+    {
+        // Arrange
+        _contextMock.Object.MergedJobDataMap.Put("__StartTime", DateTime.UtcNow);
+        _contextMock.Object.MergedJobDataMap.Put("Param1", "Value1");
+        _contextMock.Object.MergedJobDataMap.Put("Param2", 123);
+        _contextMock.Object.MergedJobDataMap.Put("Param3", null);
+
+        JobExecutionInfo capturedInfo = null;
+        _loggerMock.Setup(l => l.LogAsync(It.IsAny<JobExecutionInfo>()))
+            .Callback<JobExecutionInfo>(info => capturedInfo = info)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _listener.JobWasExecuted(_contextMock.Object, null, CancellationToken.None);
+
+        // Assert
+        _loggerMock.Verify(l => l.LogAsync(It.IsAny<JobExecutionInfo>()), Times.Once);
+
+        Assert.That(capturedInfo, Is.Not.Null);
+        Assert.That(capturedInfo.Parameters, Is.Not.Null);
+        Assert.That(capturedInfo.Parameters.Count, Is.EqualTo(3));
+        Assert.That(capturedInfo.Parameters["Param1"], Is.EqualTo("Value1"));
+        Assert.That(capturedInfo.Parameters["Param2"], Is.EqualTo("123"));
+        Assert.That(capturedInfo.Parameters["Param3"], Is.EqualTo("null"));
+        Assert.That(capturedInfo.Parameters, Does.Not.ContainKey("__StartTime"));
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/QuartzJobs/Monitoring/QuartzMonitoringEndpointsTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/QuartzJobs/Monitoring/QuartzMonitoringEndpointsTests.cs
@@ -1,0 +1,448 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using NUnit.Framework;
+using OutOfSchool.QuartzJobs.Api.Configuration;
+using OutOfSchool.QuartzJobs.Api.Extensions;
+using OutOfSchool.QuartzJobs.Api.Models;
+using OutOfSchool.QuartzJobs.Api.Services;
+
+namespace OutOfSchool.WebApi.Tests.QuartzJobs.Monitoring;
+
+[TestFixture]
+public class QuartzMonitoringEndpointsTests
+{
+    private HttpClient _client;
+    private TestServer _server;
+    private IHost _host;
+    private Mock<IQuartzMonitoringService> _monitoringServiceMock;
+
+    [SetUp]
+    public void Setup()
+    {
+        _monitoringServiceMock = new Mock<IQuartzMonitoringService>();
+
+        var hostBuilder = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddSingleton(_monitoringServiceMock.Object);
+
+                    services.AddRouting();
+                    services.AddEndpointsApiExplorer();
+
+                    services.Configure<QuartzMonitoringOptions>(opt =>
+                    {
+                        opt.Enabled = true;
+                        opt.Redis = new QuartzMonitoringOptions.RedisConfig
+                        {
+                            Server = "localhost",
+                            Port = 6379,
+                            Password = "",
+                            HistoryLength = 100
+                        };
+                    });
+                });
+
+                webHost.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapQuartzMonitoringApi();
+                    });
+                });
+            });
+
+        _host = hostBuilder.Start();
+        _server = _host.GetTestServer();
+        _client = _server.CreateClient();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _client?.Dispose();
+        _host?.Dispose();
+    }
+
+    [Test]
+    public async Task GetAllJobs_ReturnsOkWithJobs()
+    {
+        // Arrange
+        var expectedJobs = CreateSampleJobInfoList();
+        _monitoringServiceMock.Setup(s => s.GetAllJobsAsync())
+            .ReturnsAsync(expectedJobs);
+
+        // Act & Assert
+        var actual = await GetAndVerifySuccessResponseAsync<List<JobInfoDto>>("/quartz/jobs");
+
+        Assert.That(actual.Count, Is.EqualTo(2));
+        Assert.That(actual[0].Name, Is.EqualTo("TestJob1"));
+        Assert.That(actual[1].Name, Is.EqualTo("TestJob2"));
+    }
+
+    [Test]
+    public async Task GetRunningJobs_ReturnsOkWithRunningJobs()
+    {
+        // Arrange
+        var expectedJobs = CreateSampleRunningJobsList();
+        _monitoringServiceMock.Setup(s => s.GetRunningJobsAsync())
+            .ReturnsAsync(expectedJobs);
+
+        // Act & Assert
+        var actual = await GetAndVerifySuccessResponseAsync<List<RunningJobDto>>("/quartz/jobs/running");
+
+        Assert.That(actual.Count, Is.EqualTo(1));
+        Assert.That(actual[0].JobName, Is.EqualTo("TestJob1"));
+    }
+
+    [Test]
+    public async Task GetJobDetails_WithValidJobName_ReturnsOkWithJobDetails()
+    {
+        // Arrange
+        var jobName = "TestJob1";
+        var jobDetails = CreateSampleJobDetails(jobName);
+        _monitoringServiceMock.Setup(s => s.GetJobDetailsAsync(jobName))
+            .ReturnsAsync(jobDetails);
+
+        // Act & Assert
+        var actual = await GetAndVerifySuccessResponseAsync<JobDetailsDto>($"/quartz/jobs/{jobName}");
+
+        Assert.That(actual.Name, Is.EqualTo(jobName));
+        Assert.That(actual.Triggers.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public Task GetJobDetails_WithInvalidJobName_ReturnsNotFound()
+    {
+        // Arrange
+        var jobName = "NonExistentJob";
+        _monitoringServiceMock.Setup(s => s.GetJobDetailsAsync(jobName))
+            .ReturnsAsync((JobDetailsDto)null);
+
+        // Act & Assert
+        return VerifyNotFoundResponseAsync($"/quartz/jobs/{jobName}");
+    }
+
+    [Test]
+    public async Task GetJobHistory_WithValidJobName_ReturnsOkWithHistory()
+    {
+        // Arrange
+        var jobName = "TestJob1";
+        var history = CreateSampleJobHistory(jobName);
+        _monitoringServiceMock.Setup(s => s.GetJobHistoryAsync(jobName))
+            .ReturnsAsync(history);
+
+        // Act & Assert
+        var actual = await GetAndVerifySuccessResponseAsync<List<JobExecutionInfo>>($"/quartz/jobs/{jobName}/history");
+
+        Assert.That(actual.Count, Is.EqualTo(2));
+        Assert.That(actual[0].JobName, Is.EqualTo(jobName));
+        Assert.That(actual[0].WasSuccessful, Is.True);
+        Assert.That(actual[1].WasSuccessful, Is.False);
+    }
+
+    [Test]
+    public Task GetJobHistory_WithNoHistory_ReturnsNotFound()
+    {
+        // Arrange
+        var jobName = "JobWithNoHistory";
+        _monitoringServiceMock.Setup(s => s.GetJobHistoryAsync(jobName))
+            .ReturnsAsync(new List<JobExecutionInfo>());
+
+        // Act & Assert
+        return VerifyNotFoundResponseAsync($"/quartz/jobs/{jobName}/history");
+    }
+
+    [Test]
+    public async Task GetJobErrors_WithValidJobName_ReturnsOkWithErrors()
+    {
+        // Arrange
+        var jobName = "TestJob1";
+        var errors = CreateSampleJobErrors(jobName);
+        _monitoringServiceMock.Setup(s => s.GetFailedJobsAsync(jobName))
+            .ReturnsAsync(errors);
+
+        // Act & Assert
+        var actual = await GetAndVerifySuccessResponseAsync<List<JobExecutionInfo>>($"/quartz/jobs/{jobName}/errors");
+
+        Assert.That(actual.Count, Is.EqualTo(2));
+        Assert.That(actual[0].JobName, Is.EqualTo(jobName));
+        Assert.That(actual[0].WasSuccessful, Is.False);
+        Assert.That(actual[1].WasSuccessful, Is.False);
+    }
+
+    [Test]
+    public Task GetJobErrors_WithNoErrors_ReturnsNotFound()
+    {
+        // Arrange
+        var jobName = "JobWithNoErrors";
+        _monitoringServiceMock.Setup(s => s.GetFailedJobsAsync(jobName))
+            .ReturnsAsync(new List<JobExecutionInfo>());
+
+        // Act & Assert
+        return VerifyNotFoundResponseAsync($"/quartz/jobs/{jobName}/errors");
+    }
+
+    [Test]
+    public async Task GetScheduledJobs_ReturnsOkWithScheduledJobs()
+    {
+        // Arrange
+        var scheduledJobs = CreateSampleScheduledJobs();
+        _monitoringServiceMock.Setup(s => s.GetNextExecutionsForAllJobsAsync())
+            .ReturnsAsync(scheduledJobs);
+
+        // Act & Assert
+        var actual = await GetAndVerifySuccessResponseAsync<List<JobNextExecutionDto>>("/quartz/jobs/scheduled");
+
+        Assert.That(actual.Count, Is.EqualTo(2));
+        Assert.That(actual[0].JobName, Is.EqualTo("TestJob1"));
+        Assert.That(actual[1].JobName, Is.EqualTo("TestJob2"));
+    }
+
+    [Test]
+    public async Task GetJobSchedule_WithValidJobName_ReturnsOkWithSchedule()
+    {
+        // Arrange
+        var jobName = "TestJob1";
+        var scheduledJobs = CreateSampleJobSchedule(jobName);
+        _monitoringServiceMock.Setup(s => s.GetNextExecutionsForJobAsync(jobName))
+            .ReturnsAsync(scheduledJobs);
+
+        // Act & Assert
+        var actual = await GetAndVerifySuccessResponseAsync<List<JobNextExecutionDto>>($"/quartz/jobs/{jobName}/scheduled");
+
+        Assert.That(actual.Count, Is.EqualTo(1));
+        Assert.That(actual[0].JobName, Is.EqualTo(jobName));
+    }
+
+    [Test]
+    public Task GetJobSchedule_WithInvalidJobName_ReturnsNotFound()
+    {
+        // Arrange
+        var jobName = "NonExistentJob";
+        _monitoringServiceMock.Setup(s => s.GetNextExecutionsForJobAsync(jobName))
+            .ReturnsAsync(new List<JobNextExecutionDto>());
+
+        // Act & Assert
+        return VerifyNotFoundResponseAsync($"/quartz/jobs/{jobName}/scheduled");
+    }
+
+    #region Helper Methods
+
+    private async Task<T> GetAndVerifySuccessResponseAsync<T>(string endpoint)
+    {
+        var response = await _client.GetAsync(endpoint);
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var result = await response.Content.ReadFromJsonAsync<T>();
+        Assert.That(result, Is.Not.Null);
+
+        return result;
+    }
+
+    private async Task VerifyNotFoundResponseAsync(string endpoint)
+    {
+        var response = await _client.GetAsync(endpoint);
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    private List<JobInfoDto> CreateSampleJobInfoList()
+    {
+        return new List<JobInfoDto>
+        {
+            new JobInfoDto
+            {
+                Name = "TestJob1",
+                Group = "DefaultGroup",
+                JobType = "TestType1",
+                Status = "Scheduled",
+                Description = "Test job 1"
+            },
+            new JobInfoDto
+            {
+                Name = "TestJob2",
+                Group = "DefaultGroup",
+                JobType = "TestType2",
+                Status = "Paused",
+                Description = "Test job 2"
+            }
+        };
+    }
+
+    private List<RunningJobDto> CreateSampleRunningJobsList()
+    {
+        return new List<RunningJobDto>
+        {
+            new RunningJobDto
+            {
+                JobName = "TestJob1",
+                Group = "DefaultGroup",
+                StartedAt = DateTimeOffset.Now.AddMinutes(-5),
+                Trigger = "TestTrigger1",
+                TriggerGroup = "DefaultGroup"
+            }
+        };
+    }
+
+    private JobDetailsDto CreateSampleJobDetails(string jobName)
+    {
+        return new JobDetailsDto
+        {
+            Name = jobName,
+            Group = "DefaultGroup",
+            JobType = "TestType",
+            Status = "Scheduled",
+            Description = "Test job description",
+            Triggers = new List<JobTriggerDto>
+            {
+                new JobTriggerDto
+                {
+                    TriggerKey = "TestTrigger.DefaultGroup",
+                    NextExecutions = new List<DateTimeOffset>
+                    {
+                        DateTimeOffset.Now.AddMinutes(10),
+                        DateTimeOffset.Now.AddMinutes(20)
+                    }
+                }
+            }
+        };
+    }
+
+    private List<JobExecutionInfo> CreateSampleJobHistory(string jobName)
+    {
+        return new List<JobExecutionInfo>
+        {
+            new JobExecutionInfo
+            {
+                JobName = jobName,
+                JobGroup = "DefaultGroup",
+                StartTime = DateTime.Now.AddHours(-1),
+                EndTime = DateTime.Now.AddHours(-1).AddMinutes(5),
+                Duration = TimeSpan.FromMinutes(5),
+                WasSuccessful = true
+            },
+            new JobExecutionInfo
+            {
+                JobName = jobName,
+                JobGroup = "DefaultGroup",
+                StartTime = DateTime.Now.AddHours(-2),
+                EndTime = DateTime.Now.AddHours(-2).AddMinutes(3),
+                Duration = TimeSpan.FromMinutes(3),
+                WasSuccessful = false,
+                ErrorMessage = "Test error message"
+            }
+        };
+    }
+
+    private List<JobExecutionInfo> CreateSampleJobErrors(string jobName)
+    {
+        return new List<JobExecutionInfo>
+        {
+            new JobExecutionInfo
+            {
+                JobName = jobName,
+                JobGroup = "DefaultGroup",
+                StartTime = DateTime.Now.AddHours(-1),
+                EndTime = DateTime.Now.AddHours(-1).AddMinutes(5),
+                Duration = TimeSpan.FromMinutes(5),
+                WasSuccessful = false,
+                ErrorMessage = "Test error 1",
+                StackTrace = "Stack trace 1"
+            },
+            new JobExecutionInfo
+            {
+                JobName = jobName,
+                JobGroup = "DefaultGroup",
+                StartTime = DateTime.Now.AddHours(-2),
+                EndTime = DateTime.Now.AddHours(-2).AddMinutes(3),
+                Duration = TimeSpan.FromMinutes(3),
+                WasSuccessful = false,
+                ErrorMessage = "Test error 2",
+                StackTrace = "Stack trace 2"
+            }
+        };
+    }
+
+    private List<JobNextExecutionDto> CreateSampleScheduledJobs()
+    {
+        return new List<JobNextExecutionDto>
+        {
+            new JobNextExecutionDto
+            {
+                JobName = "TestJob1",
+                JobGroup = "DefaultGroup",
+                NextExecutions = new List<TriggerExecutionDto>
+                {
+                    new TriggerExecutionDto
+                    {
+                        TriggerName = "Trigger1",
+                        TriggerGroup = "DefaultGroup",
+                        NextExecutions = new List<DateTimeOffset>
+                        {
+                            DateTimeOffset.Now.AddMinutes(10),
+                            DateTimeOffset.Now.AddMinutes(20)
+                        }
+                    }
+                }
+            },
+            new JobNextExecutionDto
+            {
+                JobName = "TestJob2",
+                JobGroup = "DefaultGroup",
+                NextExecutions = new List<TriggerExecutionDto>
+                {
+                    new TriggerExecutionDto
+                    {
+                        TriggerName = "Trigger2",
+                        TriggerGroup = "DefaultGroup",
+                        NextExecutions = new List<DateTimeOffset>
+                        {
+                            DateTimeOffset.Now.AddMinutes(5),
+                            DateTimeOffset.Now.AddMinutes(15)
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    private List<JobNextExecutionDto> CreateSampleJobSchedule(string jobName)
+    {
+        return new List<JobNextExecutionDto>
+        {
+            new JobNextExecutionDto
+            {
+                JobName = jobName,
+                JobGroup = "DefaultGroup",
+                NextExecutions = new List<TriggerExecutionDto>
+                {
+                    new TriggerExecutionDto
+                    {
+                        TriggerName = "Trigger1",
+                        TriggerGroup = "DefaultGroup",
+                        NextExecutions = new List<DateTimeOffset>
+                        {
+                            DateTimeOffset.Now.AddMinutes(10),
+                            DateTimeOffset.Now.AddMinutes(20)
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    #endregion
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/QuartzJobs/Monitoring/QuartzMonitoringServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/QuartzJobs/Monitoring/QuartzMonitoringServiceTests.cs
@@ -1,0 +1,597 @@
+﻿using Moq;
+using NUnit.Framework;
+using OutOfSchool.QuartzJobs.Api.Logging;
+using OutOfSchool.QuartzJobs.Api.Models;
+using OutOfSchool.QuartzJobs.Api.Services;
+using OutOfSchool.QuartzJobs.Api.Util;
+using Quartz;
+using Quartz.Impl.Matchers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace OutOfSchool.WebApi.Tests.QuartzJobs.Monitoring;
+
+[TestFixture]
+public class QuartzMonitoringServiceTests
+{
+    private Mock<ISchedulerFactory> _schedulerFactoryMock;
+    private Mock<IScheduler> _schedulerMock;
+    private Mock<IJobExecutionLogger> _loggerMock;
+    private QuartzMonitoringService _service;
+
+    [SetUp]
+    public void Setup()
+    {
+        _schedulerFactoryMock = new Mock<ISchedulerFactory>();
+        _schedulerMock = new Mock<IScheduler>();
+        _loggerMock = new Mock<IJobExecutionLogger>();
+
+        _schedulerFactoryMock
+            .Setup(sf => sf.GetScheduler(It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(_schedulerMock.Object);
+
+        _service = new QuartzMonitoringService(_schedulerFactoryMock.Object, _loggerMock.Object);
+    }
+
+    [Test]
+    public async Task GetAllJobsAsync_ShouldReturnEmptyList_WhenNoJobsExist()
+    {
+        // Arrange
+        var emptyJobKeys = new List<JobKey>();
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(emptyJobKeys);
+
+        // Act
+        var result = await _service.GetAllJobsAsync();
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetAllJobsAsync_ShouldReturnJobsWithCorrectInfo()
+    {
+        // Arrange
+        var jobKeys = new List<JobKey>
+            {
+                new JobKey("job1", "group1"),
+                new JobKey("job2", "group2")
+            };
+
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(jobKeys);
+
+        var jobDetails = new Dictionary<string, IJobDetail>
+        {
+            ["job1"] = CreateMockJobDetail("job1", "group1", typeof(TestJob), "Job 1 description"),
+            ["job2"] = CreateMockJobDetail("job2", "group2", typeof(TestJob), "Job 2 description")
+        };
+
+        foreach (var jobKey in jobKeys)
+        {
+            _schedulerMock
+                .Setup(s => s.GetJobDetail(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(jobDetails[jobKey.Name]);
+
+            // Mock the trigger state to be Normal for all jobs
+            _schedulerMock
+                .Setup(s => s.GetTriggersOfJob(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(new List<ITrigger> { CreateMockTrigger($"trigger-{jobKey.Name}", jobKey.Group) });
+        }
+
+        _schedulerMock
+            .Setup(s => s.GetCurrentlyExecutingJobs(It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<IJobExecutionContext>());
+
+        // Act
+        var result = await _service.GetAllJobsAsync();
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(2));
+
+        var job1 = result.FirstOrDefault(j => j.Name == "job1");
+        Assert.That(job1, Is.Not.Null);
+        Assert.That(job1.Group, Is.EqualTo("group1"));
+        Assert.That(job1.JobType, Is.EqualTo(typeof(TestJob).FullName));
+        Assert.That(job1.Status, Is.EqualTo(QuartzJobStatus.Scheduled.ToString()));
+        Assert.That(job1.Description, Is.EqualTo("Job 1 description"));
+
+        var job2 = result.FirstOrDefault(j => j.Name == "job2");
+        Assert.That(job2, Is.Not.Null);
+        Assert.That(job2.Group, Is.EqualTo("group2"));
+        Assert.That(job2.JobType, Is.EqualTo(typeof(TestJob).FullName));
+        Assert.That(job2.Status, Is.EqualTo(QuartzJobStatus.Scheduled.ToString()));
+        Assert.That(job2.Description, Is.EqualTo("Job 2 description"));
+    }
+
+    [Test]
+    public async Task GetRunningJobsAsync_ShouldReturnEmptyList_WhenNoJobsRunning()
+    {
+        // Arrange
+        _schedulerMock
+            .Setup(s => s.GetCurrentlyExecutingJobs(It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<IJobExecutionContext>());
+
+        // Act
+        var result = await _service.GetRunningJobsAsync();
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetRunningJobsAsync_ShouldReturnRunningJobs()
+    {
+        // Arrange
+        var now = DateTimeOffset.Now;
+        var runningJobs = new List<IJobExecutionContext>
+            {
+                CreateMockJobExecutionContext("job1", "group1", "trigger1", "triggerGroup1", now),
+                CreateMockJobExecutionContext("job2", "group2", "trigger2", "triggerGroup2", now.AddMinutes(-5))
+            };
+
+        _schedulerMock
+            .Setup(s => s.GetCurrentlyExecutingJobs(It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(runningJobs);
+
+        // Act
+        var result = await _service.GetRunningJobsAsync();
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(2));
+
+        var job1 = result.FirstOrDefault(j => j.JobName == "job1");
+        Assert.That(job1, Is.Not.Null);
+        Assert.That(job1.Group, Is.EqualTo("group1"));
+        Assert.That(job1.Trigger, Is.EqualTo("trigger1"));
+        Assert.That(job1.TriggerGroup, Is.EqualTo("triggerGroup1"));
+        Assert.That(job1.StartedAt, Is.EqualTo(now.ToLocalTime()));
+
+        var job2 = result.FirstOrDefault(j => j.JobName == "job2");
+        Assert.That(job2, Is.Not.Null);
+        Assert.That(job2.Group, Is.EqualTo("group2"));
+        Assert.That(job2.Trigger, Is.EqualTo("trigger2"));
+        Assert.That(job2.TriggerGroup, Is.EqualTo("triggerGroup2"));
+        Assert.That(job2.StartedAt, Is.EqualTo(now.AddMinutes(-5).ToLocalTime()));
+    }
+
+    [Test]
+    public async Task GetJobDetailsAsync_ShouldReturnNull_WhenJobDoesNotExist()
+    {
+        // Arrange
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<JobKey>());
+
+        // Act
+        var result = await _service.GetJobDetailsAsync("non-existent-job");
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task GetJobDetailsAsync_ShouldReturnJobDetails_WithNormalTriggers()
+    {
+        // Arrange
+        var jobKey = new JobKey("testJob", "testGroup");
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<JobKey> { jobKey });
+
+        var jobDetail = CreateMockJobDetail("testJob", "testGroup", typeof(TestJob), "Test job description");
+        _schedulerMock
+            .Setup(s => s.GetJobDetail(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(jobDetail);
+
+        var triggers = new List<ITrigger>
+            {
+                CreateMockTrigger("trigger1", "triggerGroup1", true),
+                CreateMockTrigger("trigger2", "triggerGroup2", false)
+            };
+
+        _schedulerMock
+            .Setup(s => s.GetTriggersOfJob(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(triggers);
+
+        _schedulerMock
+            .Setup(s => s.GetCurrentlyExecutingJobs(It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<IJobExecutionContext>());
+
+        // Mock trigger states
+        foreach (var trigger in triggers)
+        {
+            _schedulerMock
+                .Setup(s => s.GetTriggerState(trigger.Key, It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(TriggerState.Normal);
+        }
+
+        // Act
+        var result = await _service.GetJobDetailsAsync("testJob");
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Name, Is.EqualTo("testJob"));
+        Assert.That(result.Group, Is.EqualTo("testGroup"));
+        Assert.That(result.JobType, Is.EqualTo(typeof(TestJob).FullName));
+        Assert.That(result.Status, Is.EqualTo(QuartzJobStatus.Scheduled.ToString()));
+        Assert.That(result.Description, Is.EqualTo("Test job description"));
+        Assert.That(result.Triggers.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetJobHistoryAsync_ShouldReturnHistoryFromLogger()
+    {
+        // Arrange
+        var jobName = "testJob";
+        var history = new List<JobExecutionInfo>
+            {
+                new JobExecutionInfo { JobName = jobName, WasSuccessful = true },
+                new JobExecutionInfo { JobName = jobName, WasSuccessful = false }
+            };
+
+        _loggerMock
+            .Setup(l => l.GetHistoryAsync(jobName))
+            .ReturnsAsync(history);
+
+        // Act
+        var result = await _service.GetJobHistoryAsync(jobName);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(2));
+        _loggerMock.Verify(l => l.GetHistoryAsync(jobName), Times.Once);
+    }
+
+    [Test]
+    public async Task GetFailedJobsAsync_ShouldReturnFailedJobsFromLogger()
+    {
+        // Arrange
+        var jobName = "testJob";
+        var failedJobs = new List<JobExecutionInfo>
+            {
+                new JobExecutionInfo { JobName = jobName, WasSuccessful = false },
+                new JobExecutionInfo { JobName = jobName, WasSuccessful = false }
+            };
+
+        _loggerMock
+            .Setup(l => l.GetFailedAsync(jobName))
+            .ReturnsAsync(failedJobs);
+
+        // Act
+        var result = await _service.GetFailedJobsAsync(jobName);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(2));
+        _loggerMock.Verify(l => l.GetFailedAsync(jobName), Times.Once);
+    }
+
+    [Test]
+    public async Task GetNextExecutionsForAllJobsAsync_ShouldReturnEmptyList_WhenNoJobsExist()
+    {
+        // Arrange
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<JobKey>());
+
+        // Act
+        var result = await _service.GetNextExecutionsForAllJobsAsync();
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetNextExecutionsForAllJobsAsync_ShouldReturnNextExecutions()
+    {
+        // Arrange
+        var jobKeys = new List<JobKey>
+            {
+                new JobKey("job1", "group1"),
+                new JobKey("job2", "group2")
+            };
+
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(jobKeys);
+
+        foreach (var jobKey in jobKeys)
+        {
+            var triggers = new List<ITrigger>
+                {
+                    CreateMockTrigger($"trigger-{jobKey.Name}", jobKey.Group, true)
+                };
+
+            _schedulerMock
+                .Setup(s => s.GetTriggersOfJob(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(triggers);
+        }
+
+        // Act
+        var result = await _service.GetNextExecutionsForAllJobsAsync();
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(2));
+
+        var job1 = result.FirstOrDefault(j => j.JobName == "job1");
+        Assert.That(job1, Is.Not.Null);
+        Assert.That(job1.JobGroup, Is.EqualTo("group1"));
+        Assert.That(job1.NextExecutions.Count, Is.EqualTo(1));
+        Assert.That(job1.NextExecutions[0].TriggerName, Is.EqualTo("trigger-job1"));
+
+        var job2 = result.FirstOrDefault(j => j.JobName == "job2");
+        Assert.That(job2, Is.Not.Null);
+        Assert.That(job2.JobGroup, Is.EqualTo("group2"));
+        Assert.That(job2.NextExecutions.Count, Is.EqualTo(1));
+        Assert.That(job2.NextExecutions[0].TriggerName, Is.EqualTo("trigger-job2"));
+    }
+
+    [Test]
+    public async Task GetNextExecutionsForJobAsync_ShouldReturnEmptyList_WhenJobDoesNotExist()
+    {
+        // Arrange
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<JobKey>());
+
+        // Act
+        var result = await _service.GetNextExecutionsForJobAsync("non-existent-job");
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetNextExecutionsForJobAsync_ShouldReturnNextExecutions()
+    {
+        // Arrange
+        var jobKey = new JobKey("testJob", "testGroup");
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<JobKey> { jobKey });
+
+        var triggers = new List<ITrigger>
+            {
+                CreateMockTrigger("trigger1", "triggerGroup1", true),
+                CreateMockTrigger("trigger2", "triggerGroup2", false)
+            };
+
+        _schedulerMock
+            .Setup(s => s.GetTriggersOfJob(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(triggers);
+
+        // Act
+        var result = await _service.GetNextExecutionsForJobAsync("testJob");
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(result[0].JobName, Is.EqualTo("testJob"));
+        Assert.That(result[0].JobGroup, Is.EqualTo("testGroup"));
+        Assert.That(result[0].NextExecutions.Count, Is.EqualTo(2));
+        Assert.That(result[0].NextExecutions[0].TriggerName, Is.EqualTo("trigger1"));
+        Assert.That(result[0].NextExecutions[1].TriggerName, Is.EqualTo("trigger2"));
+    }
+
+    [Test]
+    public async Task GetJobStatus_ShouldReturnRunning_WhenJobIsExecuting()
+    {
+        // Arrange
+        var jobKey = new JobKey("runningJob", "testGroup");
+
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<JobKey> { jobKey });
+
+        var jobDetail = CreateMockJobDetail("runningJob", "testGroup", typeof(TestJob), "Test job");
+        _schedulerMock
+            .Setup(s => s.GetJobDetail(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(jobDetail);
+
+        var triggers = new List<ITrigger> { CreateMockTrigger("trigger1", "triggerGroup1") };
+        _schedulerMock
+            .Setup(s => s.GetTriggersOfJob(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(triggers);
+
+        _schedulerMock
+            .Setup(s => s.GetTriggerState(triggers[0].Key, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(TriggerState.Normal);
+
+        // Set up a running job execution context
+        var runningContext = CreateMockJobExecutionContext("runningJob", "testGroup", "trigger1", "triggerGroup1", DateTimeOffset.Now);
+        _schedulerMock
+            .Setup(s => s.GetCurrentlyExecutingJobs(It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<IJobExecutionContext> { runningContext });
+
+        // Act
+        var result = await _service.GetJobDetailsAsync("runningJob");
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Status, Is.EqualTo(QuartzJobStatus.Running.ToString()));
+    }
+
+    [Test]
+    public async Task GetJobStatus_ShouldReturnPaused_WhenAllTriggersArePaused()
+    {
+        // Arrange
+        var jobKey = new JobKey("pausedJob", "testGroup");
+
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<JobKey> { jobKey });
+
+        var jobDetail = CreateMockJobDetail("pausedJob", "testGroup", typeof(TestJob), "Test job");
+        _schedulerMock
+            .Setup(s => s.GetJobDetail(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(jobDetail);
+
+        var triggers = new List<ITrigger> { CreateMockTrigger("trigger1", "triggerGroup1") };
+        _schedulerMock
+            .Setup(s => s.GetTriggersOfJob(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(triggers);
+
+        _schedulerMock
+            .Setup(s => s.GetTriggerState(triggers[0].Key, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(TriggerState.Paused);
+
+        _schedulerMock
+            .Setup(s => s.GetCurrentlyExecutingJobs(It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<IJobExecutionContext>());
+
+        // Act
+        var result = await _service.GetJobDetailsAsync("pausedJob");
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Status, Is.EqualTo(QuartzJobStatus.Paused.ToString()));
+    }
+
+    [Test]
+    public async Task GetJobStatus_ShouldReturnMixed_WhenTriggersHaveDifferentStates()
+    {
+        // Arrange
+        var jobKey = new JobKey("mixedJob", "testGroup");
+
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<JobKey> { jobKey });
+
+        var jobDetail = CreateMockJobDetail("mixedJob", "testGroup", typeof(TestJob), "Test job");
+        _schedulerMock
+            .Setup(s => s.GetJobDetail(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(jobDetail);
+
+        var trigger1 = CreateMockTrigger("trigger1", "triggerGroup1");
+        var trigger2 = CreateMockTrigger("trigger2", "triggerGroup2");
+
+        var triggers = new List<ITrigger> { trigger1, trigger2 };
+        _schedulerMock
+            .Setup(s => s.GetTriggersOfJob(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(triggers);
+
+        _schedulerMock
+            .Setup(s => s.GetTriggerState(trigger1.Key, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(TriggerState.Normal);
+
+        _schedulerMock
+            .Setup(s => s.GetTriggerState(trigger2.Key, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(TriggerState.Paused);
+
+        _schedulerMock
+            .Setup(s => s.GetCurrentlyExecutingJobs(It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<IJobExecutionContext>());
+
+        // Act
+        var result = await _service.GetJobDetailsAsync("mixedJob");
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Status, Is.EqualTo(QuartzJobStatus.Mixed.ToString()));
+    }
+
+    [Test]
+    public async Task GetJobStatus_ShouldReturnUnknown_WhenNoTriggersExist()
+    {
+        // Arrange
+        var jobKey = new JobKey("unknownJob", "testGroup");
+
+        _schedulerMock
+            .Setup(s => s.GetJobKeys(It.IsAny<GroupMatcher<JobKey>>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<JobKey> { jobKey });
+
+        var jobDetail = CreateMockJobDetail("unknownJob", "testGroup", typeof(TestJob), "Test job");
+        _schedulerMock
+            .Setup(s => s.GetJobDetail(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(jobDetail);
+
+        // No triggers for this job
+        _schedulerMock
+            .Setup(s => s.GetTriggersOfJob(jobKey, It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<ITrigger>());
+
+        _schedulerMock
+            .Setup(s => s.GetCurrentlyExecutingJobs(It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(new List<IJobExecutionContext>());
+
+        // Act
+        var result = await _service.GetJobDetailsAsync("unknownJob");
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Status, Is.EqualTo(QuartzJobStatus.Unknown.ToString()));
+    }
+
+    #region Helper Methods
+
+    private static IJobDetail CreateMockJobDetail(string name, string group, Type jobType, string description)
+    {
+        var jobDetailMock = new Mock<IJobDetail>();
+        jobDetailMock.Setup(jd => jd.Key).Returns(new JobKey(name, group));
+        jobDetailMock.Setup(jd => jd.JobType).Returns(jobType);
+        jobDetailMock.Setup(jd => jd.Description).Returns(description);
+        return jobDetailMock.Object;
+    }
+
+    private static ITrigger CreateMockTrigger(string name, string group, bool isCronTrigger = false)
+    {
+        if (isCronTrigger)
+        {
+            var cronTriggerMock = new Mock<ICronTrigger>();
+            cronTriggerMock.Setup(t => t.Key).Returns(new TriggerKey(name, group));
+            cronTriggerMock.Setup(t => t.CronExpressionString).Returns("0 0 12 * * ?"); // Noon every day
+            cronTriggerMock.Setup(t => t.GetNextFireTimeUtc()).Returns(DateTimeOffset.UtcNow.AddDays(1).Date.AddHours(12));
+            return cronTriggerMock.Object;
+        }
+        else
+        {
+            var triggerMock = new Mock<ITrigger>();
+            triggerMock.Setup(t => t.Key).Returns(new TriggerKey(name, group));
+            triggerMock.Setup(t => t.GetNextFireTimeUtc()).Returns(DateTimeOffset.UtcNow.AddHours(1));
+            return triggerMock.Object;
+        }
+    }
+
+    private static IJobExecutionContext CreateMockJobExecutionContext(
+        string jobName,
+        string jobGroup,
+        string triggerName,
+        string triggerGroup,
+        DateTimeOffset fireTime)
+    {
+        var jobDetailMock = new Mock<IJobDetail>();
+        jobDetailMock.Setup(jd => jd.Key).Returns(new JobKey(jobName, jobGroup));
+
+        var triggerMock = new Mock<ITrigger>();
+        triggerMock.Setup(t => t.Key).Returns(new TriggerKey(triggerName, triggerGroup));
+
+        var contextMock = new Mock<IJobExecutionContext>();
+        contextMock.Setup(c => c.JobDetail).Returns(jobDetailMock.Object);
+        contextMock.Setup(c => c.Trigger).Returns(triggerMock.Object);
+        contextMock.Setup(c => c.FireTimeUtc).Returns(fireTime);
+
+        return contextMock.Object;
+    }
+
+    private class TestJob : IJob
+    {
+        public Task Execute(IJobExecutionContext context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    #endregion
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/QuartzJobs/Monitoring/RedisJobExecutionLoggerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/QuartzJobs/Monitoring/RedisJobExecutionLoggerTests.cs
@@ -1,0 +1,148 @@
+﻿using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using OutOfSchool.QuartzJobs.Api.Configuration;
+using OutOfSchool.QuartzJobs.Api.Logging;
+using OutOfSchool.QuartzJobs.Api.Models;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace OutOfSchool.WebApi.Tests.QuartzJobs.Monitoring;
+
+[TestFixture]
+public class RedisJobExecutionLoggerTests
+{
+    private Mock<IConnectionMultiplexer> _connectionMock;
+    private Mock<IDatabase> _databaseMock;
+    private IOptions<QuartzMonitoringOptions> _options;
+    private RedisJobExecutionLogger _logger;
+    private const int DefaultHistoryLength = 5;
+    private const string TestJobName = "TestJob";
+
+    [SetUp]
+    public void Setup()
+    {
+        _databaseMock = new Mock<IDatabase>();
+        _connectionMock = new Mock<IConnectionMultiplexer>();
+        _connectionMock.Setup(x => x.GetDatabase(It.IsAny<int>(), It.IsAny<object>()))
+            .Returns(_databaseMock.Object);
+
+        _options = Options.Create(new QuartzMonitoringOptions
+        {
+            Redis = new QuartzMonitoringOptions.RedisConfig
+            {
+                HistoryLength = DefaultHistoryLength
+            }
+        });
+
+        _logger = new RedisJobExecutionLogger(_connectionMock.Object, _options);
+    }
+
+    [Test]
+    public async Task LogAsync_PushesJobExecutionInfoToRedis()
+    {
+        // Arrange
+        var info = CreateJobExecutionInfo();
+        var key = $"monitoring:jobs:{TestJobName}:history";
+        var expectedJson = JsonSerializer.Serialize(info);
+
+        _databaseMock.Setup(db => db.ListLeftPushAsync(key, expectedJson, When.Always, CommandFlags.None))
+            .ReturnsAsync(1)
+            .Verifiable();
+
+        _databaseMock.Setup(db => db.ListTrimAsync(key, 0, DefaultHistoryLength - 1, CommandFlags.None))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        // Act
+        await _logger.LogAsync(info);
+
+        // Assert
+        _databaseMock.Verify();
+    }
+
+    [Test]
+    public async Task GetHistoryAsync_ReturnsDeserializedJobExecutionInfoList()
+    {
+        // Arrange
+        var jobInfos = new List<JobExecutionInfo>
+        {
+            CreateJobExecutionInfo(true),
+            CreateJobExecutionInfo(false)
+        };
+
+        var key = $"monitoring:jobs:{TestJobName}:history";
+        var serialized = jobInfos.Select(x => (RedisValue)JsonSerializer.Serialize(x)).ToArray();
+
+        _databaseMock.Setup(db => db.ListRangeAsync(key, 0, -1, CommandFlags.None))
+            .ReturnsAsync(serialized);
+
+        // Act
+        var result = await _logger.GetHistoryAsync(TestJobName);
+
+        // Assert
+        Assert.That(result.Count, Is.EqualTo(2));
+        for (int i = 0; i < jobInfos.Count; i++)
+        {
+            Assert.That(result[i].JobName, Is.EqualTo(jobInfos[i].JobName));
+            Assert.That(result[i].WasSuccessful, Is.EqualTo(jobInfos[i].WasSuccessful));
+            Assert.That(result[i].StartTime, Is.EqualTo(jobInfos[i].StartTime).Within(TimeSpan.FromSeconds(1)));
+        }
+    }
+
+    [Test]
+    public async Task GetFailedAsync_ReturnsOnlyFailedExecutions()
+    {
+        // Arrange
+        var jobInfos = new List<JobExecutionInfo>
+        {
+            CreateJobExecutionInfo(true),
+            CreateJobExecutionInfo(false),
+            CreateJobExecutionInfo(true),
+            CreateJobExecutionInfo(false)
+        };
+
+        var key = $"monitoring:jobs:{TestJobName}:history";
+        var serialized = jobInfos.Select(x => (RedisValue)JsonSerializer.Serialize(x)).ToArray();
+
+        _databaseMock.Setup(db => db.ListRangeAsync(key, 0, -1, CommandFlags.None))
+            .ReturnsAsync(serialized);
+
+        // Act
+        var result = await _logger.GetFailedAsync(TestJobName);
+
+        // Assert
+        Assert.That(result.Count, Is.EqualTo(2));
+        Assert.That(result.All(x => !x.WasSuccessful), Is.True);
+    }
+
+    [Test]
+    public void Constructor_ShouldFallbackToDefaultHistoryLength_WhenRedisOptionsIsNull()
+    {
+        // Arrange
+        var options = Options.Create(new QuartzMonitoringOptions { Redis = null });
+
+        // Act
+        var logger = new RedisJobExecutionLogger(_connectionMock.Object, options);
+
+        // Assert
+        Assert.IsNotNull(logger);
+    }
+
+    private JobExecutionInfo CreateJobExecutionInfo(bool wasSuccessful = true)
+    {
+        return new JobExecutionInfo
+        {
+            JobName = TestJobName,
+            StartTime = DateTime.UtcNow,
+            EndTime = DateTime.UtcNow.AddSeconds(1),
+            Duration = TimeSpan.FromSeconds(1),
+            WasSuccessful = wasSuccessful,
+            ErrorMessage = wasSuccessful ? null : "Simulated error"
+        };
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/QuartzRateLimiterServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/QuartzRateLimiterServiceTests.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using OutOfSchool.WebApi.RateLimiting;
+using System.IO;
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Text.Json;
+using System.Threading.RateLimiting;
+using System.Threading;
+using System.Threading.Tasks;
+using RateLimiterOptions = OutOfSchool.WebApi.Config.RateLimiterOptions;
+
+namespace OutOfSchool.WebApi.Tests.Services;
+[TestFixture]
+public class QuartzRateLimiterServiceTests
+{
+    private QuartzRateLimiterService service;
+    private RateLimiterOptions options;
+    private Mock<ILogger<QuartzRateLimiterService>> loggerMock;
+
+    [SetUp]
+    public void SetUp()
+    {
+        options = new RateLimiterOptions
+        {
+            PermitLimit = 2,
+            QueueLimit = 5,
+            Window = 10,
+            RetryAfterSeconds = 30,
+            EnableIpBasedRateLimiting = true
+        };
+
+        loggerMock = new Mock<ILogger<QuartzRateLimiterService>>();
+        var optionsWrapper = Options.Create(options);
+
+        service = new QuartzRateLimiterService(optionsWrapper, loggerMock.Object);
+    }
+
+    [Test]
+    public void GetPolicy_WhenCalledWithIpBasedLimiting_ShouldReturnPolicyWithIpPartition()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse("192.168.0.1");
+
+        // Act
+        var partition = service.GetPolicy(context);
+
+        // Assert
+        var limiter = partition.Factory("192.168.0.1");
+        Assert.That(limiter, Is.TypeOf<FixedWindowRateLimiter>());
+    }
+
+    [Test]
+    public void GetPolicy_WhenIpBasedLimitingDisabled_ShouldUseUserName()
+    {
+        // Arrange
+        options.EnableIpBasedRateLimiting = false;
+        var context = new DefaultHttpContext();
+        context.User = new System.Security.Claims.ClaimsPrincipal(
+            new System.Security.Claims.ClaimsIdentity(
+                new[] { new System.Security.Claims.Claim("name", "testuser") }, "TestAuth"));
+
+        // Act
+        var partition = service.GetPolicy(context);
+
+        // Assert
+        var limiter = partition.Factory("testuser");
+        Assert.That(limiter, Is.TypeOf<FixedWindowRateLimiter>());
+    }
+
+    [Test]
+    public async Task HandleRejection_ShouldSet429AndRetryAfterHeaderAndReturnJson()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        var responseStream = new MemoryStream();
+        httpContext.Response.Body = responseStream;
+
+        var context = new OnRejectedContext
+        {
+            HttpContext = httpContext,
+            Lease = null!
+        };
+
+        // Act
+        await service.HandleRejection(context, CancellationToken.None);
+
+        // Assert
+        Assert.That(httpContext.Response.StatusCode, Is.EqualTo(StatusCodes.Status429TooManyRequests));
+        Assert.That(httpContext.Response.Headers["Retry-After"], Is.Not.Empty);
+
+        // check json response
+        responseStream.Seek(0, SeekOrigin.Begin);
+
+        var responseBody = await new StreamReader(responseStream).ReadToEndAsync();
+
+        var json = JsonSerializer.Deserialize<JsonElement>(responseBody);
+
+        // check if the JSON contains the expected properties
+        Assert.That(json.TryGetProperty("error", out var errorProp), Is.True, "JSON does not 'Error'");
+        Assert.That(errorProp.GetString(), Does.Contain("Rate limit exceeded"));
+
+        Assert.That(json.GetProperty("retryAfter").GetInt32(), Is.EqualTo(options.RetryAfterSeconds));
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Config/RateLimiterOptions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Config/RateLimiterOptions.cs
@@ -1,0 +1,33 @@
+﻿namespace OutOfSchool.WebApi.Config;
+
+/// <summary>
+/// Configuration options for rate limiting.
+/// </summary>
+public class RateLimiterOptions
+{
+    /// <summary>
+    /// Maximum number of requests allowed in the specified window.
+    /// </summary>
+    public int PermitLimit { get; set; }
+
+    /// <summary>
+    /// Time window in seconds for the rate limiting.
+    /// </summary>
+    public int Window { get; set; }
+
+    /// <summary>
+    /// Maximum size of the queue for pending requests (0 means no queue).
+    /// </summary>
+    public int QueueLimit { get; set; }
+
+    /// <summary>
+    /// Whether to use client IP address as the partition key.
+    /// If false, authenticated username will be used if available.
+    /// </summary>
+    public bool EnableIpBasedRateLimiting { get; set; }
+
+    /// <summary>
+    /// Time in seconds to wait before retrying after a rate limit is exceeded.
+    /// </summary>
+    public int RetryAfterSeconds { get; set; }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/EndpointFilterExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/EndpointFilterExtensions.cs
@@ -1,0 +1,11 @@
+﻿using OutOfSchool.WebApi.Filters;
+
+namespace OutOfSchool.WebApi.Extensions;
+
+public static class EndpointFilterExtensions
+{
+    public static RouteGroupBuilder RequireTechAdmin(this RouteGroupBuilder group)
+    {
+        return group.AddEndpointFilter<TechAdminAccessFilter>();
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/EndpointFilterExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/EndpointFilterExtensions.cs
@@ -4,8 +4,10 @@ namespace OutOfSchool.WebApi.Extensions;
 
 public static class EndpointFilterExtensions
 {
-    public static RouteGroupBuilder RequireTechAdmin(this RouteGroupBuilder group)
+    public static RouteGroupBuilder RequireTechAdmin(this RouteGroupBuilder builder)
     {
-        return group.AddEndpointFilter<TechAdminAccessFilter>();
+        return builder
+            .RequireAuthorization()
+            .AddEndpointFilter<TechAdminAccessFilter>();
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/RateLimitingExtensions.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/RateLimitingExtensions.cs
@@ -1,0 +1,34 @@
+﻿using OutOfSchool.WebApi.RateLimiting;
+
+namespace OutOfSchool.WebApi.Extensions;
+
+public static class RateLimiterExtensions
+{
+    /// <summary>
+    /// Adds rate limiting services for Quartz monitoring.
+    /// </summary>
+    public static IServiceCollection AddQuartzMonitoringRateLimiter(this IServiceCollection services)
+    {
+        // Register the rate limiter service
+        services.AddSingleton<IRateLimiterService, QuartzRateLimiterService>();
+
+        services.AddRateLimiter(options =>
+        {
+            // Configure the rate limiter policy
+            options.AddPolicy("QuartzMonitoringLimiter", httpContext =>
+            {
+                var service = httpContext.RequestServices.GetRequiredService<IRateLimiterService>();
+                return service.GetPolicy(httpContext);
+            });
+
+            // Configure rejection handler
+            options.OnRejected = async (context, token) =>
+            {
+                var service = context.HttpContext.RequestServices.GetRequiredService<IRateLimiterService>();
+                await service.HandleRejection(context, token);
+            };
+        });
+
+        return services;
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/SwaggerFeatureGateFilter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/Startup/SwaggerFeatureGateFilter.cs
@@ -17,7 +17,10 @@ public class SwaggerFeatureGateFilter : IDocumentFilter {
     public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context) {
 
         foreach (var apiDescription in context.ApiDescriptions) {
-            var actionDescriptor = (ControllerActionDescriptor)apiDescription.ActionDescriptor;
+            if (apiDescription.ActionDescriptor is not ControllerActionDescriptor actionDescriptor)
+            {
+                continue;
+            }
 
             var attrForController = actionDescriptor.ControllerTypeInfo.GetCustomAttributes(typeof(FeatureGateAttribute), true).Select(a => (FeatureGateAttribute)a).ToList();
             var attrForEndpoint = actionDescriptor.MethodInfo.GetCustomAttributes(typeof(FeatureGateAttribute), true).Select(a => (FeatureGateAttribute)a).ToList();

--- a/OutOfSchool/OutOfSchool.WebApi/Filters/TechAdminAccessFilter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Filters/TechAdminAccessFilter.cs
@@ -13,7 +13,9 @@ public class TechAdminAccessFilter : IEndpointFilter
 
         if (!currentUserService.IsTechAdmin())
         {
-            return Results.Forbid();
+            return Results.Json(
+                new { message = "Access denied. Only TechAdmins are allowed." },
+                statusCode: StatusCodes.Status403Forbidden);
         }
 
         return await next(context);

--- a/OutOfSchool/OutOfSchool.WebApi/Filters/TechAdminAccessFilter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Filters/TechAdminAccessFilter.cs
@@ -1,0 +1,21 @@
+﻿namespace OutOfSchool.WebApi.Filters;
+
+public class TechAdminAccessFilter : IEndpointFilter
+{
+    private readonly ICurrentUserService currentUserService;
+
+    public TechAdminAccessFilter(ICurrentUserService currentUserService)
+    {
+        this.currentUserService = currentUserService;
+    }
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+
+        if (!currentUserService.IsTechAdmin())
+        {
+            return Results.Forbid();
+        }
+
+        return await next(context);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
+++ b/OutOfSchool/OutOfSchool.WebApi/OutOfSchool.WebApi.csproj
@@ -81,6 +81,7 @@
         <ProjectReference Include="..\OutOfSchool.ElasticsearchData\OutOfSchool.ElasticsearchData.csproj" />
         <ProjectReference Include="..\OutOfSchool.EmailSender\OutOfSchool.EmailSender.csproj" />
         <ProjectReference Include="..\OutOfSchool.ExternalFileStore.Impl\OutOfSchool.ExternalFileStore.Impl.csproj" />
+		<ProjectReference Include="..\OutOfSchool.QuartzJobs.Api\OutOfSchool.QuartzJobs.Api.csproj" />
         <ProjectReference Include="..\OutOfSchool.RazorTemplatesData\OutOfSchool.RazorTemplatesData.csproj" />
     </ItemGroup>
 </Project>

--- a/OutOfSchool/OutOfSchool.WebApi/RateLimiting/IRateLimiterService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/RateLimiting/IRateLimiterService.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.RateLimiting;
+using System.Threading.RateLimiting;
+
+namespace OutOfSchool.WebApi.RateLimiting;
+
+/// <summary>
+/// Service for handling rate limiting operations.
+/// </summary>
+public interface IRateLimiterService
+{
+    /// <summary>
+    /// Gets the rate limiter policy for the given HTTP context.
+    /// </summary>
+    /// <param name="context">The HTTP context.</param>
+    /// <returns>A rate limiter partition.</returns>
+    RateLimitPartition<string> GetPolicy(HttpContext context);
+
+    /// <summary>
+    /// Handles rejected requests due to rate limiting.
+    /// </summary>
+    /// <param name="context">The rejection context.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task HandleRejection(OnRejectedContext context, CancellationToken token);
+}

--- a/OutOfSchool/OutOfSchool.WebApi/RateLimiting/QuartzRateLimiterService.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/RateLimiting/QuartzRateLimiterService.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+using System.Threading.RateLimiting;
+using RateLimiterOptions = OutOfSchool.WebApi.Config.RateLimiterOptions;
+
+namespace OutOfSchool.WebApi.RateLimiting;
+
+/// <summary>
+/// Service implementation for Quartz monitoring rate limiting.
+/// </summary>
+public class QuartzRateLimiterService : IRateLimiterService
+{
+    private readonly RateLimiterOptions options;
+    private readonly ILogger<QuartzRateLimiterService> logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuartzRateLimiterService"/> class.
+    /// </summary>
+    /// <param name="options">The rate limiter options.</param>
+    /// <param name="logger">The logger.</param>
+    public QuartzRateLimiterService(
+        IOptions<RateLimiterOptions> options,
+        ILogger<QuartzRateLimiterService> logger)
+    {
+        this.options = options.Value;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public RateLimitPartition<string> GetPolicy(HttpContext context)
+    {
+        string partitionKey = GetPartitionKey(context, options);
+
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey,
+            _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = options.PermitLimit,
+                Window = TimeSpan.FromSeconds(options.Window),
+                QueueLimit = options.QueueLimit,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+            });
+    }
+
+    /// <inheritdoc/>
+    public Task HandleRejection(OnRejectedContext context, CancellationToken token)
+    {
+        logger.LogWarning(
+            "Rate limit exceeded for client {ClientIP}, user {Username}, endpoint {Path}",
+            context.HttpContext.Connection.RemoteIpAddress,
+            context.HttpContext.User.Identity?.Name ?? "anonymous",
+            context.HttpContext.Request.Path);
+
+        context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        context.HttpContext.Response.Headers.Append(
+            "Retry-After", 
+            DateTime.UtcNow.AddSeconds(options.RetryAfterSeconds)
+            .ToString("R"));
+
+        return context.HttpContext.Response.WriteAsJsonAsync(new
+        {
+            Error = $"Rate limit exceeded. You can make another request in {options.RetryAfterSeconds} seconds.",
+            RetryAfter = options.RetryAfterSeconds
+        }, token);
+    }
+
+    /// <summary>
+    /// Gets the appropriate partition key based on configuration and request context.
+    /// </summary>
+    /// <param name="httpContext">The HTTP context.</param>
+    /// <param name="options">The rate limiter options.</param>
+    /// <returns>The partition key.</returns>
+    private static string GetPartitionKey(HttpContext httpContext, RateLimiterOptions options)
+    {
+        if (options.EnableIpBasedRateLimiting)
+        {
+            return httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown_ip";
+        }
+
+        return httpContext.User.Identity?.IsAuthenticated == true
+            ? httpContext.User.Identity.Name ?? "anonymous"
+            : "anonymous";
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -33,6 +33,7 @@ using OutOfSchool.EmailSender;
 using OutOfSchool.EmailSender.Services;
 using OutOfSchool.ExternalFileStore;
 using OutOfSchool.ExternalFileStore.Config;
+using OutOfSchool.QuartzJobs.Api.Extensions;
 using OutOfSchool.RazorTemplatesData.Services;
 using OutOfSchool.Services.Models.CompetitiveEvents;
 using OutOfSchool.Services.Models.WorkshopDrafts;
@@ -43,6 +44,7 @@ using OutOfSchool.Services.Repository.Base.Api;
 using OutOfSchool.Services.Repository.Files;
 using OutOfSchool.Services.Repository.WorkshopDraftRepository;
 using OutOfSchool.WebApi.Enums;
+using Quartz;
 using StackExchange.Redis;
 
 namespace OutOfSchool.WebApi;
@@ -135,6 +137,8 @@ public static class Startup
             },
         })
             .WithMetadata(new AllowAnonymousAttribute());
+
+        app.MapQuartzMonitoringApi();
 
         app.MapControllers();
 
@@ -566,6 +570,7 @@ public static class Startup
                 q.AddObjectStorageSynchronization(services, storageConfig.Provider, quartzConfig);
             }
 
+            q.AddQuartzMonitoringListener();
             q.AddElasticsearchSynchronization(services, configuration);
             q.AddStatisticReportsCreating(services, quartzConfig);
             q.AddOldNotificationsClearing(services, quartzConfig);
@@ -574,6 +579,8 @@ public static class Startup
             q.AddLicenseApprovalNotificationGenerating(services, quartzConfig);
             q.AddEmailSender(quartzConfig);
         });
+
+        services.AddQuartzMonitoring(configuration);
 
         var isRedisEnabled = configuration.GetValue<bool>("Redis:Enabled");
         var redisConfig = configuration

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -138,8 +138,7 @@ public static class Startup
         })
             .WithMetadata(new AllowAnonymousAttribute());
 
-        app.MapQuartzMonitoringApi()
-           .RequireTechAdmin();
+        app.MapQuartzMonitoringApi().RequireTechAdmin();
 
         app.MapControllers();
 

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -138,7 +138,8 @@ public static class Startup
         })
             .WithMetadata(new AllowAnonymousAttribute());
 
-        app.MapQuartzMonitoringApi();
+        app.MapQuartzMonitoringApi()
+           .RequireTechAdmin();
 
         app.MapControllers();
 

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -138,7 +138,11 @@ public static class Startup
         })
             .WithMetadata(new AllowAnonymousAttribute());
 
-        app.MapQuartzMonitoringApi().RequireTechAdmin();
+        app.UseRateLimiter();
+
+        app.MapQuartzMonitoringApi()
+             .RequireRateLimiting("QuartzMonitoringLimiter")
+             .RequireTechAdmin();
 
         app.MapControllers();
 
@@ -580,6 +584,13 @@ public static class Startup
             q.AddEmailSender(quartzConfig);
         });
 
+        // Rate limiter options
+        services.Configure<RateLimiterOptions>(configuration.GetSection("QuartzMonitoring:RateLimiter"));
+
+        // Rate limiter for Quartz monitoring
+        services.AddQuartzMonitoringRateLimiter();
+
+        // Add Quartz monitoring
         services.AddQuartzMonitoring(configuration);
 
         var isRedisEnabled = configuration.GetValue<bool>("Redis:Enabled");

--- a/OutOfSchool/OutOfSchool.WebApi/Util/AuthorizeCheckOperationFilter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/AuthorizeCheckOperationFilter.cs
@@ -7,9 +7,8 @@ public class AuthorizeCheckOperationFilter(string authorizationName) : IOperatio
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
-        var hasAuthorize = 
-            context.MethodInfo.DeclaringType!.GetCustomAttributes(true).OfType<AuthorizeAttribute>().Any()
-            || context.MethodInfo.GetCustomAttributes(true).OfType<AuthorizeAttribute>().Any();
+        var hasAuthorize = context.ApiDescription.ActionDescriptor.EndpointMetadata
+            .OfType<AuthorizeAttribute>().Any();
 
         if (hasAuthorize)
         {
@@ -18,7 +17,8 @@ public class AuthorizeCheckOperationFilter(string authorizationName) : IOperatio
                 new()
                 {
                     [
-                        new OpenApiSecurityScheme {
+                        new OpenApiSecurityScheme
+                        {
                             Reference = new OpenApiReference
                             {
                                 Type = ReferenceType.SecurityScheme,
@@ -29,7 +29,6 @@ public class AuthorizeCheckOperationFilter(string authorizationName) : IOperatio
                     ] = new List<string>(),
                 },
             };
-
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -267,6 +267,16 @@
     }
   },
 
+  "QuartzMonitoring": {
+    "Enabled": true,
+    "Redis": {
+      "Server": "localhost",
+      "Port": 6379,
+      "Password": "",
+      "HistoryLength": 10
+    }
+  },
+
   "ChangesLog": {
     "TrackedProperties": {
       "Provider": [ "FullTitle", "ShortTitle", "Contacts.Address", "InstitutionId", "InstitutionStatusId" ],

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -274,6 +274,13 @@
       "Port": 6379,
       "Password": "",
       "HistoryLength": 10
+    },
+    "RateLimiter": {
+      "PermitLimit": 10,
+      "Window": 60,
+      "EnableIpBasedRateLimiting": true,
+      "QueueLimit": 0,
+      "RetryAfterSeconds": 60
     }
   },
 

--- a/OutOfSchool/OutOfSchool.sln
+++ b/OutOfSchool/OutOfSchool.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.32014.148
@@ -55,6 +54,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OutOfSchool.ExternalFileStore.Api", "OutOfSchool.ExternalFileStore.Api\OutOfSchool.ExternalFileStore.Api.csproj", "{27369F06-7D23-4833-992C-A10F99B5D431}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "OutOfSchool.ExternalFileStore", "OutOfSchool.ExternalFileStore", "{9DEBC250-8BF6-4D64-97E0-B3757AEDD9A4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OutOfSchool.QuartzJobs.Api", "OutOfSchool.QuartzJobs.Api\OutOfSchool.QuartzJobs.Api.csproj", "{7D5ABC15-4B3E-E51C-D93E-5385BA2E0FFA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -146,6 +147,10 @@ Global
 		{27369F06-7D23-4833-992C-A10F99B5D431}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27369F06-7D23-4833-992C-A10F99B5D431}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27369F06-7D23-4833-992C-A10F99B5D431}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D5ABC15-4B3E-E51C-D93E-5385BA2E0FFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D5ABC15-4B3E-E51C-D93E-5385BA2E0FFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D5ABC15-4B3E-E51C-D93E-5385BA2E0FFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D5ABC15-4B3E-E51C-D93E-5385BA2E0FFA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -155,8 +160,8 @@ Global
 		{858FFC94-4A9B-4A91-917E-F672455F1B32} = {BF649E8B-4D72-4762-9A59-C8D3B4AF3A30}
 		{EC5A5CE0-1AE6-48DA-810B-A7DC6DBCDCE4} = {BF649E8B-4D72-4762-9A59-C8D3B4AF3A30}
 		{13875C12-6837-4742-88F9-C3401C5A2D85} = {BF649E8B-4D72-4762-9A59-C8D3B4AF3A30}
-		{27369F06-7D23-4833-992C-A10F99B5D431} = {9DEBC250-8BF6-4D64-97E0-B3757AEDD9A4}
 		{8F72405A-E4A0-434E-868B-DAEA8F1394BA} = {9DEBC250-8BF6-4D64-97E0-B3757AEDD9A4}
+		{27369F06-7D23-4833-992C-A10F99B5D431} = {9DEBC250-8BF6-4D64-97E0-B3757AEDD9A4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {759AF463-9F34-412E-9FC1-7B3894D79E59}


### PR DESCRIPTION
This PR implements a Quartz.NET job monitoring API for TechAdmin users, as required in [#1762](https://github.com/ita-social-projects/OoS-Backend/issues/1762).  
A new extension library **OutOfSchool.QuartzJobs.Api** was introduced and integrated into WebAPI via `MapQuartzMonitoringApi()`.

### Key Features

- **Minimal API** endpoints under `/quartz`
- **Access restricted** to TechAdmins via `.RequireTechAdmin()` and `TechAdminAccessFilter`
- **Rate Limiting** via `QuartzRateLimiterService`, configurable in `appsettings.json`
- **Redis-based job execution logging** using `JobMonitoringListener` and `RedisJobExecutionLogger`

### Endpoints

| Method | Route                                       | Description                              |
|--------|---------------------------------------------|------------------------------------------|
| GET    | `/quartz/jobs`                              | List all jobs with status and type       |
| GET    | `/quartz/jobs/running`                      | Show currently executing jobs            |
| GET    | `/quartz/jobs/scheduled`                    | Next scheduled executions for all jobs   |
| GET    | `/quartz/jobs/{jobName}`                    | Detailed info about a job and triggers   |
| GET    | `/quartz/jobs/{jobName}/scheduled`          | Next scheduled executions for one job    |
| GET    | `/quartz/jobs/{jobName}/history`            | Execution history (Redis)                |
| GET    | `/quartz/jobs/{jobName}/errors`             | Failed executions only                   |

### Implementation Highlights

- `AddQuartzMonitoringApi()` registers:
  - `QuartzMonitoringService`
  - Redis connection
  - Configuration via `QuartzMonitoringOptions`
- `JobMonitoringListener` captures job lifecycle events
- `RedisJobExecutionLogger` stores last N executions with:
  - Duration
  - Trigger type
  - Retry count
  - Status, errors, stack trace, and parameters

### Security & Stability

- Access restricted to TechAdmin users
- Rate limiter (e.g. 10 requests/minute per IP or user)
- Settings configurable via `QuartzMonitoring` section in `appsettings.json`

### Tests

- All newly added functionality is fully covered with **unit and integration tests**.
- Coverage includes:
  - Endpoint behavior
  - Job execution logging
  - Redis-based history/error storage
  - Access control
  - Rate limiter configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive Quartz job monitoring capabilities, including APIs to view job status, execution history, errors, and upcoming schedules.
  - Added rate limiting for Quartz monitoring endpoints, configurable by IP or user, with customizable retry intervals.
  - Implemented access control for monitoring endpoints, restricting access to technical administrators.
  - Added detailed job and trigger descriptions for improved job visibility.
  - Integrated Redis-based logging for job execution history.

- **Configuration**
  - Added new configuration sections for Quartz monitoring, Redis connection, and rate limiting in application settings.

- **Bug Fixes**
  - Improved type safety and error handling in API operation filters and Swagger integration.

- **Tests**
  - Added extensive unit and integration tests for Quartz monitoring APIs, rate limiting, and job execution logging.

- **Chores**
  - Updated and added necessary package dependencies for new features and testing support.
  - Included the new QuartzJobs API project in the solution and as a dependency in relevant projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->