### PR TITLE
Hotfix - moved LanguageOfEducationId property from WorkshopRequiredPropertiesDto to WorkshopMainRequiredPropertiesDto

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/TempSave/WorkshopMainRequiredPropertiesDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/TempSave/WorkshopMainRequiredPropertiesDto.cs
@@ -62,6 +62,10 @@ public class WorkshopMainRequiredPropertiesDto : IValidatableObject
     [Required]
     public Guid ProviderId { get; set; }
 
+    [Required(ErrorMessage = "Language of education is required")]
+    [Range(1, long.MaxValue, ErrorMessage = "LanguageOfEducationId must be a positive number")]
+    public long LanguageOfEducationId { get; set; }
+
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         // TODO: Validate DateTimeRanges are not empty when frontend is ready

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/TempSave/WorkshopRequiredPropertiesDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/TempSave/WorkshopRequiredPropertiesDto.cs
@@ -21,11 +21,6 @@ public class WorkshopRequiredPropertiesDto : WorkshopMainRequiredPropertiesDto
     [EnumDataType(typeof(EducationalShift), ErrorMessage = Constants.EnumErrorMessage)]
     public EducationalShift EducationalShift { get; set; } = EducationalShift.First;
 
-    [Required(ErrorMessage = "Language of education is required")]
-    [Range(1, long.MaxValue, ErrorMessage = "LanguageOfEducationId must be a positive number")]
-    public long LanguageOfEducationId { get; set; }
-
-
     [Required(ErrorMessage = "Type of age composition is required")]
     [EnumDataType(typeof(AgeComposition), ErrorMessage = Constants.EnumErrorMessage)]
     public AgeComposition AgeComposition { get; set; } = AgeComposition.SameAge;


### PR DESCRIPTION
Hotfix - moved LanguageOfEducationId property from WorkshopRequiredPropertiesDto to WorkshopMainRequiredPropertiesDto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a required field for selecting the language of education when saving main workshop details.

- **Refactor**
  - The language of education selection is now required only in the main workshop details form, and no longer appears in other workshop forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->