### PR TITLE
Implement endpoint to retrieve application count from a Parent to all Workshops of a Provider

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ApplicationService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ApplicationService.cs
@@ -476,6 +476,20 @@ public class ApplicationService : IApplicationService
         return result;
     }
 
+    /// <inheritdoc/>
+    public async Task<int> CountApplicationsByParentAndProvider(Guid parentId, Guid providerId)
+    {
+        logger.LogDebug("Getting applications count by parent and provider started.");
+
+        var count = await applicationRepository.Get(
+            whereExpression: a => (a.ParentId == parentId || a.Child.ParentId == parentId) && a.Workshop.ProviderId == providerId)
+            .AsNoTracking().CountAsync().ConfigureAwait(false);
+
+        logger.LogDebug("Number of matching applications that was retrieved is {count}", count);
+
+        return count;
+    }
+
     private void UpdateStatus(ApplicationUpdate applicationDto, Application application)
     {
         if (application.Status == applicationDto.Status)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/IApplicationService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/IApplicationService.cs
@@ -94,4 +94,12 @@ public interface IApplicationService
     /// </summary>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
     Task<int> ChangeApprovedStatusesToStudying();
+
+    /// <summary>
+    /// Retrieves a total number of applications with matching parent's id and provider's id.
+    /// </summary>
+    /// <param name="parentId">Parent's id.</param>
+    /// <param name="providerId">Provider's id.</param>
+    /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+    Task<int> CountApplicationsByParentAndProvider(Guid parentId, Guid providerId);
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ApplicationControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/ApplicationControllerTests.cs
@@ -656,6 +656,44 @@ public class ApplicationControllerTests
         Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
     }
 
+    [Test]
+    public async Task Count_WhenProviderIdIsInvalid_ShouldReturnBadRequest()
+    {
+        // Arrange
+        Guid providerId = Guid.NewGuid();
+        Guid parentId = Guid.NewGuid();
+
+        providerService.Setup(s => s.Exists(providerId))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await controller.Count(parentId, providerId).ConfigureAwait(false);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+    }
+
+    [Test]
+    public async Task Count_WhenIdsAreValid_ShouldReturnOkResult()
+    {
+        // Arrange
+        Guid providerId = Guid.NewGuid();
+        Guid parentId = Guid.NewGuid();
+
+        providerService.Setup(s => s.Exists(providerId))
+            .ReturnsAsync(true);
+
+        applicationService.Setup(s => s.CountApplicationsByParentAndProvider(parentId, providerId))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await controller.Count(parentId, providerId).ConfigureAwait(false) as OkObjectResult;
+
+        // Assert
+        Assert.That(result.StatusCode, Is.EqualTo(200));
+        Assert.That(result.Value, Is.EqualTo(1));
+    }
+
     private WorkshopV2Dto FakeWorkshop()
     {
         return new WorkshopV2Dto()

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/ApplicationServiceTests.cs
@@ -997,6 +997,29 @@ public class ApplicationServiceTests
         emailSenderMock.Verify(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<(string, string)>(), null), Times.Once);
     }
 
+    [Test]
+    public async Task CountApplicationsByParentAndProvider_WhenIdsAreValid_ShouldReturnCount()
+    {
+        // Arrange
+        var parentId = new Guid("cce7dcbf-991b-4c8e-ba30-4e3cc9e952f3");
+        var providerId = new Guid("1aa8e8e0-d35f-45cb-b66d-a01faa8fe174");
+        var applicationsMock = WithApplicationsList().AsQueryable().BuildMock();
+
+        applicationRepositoryMock.Setup(r => r.Get(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<Expression<Func<Application, bool>>>(),
+                It.IsAny<Dictionary<Expression<Func<Application, object>>, SortDirection>>()))
+            .Returns(applicationsMock)
+            .Verifiable();
+
+        // Act
+        var result = await service.CountApplicationsByParentAndProvider(parentId, providerId).ConfigureAwait(false);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(3));
+    }
+
     private static void AssertApplicationsDTOsAreEqual(ApplicationDto expected, ApplicationDto actual)
     {
         Assert.Multiple(() =>

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ApplicationController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/ApplicationController.cs
@@ -392,6 +392,39 @@ public class ApplicationController : ControllerBase
         return Ok(await applicationService.AllowedToReview(parentId, workshopId).ConfigureAwait(false));
     }
 
+    /// <summary>
+    /// Get the count of applications submitted by a parent (or their children) to workshops owned by the specified provider.
+    /// </summary>
+    /// <param name="parentId">Parent's id.</param>
+    /// <param name="providerId">Provider's id.</param>
+    /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+    /// <response code="200">Count of applications was retrieved.</response>
+    /// <response code="400">If properties are invalid.</response>
+    /// <response code="401">If the user is not authorized.</response>
+    /// <response code="403">If the user does not have permission.</response>
+    /// <response code="500">If any server error occurs.</response>
+    [HasPermission(Permissions.ApplicationRead)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(int))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [HttpGet]
+    [Route("~/api/v{version:apiVersion}/providers/{providerId:guid}/parents/{parentId:guid}/applications/count")]
+    public async Task<IActionResult> Count(Guid parentId, Guid providerId)
+    {
+        if (!await providerService.Exists(providerId).ConfigureAwait(false))
+        {
+            return BadRequest($"There is no provider with Id = {providerId}");
+        }
+
+        await currentUserService.UserHasRights(new ProviderRights(providerId), new EmployeeRights(providerId)).ConfigureAwait(false);
+
+        var count = await applicationService.CountApplicationsByParentAndProvider(parentId, providerId).ConfigureAwait(false);
+
+        return Ok(count);
+    }
+
     private async Task<bool> IsCurrentUserBlocked()
     {
         var userId = GettingUserProperties.GetUserId(User);


### PR DESCRIPTION
- Added endpoint that retrieves application count from a Parent to all Workshops of a Provider
- Added business logic for this endpoint
- Covered code with tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new API endpoint to retrieve the count of applications submitted by a parent (or their children) to workshops owned by a specific provider.

- **Tests**
	- Introduced new tests to verify correct behavior and validation for the application count endpoint, including scenarios for valid and invalid provider IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->