### PR TITLE
Remove hard requirement for language filter to be present

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopFilter.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopFilter.cs
@@ -57,7 +57,6 @@ public class WorkshopFilter : OffsetFilter
 
     public bool IsStrictWorkdays { get; set; } = false;
 
-    [Range(1,long.MaxValue, ErrorMessage = "LanguageId value must be a possitive number and greater than 0")]
     public long LanguageOfEducationId { get; set; }
 
     public long CATOTTGId { get; set; } = default;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the restriction requiring the Language of Education selection to be a positive number greater than zero when filtering workshops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->