### PR TITLE
fix(elasticsearch): handle null AverageRating in ReIndex to prevent crash

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/AverageRatingDTO.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/AverageRatingDTO.cs
@@ -12,12 +12,18 @@ public class AverageRatingDto
 public static class AverageRatingDtoExtensions
 {
     public static AverageRatingDto ToDto(this OutOfSchool.Services.Models.AverageRating averageRating)
-        => new()
+    {
+        if (averageRating is null)
         {
-            Rate = (float) averageRating.Rate,
+            return null;
+        }
+        return new()
+        {
+            Rate = (float)averageRating.Rate,
             RateQuantity = averageRating.RateQuantity,
             EntityId = averageRating.EntityId
         };
+    }
 
     public static List<AverageRatingDto> ToDto(this IEnumerable<OutOfSchool.Services.Models.AverageRating> list)
         => list.MapToList(ToDto);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/AverageRatingDTO.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/AverageRatingDTO.cs
@@ -15,7 +15,12 @@ public static class AverageRatingDtoExtensions
     {
         if (averageRating is null)
         {
-            return null;
+            return new AverageRatingDto
+            {
+                Rate = 0,
+                RateQuantity = 0,
+                EntityId = Guid.Empty
+            };
         }
         return new()
         {


### PR DESCRIPTION
###  Problem

During `ReIndex()` execution for workshops, the application crashed with a `NullReferenceException` in this line:

```csharp
var rating = await averageRatingService.GetByEntityIdAsync(entity.Id);
entity.Rating = rating?.Rate ?? default;
```

The root cause was that `averageRatingService.GetByEntityIdAsync(...)` was returning `null` for some entities (those without ratings in the DB), and the `.ToDto()` extension method was not handling `null`.

This crash led to:
- ❌ Interrupted reindexing process,
- ❌ Failure to populate Elasticsearch indices,
- ❌ No data visibility in Kibana.

<p align="center">
  On the screen below you can see exception thrown by the debugger:
</p>

<p align="center">
  <img src="https://github.com/user-attachments/assets/fec842ea-711a-43de-ab79-d7e86f45e15a" alt="Crash Screenshot">
</p>

---

### ✅ Fix

Added a `null` check in `AverageRatingDtoExtensions.ToDto(...)`, returning a safe default `AverageRatingDto` when the source is `null`.

This ensures that:
- `ReIndex()` completes even if no rating exists,
- Elasticsearch stays in a consistent and indexable state.

---

### 🧪 How to test

1. Run reindex manually (`/api/v1/ElasticsearchWorkshop/ReIndex` or equivalent).
2. Confirm no exception is thrown.
3. Verify data appears in Elasticsearch (via Kibana or `_search` API).

---

### 📎 Related

- 🧵 Internal bug report: `NullReferenceException in AverageRatingDtoExtensions`
- 📘 Possibly introduced after AutoMapper was removed in favor of manual `.ToDto()` mapping

---

### ✅ Checklist

- [x] Bug is reproduced and fixed
- [x] Fix is backward-compatible
- [x] No breaking changes introduced
- [x] Reindexing now completes without crash

---

### 📌 Notes

This PR unblocks initial sync to Elasticsearch for all environments where not all workshops have rating records yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of cases where average rating data may be missing, preventing errors when such data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->