### PR TITLE
fix: prevent null or empty email

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/BaseUpdateUserDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/BaseUpdateUserDto.cs
@@ -29,8 +29,10 @@ public static class BaseUpdateUserDtoExtensions
 
     public static User SetToModel(this BaseUpdateUserDto dto, User model)
     {
-        model.Id = dto.Id;
-        model.Email = dto.Email;
+        if (!String.IsNullOrWhiteSpace(dto.Email))
+        {
+            model.Email = dto.Email;
+        }
         model.PhoneNumber = dto.PhoneNumber;
 
         return model;


### PR DESCRIPTION

This pull request addresses a bug where the user's email could be unintentionally overwritten with a null or empty value if it was not included in the personal information update request. This led to a loss of access for users (specifically SP accounts), as email is required for login.

 Changes:
- Updated the SetToModel() method to apply the new Email value only if it is non-null and non-empty.
- Left PhoneNumber unchanged — it is still updated as provided.
- Removed any modification of the user's Id during the update.

 Testing:
- User update without an Email keeps the existing Email.
- User update with a valid Email updates the field correctly.
- PhoneNumber updates as expected.