### PR TITLE
Fix: EnumCollectionModelBinder returns null for empty values instead of empty HashSet

### DIFF
--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/EnumCollectionModelBinderTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/EnumCollectionModelBinderTests.cs
@@ -52,7 +52,7 @@ public class EnumCollectionModelBinderTests
     }
 
     [Test]
-    public async Task BindModelAsync_WithEmptyValues_ReturnsEmptyHashSet()
+    public async Task BindModelAsync_WithEmptyValues_ReturnsNull()
     {
         // Arrange
         _valueProvider.SetValue("testParam", StringValues.Empty);
@@ -62,9 +62,7 @@ public class EnumCollectionModelBinderTests
 
         // Assert
         Assert.That(_bindingContext.Result.IsModelSet, Is.True);
-        var result = _bindingContext.Result.Model as HashSet<TestEnum>;
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.Count, Is.EqualTo(0));
+        Assert.That(_bindingContext.Result.Model, Is.Null);
         Assert.That(_modelState.IsValid, Is.True);
     }
 
@@ -256,6 +254,36 @@ public class EnumCollectionModelBinderTests
         Assert.That(result.Count, Is.EqualTo(0)); // 0 is not defined in TestEnum
         Assert.That(_modelState.IsValid, Is.False);
         Assert.That(_modelState.ContainsKey("testParam"), Is.True);
+    }
+
+    [Test]
+    public async Task BindModelAsync_WithNoValues_ReturnsNull()
+    {
+        // Act
+        await _modelBinder.BindModelAsync(_bindingContext);
+
+        // Assert
+        Assert.That(_bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(_bindingContext.Result.Model, Is.Null);
+        Assert.That(_modelState.IsValid, Is.True);
+    }
+
+
+    [Test]
+    public async Task BindModelAsync_WithOnlyWhitespaceValues_ReturnsEmptyHashSet()
+    {
+        // Arrange
+        _valueProvider.SetValue("testParam", new StringValues(["", "   ", null]));
+
+        // Act
+        await _modelBinder.BindModelAsync(_bindingContext);
+
+        // Assert
+        Assert.That(_bindingContext.Result.IsModelSet, Is.True);
+        var result = _bindingContext.Result.Model as HashSet<TestEnum>;
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Count, Is.EqualTo(0));
+        Assert.That(_modelState.IsValid, Is.True);
     }
 
     // Helper class for testing

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/EnumCollectionModelBinder.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/EnumCollectionModelBinder.cs
@@ -14,9 +14,9 @@ public class EnumCollectionModelBinder<T> : IModelBinder where T : struct, Enum
 
         var values = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
 
-        if (values == StringValues.Empty)
+        if (values == ValueProviderResult.None || values == StringValues.Empty)
         {
-            bindingContext.Result = ModelBindingResult.Success(new HashSet<T>());
+            bindingContext.Result = ModelBindingResult.Success(null);
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
## Problem
The `GetWorkshopDraftsByFilter` endpoint was returning **204 No Content** instead of the expected workshop drafts when no `WorkshopDraftStatus` filter parameters were provided in the request.

**Root Cause:** The new `EnumCollectionModelBinder<T>` was creating an empty `HashSet<WorkshopDraftStatus>()` when no enum values were passed, preventing the model's default value logic from working correctly.

## Solution
Modified `EnumCollectionModelBinder<T>` to return `null` instead of an empty `HashSet` when:
- No query parameter is provided (`ValueProviderResult.None`)
- Empty query parameter is provided (`StringValues.Empty`)

This allows the model property getter to return default values correctly:
```csharp
public HashSet<WorkshopDraftStatus> WorkshopDraftStatuses
{
    get => workshopDraftStatuses ?? GetDefaultStatuses(); // Now works correctly
    set => workshopDraftStatuses = value;
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty or missing input values in model binding, ensuring that no values result in a null collection, while whitespace-only values result in an empty collection.

- **Tests**
  - Updated and added tests to verify correct behavior for empty, missing, and whitespace-only input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->