### PR TITLE
create statistic endpoint + service methods to get popular competitions

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/IStatisticService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/IStatisticService.cs
@@ -1,4 +1,5 @@
 ﻿using OutOfSchool.BusinessLogic.Models;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 
 namespace OutOfSchool.BusinessLogic.Services;
@@ -8,6 +9,22 @@ namespace OutOfSchool.BusinessLogic.Services;
 /// </summary>
 public interface IStatisticService
 {
+    /// <summary>
+    /// Get popular competitions using Redis.
+    /// </summary>
+    /// <param name="limit">Number of entries to return.</param>
+    /// <param name="catottgId">Codeficator's id.</param>
+    /// <returns>List of popular categories.</returns>
+    Task<IEnumerable<CompetitiveEventViewCardDto>> GetPopularCompetitiveEvents(int lLimit, long catottgId);
+
+    /// <summary>
+    /// Get popular competitions from DB.
+    /// </summary>
+    /// <param name="limit">Number of entries to return.</param>
+    /// <param name="catottgId">Codeficator's id.</param>
+    /// <returns>List of popular categories.</returns>
+    Task<IEnumerable<CompetitiveEventViewCardDto>> GetPopularCompetitiveEventsFromDatabase(int limit, long catottgId);
+
     /// <summary>
     /// Get popular directions using Redis.
     /// </summary>

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/StatisticService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/StatisticService.cs
@@ -1,4 +1,5 @@
 ﻿using OutOfSchool.BusinessLogic.Models;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.BusinessLogic.Services.AverageRatings;
 using OutOfSchool.Common.Enums;
@@ -19,6 +20,7 @@ namespace OutOfSchool.BusinessLogic.Services;
 public class StatisticService(
     IApplicationRepository applicationRepository,
     IWorkshopRepository workshopRepository,
+    ICompetitiveEventRepository competitiveEventRepository,
     IEntityRepositorySoftDeleted<long, Direction> directionRepository,
     ILogger<StatisticService> logger,
     ICacheService cache,
@@ -199,5 +201,44 @@ public class StatisticService(
         }
 
         return workshopsCards;
+    }
+
+    public async Task<IEnumerable<CompetitiveEventViewCardDto>> GetPopularCompetitiveEvents(int limit, long catottgId)
+    {
+        logger.LogInformation("Getting popular competitive events started.");
+
+        var cacheKey = $"GetPopularCompetitions_{limit}_{catottgId}";
+
+        var competitionsResult = await cache.GetOrAddAsync(cacheKey, () =>
+            GetPopularCompetitiveEventsFromDatabase(limit, catottgId)).ConfigureAwait(false);
+
+        return competitionsResult;
+    }
+
+    public async Task<IEnumerable<CompetitiveEventViewCardDto>> GetPopularCompetitiveEventsFromDatabase(int limit, long catottgId)
+    {
+        var eventsQuery = competitiveEventRepository
+            .Get(whereExpression: e => !e.IsDeleted)
+            .Include(e => e.Contacts).ThenInclude(c => c.Address).ThenInclude(a => a.CATOTTG)
+            .Include(e => e.OrganizerOfTheEvent)
+            .AsQueryable();
+
+        if (catottgId > 0)
+        {
+            eventsQuery = eventsQuery.Where(e =>
+                e.Contacts.Any(c => c.IsDefault &&
+                    (c.Address.CATOTTGId == catottgId ||
+                     (c.Address.CATOTTG.Category == CodeficatorCategory.CityDistrict.Name &&
+                      c.Address.CATOTTG.ParentId == catottgId))));
+        }
+
+        var popularEvents = await eventsQuery
+            .OrderBy(e => e.ScheduledStartTime)
+            .Take(limit)
+            .AsNoTracking().ToListAsync();
+
+        logger.LogInformation($"{popularEvents.Count} competitive events were successfully received from DB");
+
+        return popularEvents.ToViewCardDto();
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatisticServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/StatisticServiceTest.cs
@@ -29,6 +29,7 @@ public class StatisticServiceTest
 
     private Mock<IApplicationRepository> applicationRepository;
     private Mock<IWorkshopRepository> workshopRepository;
+    private Mock<ICompetitiveEventRepository> competitiveEventRepository;
     private Mock<IEntityRepositorySoftDeleted<long, Direction>> directionRepository;
     private Mock<ICacheService> cache;
     private Mock<IAverageRatingService> averageRatingServiceMock;
@@ -38,6 +39,7 @@ public class StatisticServiceTest
     {
         applicationRepository = new Mock<IApplicationRepository>();
         workshopRepository = new Mock<IWorkshopRepository>();
+        competitiveEventRepository = new Mock<ICompetitiveEventRepository>();
         directionRepository = new Mock<IEntityRepositorySoftDeleted<long, Direction>>();
         var logger = new Mock<ILogger<StatisticService>>();
         cache = new Mock<ICacheService>();
@@ -46,6 +48,7 @@ public class StatisticServiceTest
         service = new StatisticService(
             applicationRepository.Object,
             workshopRepository.Object,
+            competitiveEventRepository.Object,
             directionRepository.Object,
             logger.Object,
             cache.Object,

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CompetitiveEventController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CompetitiveEventController.cs
@@ -30,6 +30,7 @@ public class CompetitiveEventController : ControllerBase
     /// </summary>
     /// <param name="id">CompetitiveEvent id.</param>
     /// <returns>CompetitiveEvent.</returns>
+    [AllowAnonymous]
     [HasPermission(Permissions.CompetitiveEventRead)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CompetitiveEventDto))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CompetitiveEventController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CompetitiveEventController.cs
@@ -31,7 +31,6 @@ public class CompetitiveEventController : ControllerBase
     /// <param name="id">CompetitiveEvent id.</param>
     /// <returns>CompetitiveEvent.</returns>
     [AllowAnonymous]
-    [HasPermission(Permissions.CompetitiveEventRead)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CompetitiveEventDto))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/StatisticController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/StatisticController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.BusinessLogic.Models;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 
 namespace OutOfSchool.WebApi.Controllers.V1;
@@ -78,6 +79,35 @@ public class StatisticController : ControllerBase
 
         return Ok(popularWorkshops);
     }
+
+    /// <summary>
+    /// Get popular competitive events.
+    /// </summary>
+    /// <param name="limit">The number of entries.</param>
+    /// <param name="catottgId">Codeficator's id.</param>
+    /// <returns>List of popular competitve events.</returns>
+    [HttpGet("competitions")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<CompetitiveEventViewCardDto>))]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ResponseCache(CacheProfileName = Constants.CacheProfilePublic)]
+    [AllowAnonymous]
+    public async Task<IActionResult> GetCompetitiveEvents(int limit, [FromQuery] long catottgId)
+    {
+        int newLimit = ValidateNumberOfEntries(limit);
+
+        var popularCompetitions = await service
+            .GetPopularCompetitiveEvents(newLimit, catottgId) //
+            .ConfigureAwait(false);
+
+        if (!popularCompetitions.Any())
+        {
+            return NoContent();
+        }
+
+        return Ok(popularCompetitions);
+    }
+
 
     private static int ValidateNumberOfEntries(int limit)
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added methods to retrieve popular competitive events from cache and database.
  - Introduced a new API endpoint to fetch a list of competitive events with filtering and result limits.
  - Made the `GetById` endpoint accessible anonymously in the competitive event controller.
- **Tests**
  - Updated test setup to support future testing of competitive event retrieval features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->