### PR TITLE
fix(dto): update Price assignment logic in WorkshopV2DtoExtensions

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
@@ -46,7 +46,7 @@ public static class WorkshopV2DtoExtensions
             FormOfLearning = dto.FormOfLearning,
             WorkshopStatus = dto.Status,
             ProviderLicenseStatus = dto.ProviderLicenseStatus,
-            Price = dto.Price ?? default,
+            Price = dto.IsPaid ? dto.Price ?? default : 0,
             PayRate = dto.PayRate ?? default,
             AreThereBenefits = dto.AreThereBenefits,
             PreferentialTermsOfParticipation = dto.PreferentialTermsOfParticipation,


### PR DESCRIPTION
Update Price assignment to conditionally set value based on IsPaid. If IsPaid is true, assign dto.Price or default; if false, set to 0. Ensures unpaid workshops always have a Price of 0 per business rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that unpaid workshops now display a price of zero in draft content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->