### PR TITLE
feat(api): add feature flag checks for WorkshopController in v1 API

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.FeatureManagement;
 using Moq;
 using NUnit.Framework;
 using OutOfSchool.BusinessLogic.Common;
@@ -41,6 +42,7 @@ public class WorkshopControllerTests
     private static ProviderDto provider;
 
     private WorkshopController controller;
+    private Mock<IFeatureManager> featureManagerMoq;
     private Mock<IWorkshopServicesCombiner> workshopServiceMoq;
     private Mock<IProviderService> providerServiceMoq;
     private Mock<IUserService> userServiceMoq;
@@ -87,6 +89,7 @@ public class WorkshopControllerTests
         providerServiceMoq = new Mock<IProviderService>();
         userServiceMoq = new Mock<IUserService>();
         loggerMoq = new Mock<ILogger<WorkshopController>>();
+        featureManagerMoq = new Mock<IFeatureManager>();
         currentUserServiceMoq = new Mock<ICurrentUserService>();
 
         controller = new WorkshopController(
@@ -94,6 +97,7 @@ public class WorkshopControllerTests
             providerServiceMoq.Object,
             userServiceMoq.Object,
             currentUserServiceMoq.Object,
+            featureManagerMoq.Object,
             loggerMoq.Object)
         {
             ControllerContext = new ControllerContext() { HttpContext = httpContextMoq.Object },

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopControllerTests.cs
@@ -1162,6 +1162,45 @@ public class WorkshopControllerTests
 
     #endregion
 
+    #region FeatureFlagBehavior
+
+    [Test]
+    public async Task Create_WhenRelease2FeatureFlagEnabled_ShouldReturnGoneResult()
+    {
+        // Arrange
+        featureManagerMoq.Setup(f => f.IsEnabledAsync("Release2"))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await controller.Create(workshopCreateRequestDto) as ObjectResult;
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.AreEqual(StatusCodes.Status410Gone, result.StatusCode);
+        Assert.AreEqual("Workshop API v1 is deprecated. Please use API v2 via draft creation.", result.Value);
+        workshopServiceMoq.Verify(x => x.Create(It.IsAny<WorkshopCreateRequestDto>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Update_WhenRelease2FeatureFlagEnabled_ShouldReturnGoneResult()
+    {
+        // Arrange
+        featureManagerMoq.Setup(f => f.IsEnabledAsync("Release2"))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await controller.Update(workshopUpdateDto) as ObjectResult;
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.AreEqual(StatusCodes.Status410Gone, result.StatusCode);
+        Assert.AreEqual("Workshop API v1 is deprecated. Please use API v2 via draft creation.", result.Value);
+        workshopServiceMoq.Verify(x => x.Update(It.IsAny<WorkshopCreateUpdateDto>()), Times.Never);
+    }
+
+
+    #endregion
+
     private WorkshopStatusDto WithWorkshopStatusDto(Guid workshopDtoId, WorkshopStatus workshopStatus)
     {
         return new WorkshopStatusDto()

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/WorkshopController.cs
@@ -20,6 +20,7 @@ public class WorkshopController : ControllerBase
     private readonly IProviderService providerService;
     private readonly IUserService userService;
     private readonly ICurrentUserService currentUserService;
+    private readonly IFeatureManager featureManager;
     private readonly ILogger<WorkshopController> logger;
     private const int DefaultPageSize = 9;
 
@@ -29,18 +30,21 @@ public class WorkshopController : ControllerBase
     /// <param name="combinedWorkshopService">Service for operations with Workshops.</param>
     /// <param name="providerService">Service for Provider model.</param>
     /// <param name="userService">Service for operations with users.</param>
+    /// <param name="featureManager">Feature manager for feature flags.</param>
     /// <param name="logger"><see cref="Microsoft.Extensions.Logging.ILogger{T}"/> object.</param>
     public WorkshopController(
         IWorkshopServicesCombiner combinedWorkshopService,
         IProviderService providerService,
         IUserService userService,
         ICurrentUserService currentUserService,
+        IFeatureManager featureManager,
         ILogger<WorkshopController> logger)
     {
         this.combinedWorkshopService = combinedWorkshopService;
         this.providerService = providerService;
         this.userService = userService;
         this.currentUserService = currentUserService;
+        this.featureManager = featureManager;
         this.logger = logger;
     }
 
@@ -274,6 +278,10 @@ public class WorkshopController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> Create([FromBody] WorkshopCreateRequestDto dto)
     {
+        if (await featureManager.IsEnabledAsync("Release2"))
+        {
+           return StatusCode(StatusCodes.Status410Gone, "Workshop API v1 is deprecated. Please use API v2 via draft creation.");
+        }
         if (dto == null)
         {
             return BadRequest("Workshop is null.");
@@ -334,6 +342,10 @@ public class WorkshopController : ControllerBase
     [HttpPut]
     public async Task<IActionResult> Update([FromBody] WorkshopCreateUpdateDto dto)
     {
+        if (await featureManager.IsEnabledAsync("Release2"))
+        {
+            return StatusCode(StatusCodes.Status410Gone, "Workshop API v1 is deprecated. Please use API v2 via draft creation.");
+        }
         if (dto == null)
         {
             return BadRequest("Workshop is null.");


### PR DESCRIPTION
## 🚀 Summary

This PR **disables the `v1/Workshop/Create` and `v1/Workshop/Update` endpoints** when the new draft-based flow in v2 is enabled via Feature Management.

It **closes #1813** by ensuring that workshops can no longer be created directly through v1 — they must follow the new draft creation and moderation process introduced in v2.

---

## 🛠️ What has been changed

- Updated `v1/WorkshopController` methods:
  - `Create`
  - `Update`
- Each method now checks `IFeatureManager.IsEnabledAsync("Release2")` and returns `410 Gone` when the flag is active.

---

## ✅ Motivation and Context

> **Problem:** The legacy v1 API allows creating workshops directly without draft/moderation (see #1813). This violates the new business rules introduced in API v2.

> **Goal:** Prevent users from bypassing the moderation flow by disabling the affected v1 endpoints.

By leveraging `IFeatureManager`, we gain flexibility:
- 🔧 Easily toggle the behavior in different environments.
- 🧪 Allow A/B testing or phased rollout if needed.
- ❌ Avoid hard deletion of v1 logic during transition.

---

## 🔍 How to test

1. Set the following in `appsettings.json`:
   ```json
   "FeatureManagement": {
     "Release2": true
   }


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a mechanism to disable the v1 Workshop API create and update endpoints when a specific feature flag is enabled. Users will receive a message indicating deprecation and guidance to use API v2 when these endpoints are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->