### PR TITLE
feature(champion path): add support  of "Шлях чемпіонів" (ChampionPath)  for Workshop

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/TempSave/WorkshopDescriptionDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/TempSave/WorkshopDescriptionDto.cs
@@ -16,6 +16,8 @@ public class WorkshopDescriptionDto : WorkshopRequiredPropertiesDto
 
     public Guid? InstitutionHierarchyId { get; set; }
 
+    public bool IsChampionPath { get; set; } = false;
+
     public List<long> DirectionIds { get; set; }
 
     [ModelBinder(BinderType = typeof(JsonModelBinder))]

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -117,6 +117,8 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
 
     public bool AreThereBenefits { get; set; } = default;
 
+    public bool IsChampionPath { get; set; } = false;
+
     [MaxLength(500)]
     public string PreferentialTermsOfParticipation { get; set; }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateRequestDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateRequestDto.cs
@@ -11,7 +11,8 @@ public class WorkshopCreateRequestDto : WorkshopContactsDto
 
     [ModelBinder(BinderType = typeof(JsonModelBinder))]
     public List<TeacherDTO> Teachers { get; set; }
-
+    
+    public bool IsChampionPath {get; set; }
     public Guid? DefaultTeacherId { get; set; }
 }
 
@@ -51,5 +52,6 @@ public static class WorkshopCreateRequestDtoExtensions
             DefaultTeacherId = dto.DefaultTeacherId,
 
             LanguageOfEducationId = dto.LanguageOfEducationId,
+            IsChampionPath = dto.IsChampionPath,
         };
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateRequestDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateRequestDto.cs
@@ -41,7 +41,6 @@ public static class WorkshopCreateRequestDtoExtensions
             PreferentialTermsOfParticipation = dto.PreferentialTermsOfParticipation,
             StudyPeriodStartDate = dto.StudyPeriodDates.StartDate.ToStudyPeriodDate(),
             StudyPeriodEndDate = dto.StudyPeriodDates.EndDate.ToStudyPeriodDate(),
-
             WorkshopDescriptionItems = dto.WorkshopDescriptionItems?.ToModel(),
             InstitutionHierarchyId = dto.InstitutionHierarchyId,
             Keywords = string.Join(Constants.MappingSeparator, dto.Keywords?.Distinct() ?? []),

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateUpdateDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateUpdateDto.cs
@@ -52,6 +52,7 @@ public static class WorkshopCreateUpdateDtoExtensions
         model.WorkshopType = dto.WorkshopType;
         model.DefaultTeacherId = dto.DefaultTeacherId;
         model.ParentWorkshopId = dto.ParentWorkshopId;
+        model.IsChampionPath = dto.IsChampionPath;
 
         return model;
     }
@@ -94,5 +95,6 @@ public static class WorkshopCreateUpdateDtoExtensions
             WorkshopType = dto.WorkshopType,
             DefaultTeacherId = dto.DefaultTeacherId,
             ParentWorkshopId = dto.ParentWorkshopId,
+            IsChampionPath =  dto.IsChampionPath,
         };
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopDto.cs
@@ -113,7 +113,8 @@ public static class WorkshopDtoExtensions
             StudyPeriodEndDay = dto.StudyPeriodDates.EndDate.Day,
             StudyPeriodEndMonth = dto.StudyPeriodDates.EndDate.Month,
             LanguageOfEducationId = dto.LanguageOfEducationId,
-            LanguageOfEducationName = dto.LanguageOfEducationName
+            LanguageOfEducationName = dto.LanguageOfEducationName,
+            IsChampionPath =  dto.IsChampionPath,
         };
     }
 
@@ -186,6 +187,7 @@ public static class WorkshopDtoExtensions
             Facebook = defaultContact?.SocialNetworks?.FirstOrDefault(s => s.Type == SocialNetworkContactType.Facebook)?.Url,
             Instagram = defaultContact?.SocialNetworks?.FirstOrDefault(s => s.Type == SocialNetworkContactType.Instagram)?.Url,
             Address = defaultContact?.Address?.ToDto(),
+            IsChampionPath = model.IsChampionPath,
         };
     }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2CreateRequestDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2CreateRequestDto.cs
@@ -58,7 +58,8 @@ public static class WorkshopV2CreateRequestDtoExtensions
             
             AvailableSeats = dto.AvailableSeats ?? default,
             Contacts = dto.Contacts?.ToModel() ?? [],
-            LanguageOfEducationId = dto.LanguageOfEducationId,            
+            LanguageOfEducationId = dto.LanguageOfEducationId,
+            IsChampionPath = dto.IsChampionPath,
         };
 
     public static WorkshopV2CreateRequestDto ToV2CreateRequestDto(this OutOfSchool.Services.Models.WorkshopDrafts.WorkshopDraft draft)
@@ -103,5 +104,6 @@ public static class WorkshopV2CreateRequestDtoExtensions
             Teachers = draft.Teachers?.Where(x => !x.IsDefaultTeacher).ToDto() ?? [],
 
             CoverImageId = draft.CoverImageId,
+            IsChampionPath = draft.WorkshopDraftContent?.IsChampionPath ?? default,
         };
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
@@ -68,7 +68,7 @@ public static class WorkshopV2DtoExtensions
             Website = dto.Website,
             Facebook = dto.Facebook,
             Instagram = dto.Instagram,
-            
+            IsChampionPath = dto.IsChampionPath
         };
 
     public static void SetToDraft(this WorkshopV2Dto dto, OutOfSchool.Services.Models.WorkshopDrafts.WorkshopDraft model)
@@ -134,7 +134,8 @@ public static class WorkshopV2DtoExtensions
             WorkshopType = draft.WorkshopDraftContent?.WorkshopType ?? default,
             ParentWorkshopId = draft.WorkshopDraftContent?.ParentWorkshopId,
             Contacts = draft.WorkshopDraftContent?.Contacts?.ToDto() ?? [],
-            NoAgeRestrictions = draft.WorkshopDraftContent?.NoAgeRestrictions ?? default,
+            NoAgeRestrictions = draft.WorkshopDraftContent?.NoAgeRestrictions ?? false,
+            IsChampionPath = draft.WorkshopDraftContent?.IsChampionPath ?? false,
 
             CoverImageId = draft.CoverImageId,
             ImageIds = draft.Images?.Select(x => x.ExternalStorageId).ToList() ?? [],
@@ -192,7 +193,7 @@ public static class WorkshopV2DtoExtensions
         model.DefaultTeacherId = dto.DefaultTeacherId;
         model.ParentWorkshopId = dto.ParentWorkshopId;
         model.CoverImageId = dto.CoverImageId;
-
+        model.IsChampionPath = dto.IsChampionPath;
         return model;
     }
 
@@ -241,6 +242,7 @@ public static class WorkshopV2DtoExtensions
             EducationalShift = model.EducationalShift,
             LanguageOfEducationId = model.LanguageOfEducationId,
             LanguageOfEducationName = model.LanguageOfEducation?.Name,
+            IsChampionPath = model.IsChampionPath,
             StudyPeriodDates = model.ToStudyPeriodDatesDto(),
             AgeComposition = model.AgeComposition,
             Coverage = model.Coverage,
@@ -249,7 +251,6 @@ public static class WorkshopV2DtoExtensions
             ParentWorkshopId = model.ParentWorkshopId,
             ParentWorkshop = model.ParentWorkshop?.ToDto(),
             Contacts = model.Contacts?.ToDto() ?? [],
-
             TagIds = model.Tags?.Select(x => x.Id).ToList() ?? [],
 
             CoverImageId = model.CoverImageId,

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -41,9 +41,11 @@ namespace OutOfSchool.BusinessLogic.Services;
 /// <param name="codeficatorService">Srvice for CATOTTG.</param>
 /// <param name="searchStringService">Service for handling the search string.</param>
 /// <param name="tagService">Service for Tag entity.</param>
+/// <param name="institutionHierarchyService"> Service for institutionHierarchy entity.</param>
 public class WorkshopService(
     IWorkshopRepository workshopRepository,
     ILanguageService languageService,
+    IInstitutionHierarchyService institutionHierarchyService,
     IEntityRepository<long, Tag> tagRepository,
     IEntityRepositorySoftDeleted<long, DateTimeRange> dateTimeRangeRepository,
     IEntityRepositorySoftDeleted<Guid, ChatRoomWorkshop> roomRepository,
@@ -80,8 +82,14 @@ public class WorkshopService(
     {
         _ = dto ?? throw new ArgumentNullException(nameof(dto));
         logger.LogInformation("Workshop creating was started.");
-
+        
+        // Validate related entities
         await ValidateLanguageExists(dto.LanguageOfEducationId).ConfigureAwait(false);
+        
+        var (workshopType,isChampionPath) = await ValidateInstitutionHierarchy(dto.InstitutionHierarchyId,dto.WorkshopType);
+        dto.WorkshopType = workshopType;
+        dto.IsChampionPath = isChampionPath;
+        
         // TODO: after refactoring the DTOs for the Workshop entities, this method needs to be replaced with the correct mapping
         await SetIdsToDefaultValue(dto); // This method sets the dto properties with Id to the default value.
         var createdWorkshop = await CheckDtoAndPrepareCreatedWorkshop(dto);
@@ -109,7 +117,11 @@ public class WorkshopService(
         _ = dto ?? throw new ArgumentNullException(nameof(dto));
         logger.LogInformation("Workshop creating was started.");
         await ValidateLanguageExists(dto.LanguageOfEducationId).ConfigureAwait(false);
-
+        
+        var (workshopType,isChampionPath) = await ValidateInstitutionHierarchy(dto.InstitutionHierarchyId,dto.WorkshopType);
+        dto.WorkshopType = workshopType;
+        dto.IsChampionPath = isChampionPath;
+        
         // TODO: after refactoring the DTOs for the Workshop entities, this method needs to be replaced with the correct mapping
         await SetIdsToDefaultValue(dto); // This method sets the properties with the Id to the default value.
         var createdWorkshop = await CheckDtoAndPrepareCreatedWorkshop(dto);
@@ -340,6 +352,12 @@ public class WorkshopService(
         _ = dto ?? throw new ArgumentNullException(nameof(dto));
         logger.LogInformation($"Updating Workshop with Id = {dto?.Id} started.");
         await ValidateLanguageExists(dto.LanguageOfEducationId).ConfigureAwait(false);
+        
+        var (workshopType,isChampionPath) = await ValidateInstitutionHierarchy(dto.InstitutionHierarchyId,dto.WorkshopType);
+        dto.WorkshopType = workshopType;
+        dto.IsChampionPath = isChampionPath;
+        
+      //  await ValidateInstitutionHierarchy(dto).ConfigureAwait(false);   
         async Task<Workshop> UpdateWorkshopLocally()
         {
             await UpdateDateTimeRanges(dto.DateTimeRanges, dto.Id).ConfigureAwait(false);
@@ -455,7 +473,11 @@ public class WorkshopService(
         _ = dto ?? throw new ArgumentNullException(nameof(dto));
         logger.LogInformation($"Updating {nameof(Workshop)} with Id = {dto.Id} started.");
         await ValidateLanguageExists(dto.LanguageOfEducationId).ConfigureAwait(false);
-
+        
+        var (workshopType,isChampionPath) = await ValidateInstitutionHierarchy(dto.InstitutionHierarchyId,dto.WorkshopType);
+        dto.WorkshopType = workshopType;
+        dto.IsChampionPath = isChampionPath;
+        
         async Task<(Workshop updatedWorkshop, MultipleImageChangingResult multipleImageChangingResult,
             ImageChangingResult changingCoverImageResult)> UpdateWorkshopWithDependencies()
         {
@@ -1316,6 +1338,36 @@ public class WorkshopService(
             logger.LogWarning(errorMessage);
             throw new InvalidOperationException(errorMessage);
         }
+    }
+    
+    /// <summary>
+    /// Validates the workshop's institution hierarchy and adjusts the workshop type and champion path flag accordingly.
+    /// This method is designed to be **universal** and can be used for both creating and updating workshops across different versions:
+    /// - It works seamlessly in `CreateV1`, `CreateV2`, `UpdateV1`, and `UpdateV2` methods, ensuring that the `workshopType` is correctly validated and the `isChampionPath` flag is set based on the institution hierarchy.
+    /// The function ensures that:
+    /// - If the institution hierarchy corresponds to "Мінспорт" (Ministry of Sport), it sets the `WorkshopType` to "Section" and `isChampionPath` to `true`.
+    /// - If the institution is not "Мінспорт", it sets `isChampionPath` to `false`, as per business logic.
+    /// This allows consistent validation across multiple parts of the system, reducing code duplication and improving maintainability.
+    /// The method returns a tuple containing the updated `workshopType` and `isChampionPath`.
+    /// </summary>
+    private async Task<(WorkshopType workshopType, bool isChampionPath)> ValidateInstitutionHierarchy(Guid? institutionHierarchyId, WorkshopType workshopType)
+    {
+        if (institutionHierarchyId == null)
+        {
+            throw new InvalidOperationException("InstitutionHierarchyId cannot be null.");
+        }
+
+        // Get information about the institution hierarchy
+        var institutionHierarchyDto = await institutionHierarchyService.GetById(institutionHierarchyId.Value).ConfigureAwait(false);
+
+        // If the institution is "Мінспорт", set workshopType and isChampionPath; otherwise, use default values
+        var isChampionPath = institutionHierarchyDto.Institution.Title.Equals("Мінспорт", StringComparison.OrdinalIgnoreCase);
+        if (isChampionPath)
+        {
+            workshopType = WorkshopType.Section;
+        }
+
+        return (workshopType, isChampionPath);
     }
 
     private async Task SetIdsToDefaultValue(WorkshopCreateRequestDto dto)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq.Expressions;
 using H3Lib;
 using H3Lib.Extensions;
+using Microsoft.Extensions.Options;
 using OutOfSchool.BusinessLogic.Common;
 using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Models;
@@ -63,7 +64,8 @@ public class WorkshopService(
     IContactsService<Workshop, IHasContactsDto<Workshop>> contactsService,
     IApplicationRepository applicationRepository,
     IFeatureManager featureManager,
-    IChangesLogService changesLogService
+    IChangesLogService changesLogService,
+    IOptions<InstitutionOptions> institutionOptions
 ) : IWorkshopService, ISensitiveWorkshopsService
 {
     /// <summary>
@@ -1361,12 +1363,11 @@ public class WorkshopService(
         var institutionHierarchyDto = await institutionHierarchyService.GetById(institutionHierarchyId.Value).ConfigureAwait(false);
 
         // If the institution is "Мінспорт", set workshopType and isChampionPath; otherwise, use default values
-        var isChampionPath = institutionHierarchyDto.Institution.Title.Equals("Мінспорт", StringComparison.OrdinalIgnoreCase);
+        var isChampionPath = institutionHierarchyDto.Institution.Title.Equals(institutionOptions.Value.MinistryOfSportTitle, StringComparison.OrdinalIgnoreCase);
         if (isChampionPath)
         {
             workshopType = WorkshopType.Section;
         }
-
         return (workshopType, isChampionPath);
     }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -107,7 +107,7 @@ public class WorkshopService(
 
         return workshopDtos;
     }
-
+    
     /// <inheritdoc/>
     /// <exception cref="ArgumentNullException">If <see cref="WorkshopDto"/> is null.</exception>
     /// <exception cref="InvalidOperationException">If unreal to map teachers.</exception>

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -12,6 +12,7 @@ using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.BusinessLogic.Services.ProviderServices;
 using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Enums.Workshop;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Enums.WorkshopStatus;
 using OutOfSchool.Services.Models.Images;
@@ -109,7 +110,8 @@ public class WorkshopDraftService(
             }
         }
         await SetLanguageNameOrThrow(workshopV2Dto).ConfigureAwait(false);
-
+        await ValidateAndAdjustInstitutionHierarchyAsync(workshopV2Dto).ConfigureAwait(false);
+        
         // Executes the creation of a workshop draft along with its associated teachers within a database transaction.
         // The result is the created draft with all its related teachers.
         var createdDraftWithAssociatedTeachers = await workshopDraftRepository
@@ -231,6 +233,8 @@ public class WorkshopDraftService(
                 throw new ArgumentException("This WorkshopDraft can`t be updated.");
             }
             await SetLanguageNameOrThrow(workshopDraftUpdateDto.WorkshopV2Dto).ConfigureAwait(false);
+            await ValidateAndAdjustInstitutionHierarchyAsync(workshopDraftUpdateDto.WorkshopV2Dto).ConfigureAwait(false);
+            
             workshopDraftUpdateDto.WorkshopV2Dto.SetToDraft(workshopDraft);
 
             var coverImageResult = await workshopDraftImagesService.ChangeCoverImageAsync(
@@ -819,7 +823,6 @@ public class WorkshopDraftService(
         var workshopDraft = workshopV2Dto.ToDraft();
 
         var licenseStatusAndOwnership = await providerService.GetLicenseStatusAndOwnershipAsync(workshopV2Dto.ProviderId);
-
         workshopDraft.WorkshopDraftContent.ProviderLicenseStatus = licenseStatusAndOwnership.Item1;
         workshopDraft.WorkshopDraftContent.OwnershipType = licenseStatusAndOwnership.Item2;
         workshopDraft.WorkshopDraftContent.WorkshopStatus = WorkshopStatus.Open;
@@ -1189,6 +1192,34 @@ public class WorkshopDraftService(
             throw new InvalidOperationException(errorMessage);
         }
         dto.LanguageOfEducationName = language.Name;
+    }
+    
+    /// <summary>
+    /// Validates and updates the InstitutionHierarchy-related properties in the provided DTO:
+    /// - Sets WorkshopType to Section and IsChampionPath to true if institution is "Мінспорт".
+    /// </summary>
+    private async Task ValidateAndAdjustInstitutionHierarchyAsync(WorkshopV2Dto dto)
+    {
+        if (dto.InstitutionHierarchyId == null)
+        {
+            throw new InvalidOperationException("InstitutionHierarchyId cannot be null.");
+        }
+
+        var institutionHierarchy = await institutionHierarchyRepository
+            .GetById(dto.InstitutionHierarchyId.Value)
+            .ConfigureAwait(false);
+
+        if (institutionHierarchy == null)
+        {
+            throw new InvalidOperationException($"InstitutionHierarchy with ID = {dto.InstitutionHierarchyId} was not found.");
+        }
+
+        dto.IsChampionPath = institutionHierarchy.Institution.Title.Equals("Мінспорт", StringComparison.OrdinalIgnoreCase);
+
+        if (dto.IsChampionPath)
+        {
+            dto.WorkshopType = WorkshopType.Section;
+        }
     }
     /// <summary>
     /// Validates whether the specified moderator or tech admin is allowed to access and modify the given workshop draft.

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -63,7 +63,8 @@ public class WorkshopDraftService(
     ISearchStringService searchStringService,
     IInstitutionHierarchyRepository institutionHierarchyRepository,
     ICodeficatorRepository codeficatorRepository,
-    IChangesLogService changesLogService
+    IChangesLogService changesLogService,
+    IOptions<InstitutionOptions> institutionSettings
 ) : IWorkshopDraftService, ISensitiveWorkshopDraftService
 {
     private readonly int maxParallelUploads = options.Value.MaxParallelImageUploads;
@@ -1213,8 +1214,15 @@ public class WorkshopDraftService(
         {
             throw new InvalidOperationException($"InstitutionHierarchy with ID = {dto.InstitutionHierarchyId} was not found.");
         }
-
-        dto.IsChampionPath = institutionHierarchy.Institution.Title.Equals("Мінспорт", StringComparison.OrdinalIgnoreCase);
+        
+        if (institutionHierarchy.Institution == null)
+        {
+          throw new InvalidOperationException($"Institution not found for InstitutionHierarchy with ID = {dto.InstitutionHierarchyId}.");
+        }
+        
+        dto.IsChampionPath = institutionHierarchy.Institution.Title.Equals(
+            institutionSettings.Value.MinistryOfSportTitle,
+            StringComparison.OrdinalIgnoreCase);
 
         if (dto.IsChampionPath)
         {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -1028,18 +1028,16 @@ public class WorkshopDraftService(
 
     private async Task<List<long>> GetDirectionIdsForWorkshopDraft(WorkshopDraft workshopDraft)
     {
-        var institutionHierarchyId = workshopDraft.WorkshopDraftContent.InstitutionHierarchyId;
-
-        if (institutionHierarchyId == null)
+        if (workshopDraft?.WorkshopDraftContent?.InstitutionHierarchyId == null)
         {
             return null;
         }
-
+        
         var institutionHierarchyDto = await institutionHierarchyRepository.GetByIdWithDetails(
             id: (Guid)workshopDraft.WorkshopDraftContent.InstitutionHierarchyId,
             includeExpression: includeDirectionsFunc);
 
-        return institutionHierarchyDto.SubDirections.Select(d => d.DirectionId).ToList();
+        return institutionHierarchyDto?.SubDirections?.Select(d => d.DirectionId).ToList();
     }
 
     private async Task<List<long>> GetSubDirectionIdsForWorkshopDraft(WorkshopDraft workshopDraft)

--- a/OutOfSchool/OutOfSchool.Common/Config/InstitutionOptions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Config/InstitutionOptions.cs
@@ -1,0 +1,7 @@
+namespace OutOfSchool.Common.Config;
+
+public class InstitutionOptions
+{
+    public const string Name = "InstitutionOptions";
+    public string MinistryOfSportTitle { get; set; }
+}

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -110,6 +110,8 @@ public class Workshop : BusinessEntity, IImageDependentEntity<Workshop>, IHasEnt
 
     public Coverage Coverage { get; set; } = Coverage.School;
 
+    public bool IsChampionPath { get; set; } = false;
+
     [Required(ErrorMessage = "Provider is required")]
     public Guid ProviderId { get; set; }
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDrafts/WorkshopDraftContent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDrafts/WorkshopDraftContent.cs
@@ -109,4 +109,6 @@ public class WorkshopDraftContent :
     public string Facebook { get; set; }
 
     public string Instagram { get; set; }
+    
+    public bool IsChampionPath { get;set; }
 }

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/Models/WorkshopES.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/Models/WorkshopES.cs
@@ -109,4 +109,6 @@ namespace OutOfSchool.ElasticsearchData.Models;
     public Coverage Coverage { get; set; }
 
     public List<string> Tags { get; set; }
+
+    public bool IsChampionPath { get; set; } 
 }

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250702135745_AddIsChampionPath.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250702135745_AddIsChampionPath.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
@@ -11,9 +12,11 @@ using OutOfSchool.Services;
 namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250702135745_AddIsChampionPath")]
+    partial class AddIsChampionPath
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250702135745_AddIsChampionPath.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250702135745_AddIsChampionPath.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+{
+    /// <inheritdoc />
+    public partial class AddIsChampionPath : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsChampionPath",
+                table: "Workshops",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsChampionPath",
+                table: "Workshops");
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceDBTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceDBTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using Moq;
 using NUnit.Framework;
@@ -17,6 +18,7 @@ using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Services.Workshops;
+using OutOfSchool.Common.Config;
 using OutOfSchool.Services;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Models.ChatWorkshop;
@@ -51,8 +53,7 @@ public class SensitiveWorkshopsServiceDBTests
     private Mock<IApplicationRepository> applicationRepositoryMock;
     private Mock<IFeatureManager> featureManagerMock;
     private Mock<IChangesLogService> changesLogServiceMock;
-
-
+    private Mock<IOptions<InstitutionOptions>> institutionOptionsMock;
     [SetUp]
     public void SetUp()
     {
@@ -77,7 +78,7 @@ public class SensitiveWorkshopsServiceDBTests
         featureManagerMock = new Mock<IFeatureManager>();
         searchStringServiceMock = new Mock<ISearchStringService>();
         changesLogServiceMock = new Mock<IChangesLogService>();
-
+        institutionOptionsMock = new  Mock<IOptions<InstitutionOptions>>();
         sensitiveWorkshopService =
             new WorkshopService(
                 workshopRepository,
@@ -100,10 +101,14 @@ public class SensitiveWorkshopsServiceDBTests
                 contactsServiceMock.Object,
                 applicationRepositoryMock.Object,
                 featureManagerMock.Object,
-                changesLogServiceMock.Object);
+                changesLogServiceMock.Object,
+                institutionOptionsMock.Object);
 
         languageServiceMock.Setup(x => x.GetById(It.Is<long>(id => id == 1)))
                 .ReturnsAsync(new LanguageDto { Id = 1, Name = "English" });
+        institutionOptionsMock.Setup(x => x.Value)
+            .Returns(new InstitutionOptions { MinistryOfSportTitle = "Мінспорт" });
+        
         MockInstitutionHierarchy();
         dbContext.Database.EnsureDeleted();
         dbContext.Database.EnsureCreated();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceDBTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceDBTests.cs
@@ -9,11 +9,13 @@ using Microsoft.FeatureManagement;
 using Moq;
 using NUnit.Framework;
 using OutOfSchool.BusinessLogic.Models;
+using OutOfSchool.BusinessLogic.Models.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.BusinessLogic.Services;
 using OutOfSchool.BusinessLogic.Services.AverageRatings;
 using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
+using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Services.Workshops;
 using OutOfSchool.Services;
 using OutOfSchool.Services.Models;
@@ -37,6 +39,7 @@ public class SensitiveWorkshopsServiceDBTests
     private ISensitiveWorkshopsService sensitiveWorkshopService;
     private IWorkshopRepository workshopRepository;
     private Mock<ICodeficatorService> codeficatorServiceMock;
+    private Mock<IInstitutionHierarchyService>  institutionHierarchyServiceMock;
     private Mock<IMinistryAdminService> ministryAdminServiceMock;
     private Mock<ICurrentUserService> currentUserServiceMock;
     private Mock<IRegionAdminService> regionAdminServiceMock;
@@ -61,7 +64,7 @@ public class SensitiveWorkshopsServiceDBTests
         dbContext = new TestOutOfSchoolDbContext(dbContextOptions);
 
         workshopRepository = new WorkshopRepository(dbContext);
-        
+        institutionHierarchyServiceMock = new Mock<IInstitutionHierarchyService>();
         codeficatorServiceMock = new Mock<ICodeficatorService>();
         languageServiceMock = new Mock<ILanguageService>();
         ministryAdminServiceMock = new Mock<IMinistryAdminService>();
@@ -79,6 +82,7 @@ public class SensitiveWorkshopsServiceDBTests
             new WorkshopService(
                 workshopRepository,
                 languageServiceMock.Object,
+                institutionHierarchyServiceMock.Object,
                 tagRepository.Object,
                 new Mock<IEntityRepositorySoftDeleted<long, DateTimeRange>>().Object,
                 new Mock<IEntityRepositorySoftDeleted<Guid, ChatRoomWorkshop>>().Object,
@@ -100,7 +104,7 @@ public class SensitiveWorkshopsServiceDBTests
 
         languageServiceMock.Setup(x => x.GetById(It.Is<long>(id => id == 1)))
                 .ReturnsAsync(new LanguageDto { Id = 1, Name = "English" });
-
+        MockInstitutionHierarchy();
         dbContext.Database.EnsureDeleted();
         dbContext.Database.EnsureCreated();
     }
@@ -482,6 +486,14 @@ public class SensitiveWorkshopsServiceDBTests
         };
     }
 
+    private void MockInstitutionHierarchy()
+    {
+        institutionHierarchyServiceMock.Setup(s => s.GetById(It.IsAny<Guid>()))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Мінспорт"}
+            });
+    }
     private async Task<List<WorkshopDto>> MapWorkshopsToDtos()
     {
         var workshops = await SeedWorkshops();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceTests.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using Moq;
 using NUnit.Framework;
@@ -16,6 +17,7 @@ using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Services.Workshops;
+using OutOfSchool.Common.Config;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Models.ChatWorkshop;
@@ -48,6 +50,7 @@ public class SensitiveWorkshopsServiceTests
     private Mock<IApplicationRepository> applicationRepositoryMock;
     private Mock<IFeatureManager> featureManagerMock;
     private Mock<IChangesLogService> changesLogServiceMock;
+    private Mock<IOptions<InstitutionOptions>> institutionOptionsMock;
 
 
     [SetUp]
@@ -67,7 +70,7 @@ public class SensitiveWorkshopsServiceTests
         applicationRepositoryMock = new Mock<IApplicationRepository>();
         featureManagerMock = new Mock<IFeatureManager>();
         changesLogServiceMock = new Mock<IChangesLogService>();
-
+        institutionOptionsMock = new Mock<IOptions<InstitutionOptions>>();
         sensitiveWorkshopService =
             new WorkshopService(
                 workshopRepository.Object,
@@ -90,10 +93,13 @@ public class SensitiveWorkshopsServiceTests
                 contactsServiceMock.Object,
                 applicationRepositoryMock.Object,
                 featureManagerMock.Object,
-                changesLogServiceMock.Object);
+                changesLogServiceMock.Object,
+                institutionOptionsMock.Object);
 
         languageServiceMock.Setup(x => x.GetById(It.IsAny<long>()))
             .ReturnsAsync(new LanguageDto { Id = 1, Name = "English" });
+        institutionOptionsMock.Setup(x => x.Value)
+            .Returns(new InstitutionOptions { MinistryOfSportTitle = "Мінспорт" });
     }
 
     #region FetchByFilterForAdmins

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/SensitiveWorkshopsServiceTests.cs
@@ -14,6 +14,7 @@ using OutOfSchool.BusinessLogic.Services;
 using OutOfSchool.BusinessLogic.Services.AverageRatings;
 using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
+using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Services.Workshops;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Models;
@@ -31,10 +32,11 @@ public class SensitiveWorkshopsServiceTests
     private readonly string includingPropertiesForMappingDtoModel =
         $"{nameof(Workshop.Teachers)},{nameof(Workshop.DateTimeRanges)},"
         + $"{nameof(Workshop.InstitutionHierarchy)},Contacts.Address.CATOTTG";
-
+    
     private ISensitiveWorkshopsService sensitiveWorkshopService;
     private Mock<IWorkshopRepository> workshopRepository;
     private Mock<IMinistryAdminService> ministryAdminServiceMock;
+    private Mock <IInstitutionHierarchyService> institutionHierarchyServiceMock;
     private Mock<IRegionAdminService> regionAdminServiceMock;
     private Mock<ICodeficatorService> codeficatorServiceMock;
     private Mock<ICurrentUserService> currentUserServiceMock;
@@ -52,6 +54,7 @@ public class SensitiveWorkshopsServiceTests
     public void SetUp()
     {
         workshopRepository = new Mock<IWorkshopRepository>();
+        institutionHierarchyServiceMock =  new Mock<IInstitutionHierarchyService>();
         currentUserServiceMock = new Mock<ICurrentUserService>();
         ministryAdminServiceMock = new Mock<IMinistryAdminService>();
         regionAdminServiceMock = new Mock<IRegionAdminService>();
@@ -69,6 +72,7 @@ public class SensitiveWorkshopsServiceTests
             new WorkshopService(
                 workshopRepository.Object,
                 languageServiceMock.Object,
+                institutionHierarchyServiceMock.Object,
                 tagRepository.Object,
                 new Mock<IEntityRepositorySoftDeleted<long, DateTimeRange>>().Object,
                 new Mock<IEntityRepositorySoftDeleted<Guid, ChatRoomWorkshop>>().Object,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceDBTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceDBTests.cs
@@ -12,6 +12,7 @@ using OutOfSchool.BusinessLogic.Services;
 using OutOfSchool.BusinessLogic.Services.AverageRatings;
 using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
+using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Services;
 using OutOfSchool.Services.Models;
@@ -29,9 +30,9 @@ public class WorkshopServiceDBTests
 {
     private DbContextOptions<OutOfSchoolDbContext> dbContextOptions;
     private TestOutOfSchoolDbContext dbContext;
-
     private IWorkshopService workshopService;
     private IWorkshopRepository workshopRepository;
+    private Mock <IInstitutionHierarchyService> institutionHierarchyService;
     private Mock<IEntityRepositorySoftDeleted<long, DateTimeRange>> dateTimeRangeRepository;
     private Mock<IEntityRepositorySoftDeleted<Guid, ChatRoomWorkshop>> roomRepository;
     private Mock<ITeacherService> teacherService;
@@ -76,6 +77,7 @@ public class WorkshopServiceDBTests
         ministryAdminServiceMock = new Mock<IMinistryAdminService>();
         regionAdminServiceMock = new Mock<IRegionAdminService>();
         codeficatorServiceMock = new Mock<ICodeficatorService>();
+        institutionHierarchyService = new Mock<IInstitutionHierarchyService>();
         tagServiceMock = new Mock<ITagService>();
         var searchStringServiceMock = new Mock<ISearchStringService>();
         tagRepository = new Mock<IEntityRepository<long, Tag>>();
@@ -88,6 +90,7 @@ public class WorkshopServiceDBTests
                 new WorkshopService(
                     workshopRepository,
                     languageServiceMock.Object,
+                    institutionHierarchyService.Object,
                     tagRepository.Object,
                     dateTimeRangeRepository.Object,
                     roomRepository.Object,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceDBTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceDBTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using Moq;
 using NUnit.Framework;
@@ -13,6 +14,7 @@ using OutOfSchool.BusinessLogic.Services.AverageRatings;
 using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
+using OutOfSchool.Common.Config;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Services;
 using OutOfSchool.Services.Models;
@@ -51,6 +53,7 @@ public class WorkshopServiceDBTests
     private Mock<IApplicationRepository> applicationRepositoryMock;
     private Mock<IFeatureManager> featureManagerMock;
     private Mock<IChangesLogService> changesLogServiceMock;
+    private Mock<IOptions<InstitutionOptions>> institutionOptionsMock;
 
 
     [SetUp]
@@ -85,6 +88,7 @@ public class WorkshopServiceDBTests
         applicationRepositoryMock = new Mock<IApplicationRepository>();
         featureManagerMock = new Mock<IFeatureManager>();
         changesLogServiceMock = new Mock<IChangesLogService>();
+        institutionOptionsMock = new Mock<IOptions<InstitutionOptions>>();
 
         workshopService =
                 new WorkshopService(
@@ -108,11 +112,14 @@ public class WorkshopServiceDBTests
                     contactsServiceMock.Object,
                     applicationRepositoryMock.Object,
                     featureManagerMock.Object,
-                    changesLogServiceMock.Object);
+                    changesLogServiceMock.Object,
+                    institutionOptionsMock.Object);
 
         Seed();
         languageServiceMock.Setup(x => x.GetById(It.IsAny<long>()))
                 .ReturnsAsync(new LanguageDto { Id = 1, Name = "English" });
+        institutionOptionsMock.Setup(x => x.Value)
+            .Returns(new InstitutionOptions { MinistryOfSportTitle = "Мінспорт" });
     }
 
     [TearDown]

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using MockQueryable.Moq;
 using Moq;
@@ -24,6 +25,7 @@ using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Services.Workshops;
+using OutOfSchool.Common.Config;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Enums.Workshop;
 using OutOfSchool.Services.Enums;
@@ -63,6 +65,7 @@ public class WorkshopServiceTests
     private Mock<IApplicationRepository> applicationRepository;
     private Mock<IFeatureManager> featureManager;
     private Mock<IChangesLogService> changesLogService;
+    private Mock<IOptions<InstitutionOptions>> institutionOptionsMock;
     private Guid providerId;
     private Guid studySubjectId;
 
@@ -92,6 +95,7 @@ public class WorkshopServiceTests
         applicationRepository = new Mock<IApplicationRepository>();
         featureManager = new Mock<IFeatureManager>();
         changesLogService = new Mock<IChangesLogService>();
+        institutionOptionsMock = new Mock<IOptions<InstitutionOptions>>();
         providerId = Guid.NewGuid();
         studySubjectId = Guid.NewGuid();
 
@@ -117,10 +121,13 @@ public class WorkshopServiceTests
                     contactsServiceMock.Object,
                     applicationRepository.Object,
                     featureManager.Object,
-                    changesLogService.Object
+                    changesLogService.Object,
+                    institutionOptionsMock.Object
                     );
         languageServiceMock.Setup(s => s.GetById(It.IsAny<long>()))
             .ReturnsAsync((long id) => new LanguageDto { Id = id, Name = "English" });
+        institutionOptionsMock.Setup(x => x.Value)
+            .Returns(new InstitutionOptions { MinistryOfSportTitle = "Мінспорт" });
     }
 
     #region Create

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -273,6 +273,65 @@ public class WorkshopServiceTests
         await workshopService.Invoking(w => w.Create(WorkshopCreateRequestDtoGenerator.FromModel(createdEntity)))
             .Should().ThrowAsync<InvalidOperationException>();
     }
+    
+    [Test]
+    public async Task Create_WhenInstitutionTitleIsMinSport_ShouldSetWorkshopTypeToSectionAndIsChampionPathTrue()
+    {
+        // Arrange
+        var createdEntity = WorkshopGenerator.Generate().WithProvider();
+        createdEntity.InstitutionHierarchyId = Guid.NewGuid();
+        createdEntity.WorkshopType = WorkshopType.Studio;
+
+        SetupCreate(createdEntity);
+
+        institutionHierarchyServiceMock.Setup(s => s.GetById(createdEntity.InstitutionHierarchyId.Value))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Мінспорт" }
+            });
+        featureManager.Setup(f => f.IsEnabledAsync("EnableWorkshopGroupTypeField")).ReturnsAsync(true);
+        var dto = WorkshopCreateRequestDtoGenerator.FromModel(createdEntity);
+        workshopRepository.Setup(w => w.Create(It.IsAny<Workshop>()))
+            .ReturnsAsync((Workshop w) => w); 
+        // Act
+        var result = await workshopService.Create(dto).ConfigureAwait(false);
+
+        // Assert
+        result.WorkshopType.Should().Be(WorkshopType.Section);
+        result.IsChampionPath.Should().BeTrue();
+    }
+    
+    [Test]
+    public async Task Create_WhenInstitutionTitleIsNotMinSport_ShouldNotChangeWorkshopTypeAndIsChampionPathFalse()
+    {
+        // Arrange
+        var createdEntity = WorkshopGenerator.Generate().WithProvider();
+        createdEntity.InstitutionHierarchyId = Guid.NewGuid();
+        createdEntity.WorkshopType = WorkshopType.Studio;
+
+        SetupCreate(createdEntity);
+
+        institutionHierarchyServiceMock.Setup(s => s.GetById(createdEntity.InstitutionHierarchyId.Value))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Інший заклад" }
+            });
+    
+        featureManager.Setup(f => f.IsEnabledAsync("EnableWorkshopGroupTypeField")).ReturnsAsync(true);
+
+        var dto = WorkshopCreateRequestDtoGenerator.FromModel(createdEntity);
+        
+        workshopRepository.Setup(w => w.Create(It.IsAny<Workshop>()))
+            .ReturnsAsync((Workshop w) => w);
+
+        // Act
+        var result = await workshopService.Create(dto).ConfigureAwait(false);
+
+        // Assert
+        result.WorkshopType.Should().Be(WorkshopType.Studio);
+        result.IsChampionPath.Should().BeFalse();
+    }
+
     #endregion
 
     #region CreateV2
@@ -502,6 +561,42 @@ public class WorkshopServiceTests
         result.Should().NotBeNull();
         result.UploadingCoverImageResult.Should().BeNull();
     }
+    
+    [Test]
+    public async Task CreateV2_WhenInstitutionTitleIsMinSport_ShouldSetWorkshopTypeToSectionAndIsChampionPathTrue()
+    {
+        // Arrange
+        var createdEntity = WorkshopGenerator.Generate().WithProvider();
+        createdEntity.InstitutionHierarchyId = Guid.NewGuid();
+        createdEntity.WorkshopType = WorkshopType.Studio;
+
+        SetupCreateV2(createdEntity);
+
+        institutionHierarchyServiceMock.Setup(s => s.GetById(createdEntity.InstitutionHierarchyId.Value))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Мінспорт" }
+            });
+
+        featureManager.Setup(f => f.IsEnabledAsync("EnableWorkshopGroupTypeField")).ReturnsAsync(true);
+
+        var dto = WorkshopV2CreateRequestDtoGenerator.FromModel(createdEntity);
+        
+        workshopRepository.Setup(w => w.Create(It.IsAny<Workshop>()))
+            .ReturnsAsync((Workshop w) => w);
+
+        workshopRepository.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<(Workshop, MultipleImageUploadingResult, Result<string>)>>>()))
+            .Returns((Func<Task<(Workshop, MultipleImageUploadingResult, Result<string>)>> f) => f());
+
+        // Act
+        var result = await workshopService.CreateV2(dto).ConfigureAwait(false);
+
+        // Assert
+        result.Workshop.WorkshopType.Should().Be(WorkshopType.Section);
+        result.Workshop.IsChampionPath.Should().BeTrue();
+    }
+
+
     #endregion
 
     #region GetAll
@@ -1014,6 +1109,89 @@ public class WorkshopServiceTests
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"*Language with ID = {dto.LanguageOfEducationId}*");
     }
+    
+    [Test]
+    public async Task Update_WhenInstitutionTitleIsExactlyMinSport_ShouldSetSectionAndChampionPath()
+    {
+        // Arrange
+        var dto = WorkshopCreateUpdateDtoGenerator.Generate();
+        dto.InstitutionHierarchyId = Guid.NewGuid();
+        dto.WorkshopType = WorkshopType.Studio;
+
+        var teachers = TeachersGenerator.Generate(2);
+        dto.Teachers = teachers.ToDto();
+
+        var workshop = dto.SetToModel(WorkshopGenerator.Generate());
+        workshop.Teachers = teachers;
+        workshop.Applications = [];
+
+        SetupUpdate(workshop);
+        
+        applicationRepository
+            .Setup(x => x.CountTakenSeatsForWorkshops(It.IsAny<List<Guid>>()))
+            .ReturnsAsync(new List<WorkshopTakenSeats>());
+        
+        institutionHierarchyServiceMock.Setup(s => s.GetById(dto.InstitutionHierarchyId.Value))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Мінспорт" }
+            });
+
+        // Act
+        var result = await workshopService.Update(dto).ConfigureAwait(false);
+
+        // Assert
+        result.WorkshopType.Should().Be(WorkshopType.Section);
+        result.IsChampionPath.Should().BeTrue();
+    }
+    
+    [Test]
+    public async Task Update_WhenInstitutionTitleIsDifferent_ShouldKeepWorkshopTypeAndSetChampionPathFalse()
+    {
+        // Arrange
+        var dto = WorkshopCreateUpdateDtoGenerator.Generate();
+        dto.InstitutionHierarchyId = Guid.NewGuid();
+        dto.WorkshopType = WorkshopType.CreativeUnion;
+
+        var teachers = TeachersGenerator.Generate(2);
+        dto.Teachers = teachers.ToDto();
+
+        var workshop = dto.SetToModel(WorkshopGenerator.Generate());
+        workshop.Teachers = teachers;
+        workshop.Applications = [];
+
+        SetupUpdate(workshop);
+        applicationRepository
+            .Setup(x => x.CountTakenSeatsForWorkshops(It.IsAny<List<Guid>>()))
+            .ReturnsAsync(new List<WorkshopTakenSeats>());
+        
+        institutionHierarchyServiceMock.Setup(s => s.GetById(dto.InstitutionHierarchyId.Value))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Some Other Institution" }
+            });
+
+        // Act
+        var result = await workshopService.Update(dto).ConfigureAwait(false);
+
+        // Assert
+        result.WorkshopType.Should().Be(WorkshopType.CreativeUnion);
+        result.IsChampionPath.Should().BeFalse();
+    }
+    
+    [Test]
+    public async Task Update_WhenInstitutionHierarchyIdIsNull_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var dto = WorkshopCreateUpdateDtoGenerator.Generate();
+        dto.InstitutionHierarchyId = null;
+
+        // Act & Assert
+        await workshopService.Invoking(s => s.Update(dto))
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("InstitutionHierarchyId cannot be null.");
+    }
 
     [Test]
     public async Task UpdateV2_WithInvalidLanguageId_ShouldThrowInvalidOperationException()
@@ -1031,6 +1209,107 @@ public class WorkshopServiceTests
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"*Language with ID = {dto.LanguageOfEducationId}*");
+    }
+    
+    [Test]
+    public async Task UpdateV2_WhenInstitutionTitleIsExactlyMinSport_ShouldSetSectionAndChampionPath()
+    {
+        // Arrange
+        var dto = WorkshopV2DtoGenerator.Generate();
+        dto.InstitutionHierarchyId = Guid.NewGuid();
+        dto.WorkshopType = WorkshopType.CreativeUnion;
+        dto.Teachers = TeachersGenerator.Generate(2).ToDto();
+        dto.DateTimeRanges = [];
+        dto.AvailableSeats = 0;
+    
+        var workshop = dto.SetToModel(WorkshopGenerator.Generate());
+        workshop.Teachers = TeachersGenerator.Generate(2);
+        workshop.Applications = [];
+
+        SetupUpdate(workshop);
+
+        institutionHierarchyServiceMock.Setup(s => s.GetById(dto.InstitutionHierarchyId.Value))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Мінспорт" }
+            });
+
+        applicationRepository.Setup(x => x.CountTakenSeatsForWorkshops(It.IsAny<List<Guid>>()))
+            .ReturnsAsync(new List<WorkshopTakenSeats>());
+
+        workshopImagesMediator.Setup(i => i.ChangeImagesAsync(It.IsAny<Workshop>(), It.IsAny<IList<string>>(), It.IsAny<IList<IFormFile>>()))
+            .ReturnsAsync(new MultipleImageChangingResult());
+
+        workshopImagesMediator.Setup(i => i.ChangeCoverImageAsync(It.IsAny<Workshop>(), It.IsAny<string>(), It.IsAny<IFormFile>()))
+            .ReturnsAsync(new ImageChangingResult());
+
+        workshopRepository.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<(Workshop, MultipleImageChangingResult, ImageChangingResult)>>>()))
+            .Returns((Func<Task<(Workshop, MultipleImageChangingResult, ImageChangingResult)>> f) => f.Invoke());
+
+        // Act
+        var result = await workshopService.UpdateV2(dto).ConfigureAwait(false);
+
+        // Assert
+        result.Workshop.WorkshopType.Should().Be(WorkshopType.Section);
+        result.Workshop.IsChampionPath.Should().BeTrue();
+    }
+    
+    [Test]
+    public async Task UpdateV2_WhenInstitutionTitleIsNotMinSport_ShouldKeepWorkshopTypeAndSetChampionPathFalse()
+    {
+        // Arrange
+        var dto = WorkshopV2DtoGenerator.Generate();
+        dto.InstitutionHierarchyId = Guid.NewGuid();
+        dto.WorkshopType = WorkshopType.Studio;
+        dto.Teachers = TeachersGenerator.Generate(2).ToDto();
+        dto.DateTimeRanges = [];
+        dto.AvailableSeats = 5;
+
+        var workshop = dto.SetToModel(WorkshopGenerator.Generate());
+        workshop.Teachers = TeachersGenerator.Generate(2);
+        workshop.Applications = [];
+
+        SetupUpdate(workshop);
+
+        institutionHierarchyServiceMock.Setup(s => s.GetById(dto.InstitutionHierarchyId.Value))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Some Other Org" }
+            });
+
+        applicationRepository.Setup(x => x.CountTakenSeatsForWorkshops(It.IsAny<List<Guid>>()))
+            .ReturnsAsync(new List<WorkshopTakenSeats>());
+
+        workshopImagesMediator.Setup(i => i.ChangeImagesAsync(It.IsAny<Workshop>(), It.IsAny<IList<string>>(), It.IsAny<IList<IFormFile>>()))
+            .ReturnsAsync(new MultipleImageChangingResult());
+
+        workshopImagesMediator.Setup(i => i.ChangeCoverImageAsync(It.IsAny<Workshop>(), It.IsAny<string>(), It.IsAny<IFormFile>()))
+            .ReturnsAsync(new ImageChangingResult());
+
+        workshopRepository.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<(Workshop, MultipleImageChangingResult, ImageChangingResult)>>>()))
+            .Returns((Func<Task<(Workshop, MultipleImageChangingResult, ImageChangingResult)>> f) => f.Invoke());
+
+        // Act
+        var result = await workshopService.UpdateV2(dto).ConfigureAwait(false);
+
+        // Assert
+        result.Workshop.WorkshopType.Should().Be(WorkshopType.Studio);
+        result.Workshop.IsChampionPath.Should().BeFalse();
+    }
+    
+    [Test]
+    public async Task UpdateV2_WhenInstitutionHierarchyIdIsNull_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var dto = WorkshopV2DtoGenerator.Generate();
+        dto.InstitutionHierarchyId = null;
+
+        // Act & Assert
+        await workshopService
+            .Invoking(s => s.UpdateV2(dto))
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("InstitutionHierarchyId cannot be null.");
     }
     #endregion
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -15,12 +15,14 @@ using NUnit.Framework;
 using OutOfSchool.BusinessLogic.Common;
 using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.Images;
+using OutOfSchool.BusinessLogic.Models.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Models.Tag;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.BusinessLogic.Services;
 using OutOfSchool.BusinessLogic.Services.AverageRatings;
 using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
+using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Services.Workshops;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Enums.Workshop;
@@ -40,6 +42,7 @@ public class WorkshopServiceTests
 {
     private IWorkshopService workshopService;
     private Mock<IWorkshopRepository> workshopRepository;
+    private Mock<IInstitutionHierarchyService>  institutionHierarchyServiceMock;
     private Mock<IEntityRepositorySoftDeleted<long, DateTimeRange>> dateTimeRangeRepository;
     private Mock<IEntityRepositorySoftDeleted<Guid, ChatRoomWorkshop>> roomRepository;
     private Mock<ITeacherService> teacherService;
@@ -68,6 +71,7 @@ public class WorkshopServiceTests
     public void SetUp()
     {
         workshopRepository = new Mock<IWorkshopRepository>();
+        institutionHierarchyServiceMock = new Mock<IInstitutionHierarchyService>();
         dateTimeRangeRepository = new Mock<IEntityRepositorySoftDeleted<long, DateTimeRange>>();
         roomRepository = new Mock<IEntityRepositorySoftDeleted<Guid, ChatRoomWorkshop>>();
         teacherService = new Mock<ITeacherService>();
@@ -95,6 +99,7 @@ public class WorkshopServiceTests
                 new WorkshopService(
                     workshopRepository.Object,
                     languageServiceMock.Object,
+                    institutionHierarchyServiceMock.Object,
                     tagRepository.Object,
                     dateTimeRangeRepository.Object,
                     roomRepository.Object,
@@ -1371,6 +1376,15 @@ public class WorkshopServiceTests
     #endregion
 
     #region Setup
+    
+    private void SetupInstitutionHierarchy()
+    {
+        institutionHierarchyServiceMock.Setup(s => s.GetById(It.IsAny<Guid>()))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Мінспорт"}
+            });
+    }
     private void SetupCreate(Workshop workshop, bool isMemberOfWorkshopIdExisted = false)
     {
         providerRepositoryMock.Setup(p => p.GetById(It.IsAny<Guid>()))
@@ -1381,6 +1395,7 @@ public class WorkshopServiceTests
             .ReturnsAsync(It.IsAny<int>());
         workshopRepository.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<Workshop>>>()))
             .Returns((Func<Task<Workshop>> f) => f.Invoke());
+        SetupInstitutionHierarchy();
     }
 
     private void SetupCreateV2(Workshop workshop, bool isMemberOfWorkshopIdExisted = false, int numberOfImages = 0)
@@ -1409,7 +1424,7 @@ public class WorkshopServiceTests
 
         languageServiceMock.Setup(s => s.GetById(It.IsAny<long>()))
             .ReturnsAsync((long id) => new LanguageDto { Id = id, Name = "English" });
-
+        SetupInstitutionHierarchy();
         var multipleImageUploadingResult = new MultipleImageUploadingResult()
         {
             MultipleKeyValueOperationResult = new MultipleKeyValueOperationResult(),
@@ -1513,7 +1528,9 @@ public class WorkshopServiceTests
         workshopRepository.Setup(w => w.SaveChangesAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(It.IsAny<int>());
 
         workshopRepository.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<Workshop>>>()))
-            .Returns((Func<Task<Workshop>> f) => f.Invoke());
+            .Returns((Func<Task<Workshop>> f) => f.Invoke()); 
+        
+        SetupInstitutionHierarchy();
     }
 
     private void SetupArchive(Workshop workshop, bool doesWorkshopExist)

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveWorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveWorkshopDraftServiceTests.cs
@@ -20,6 +20,7 @@ using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.ProviderServices;
 using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.BusinessLogic.Services.WorkshopDrafts;
+using OutOfSchool.Common.Config;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Enums.WorkshopStatus;
@@ -85,6 +86,7 @@ public class SensitiveWorkshopDraftServiceTests
 
         var logger = new Mock<ILogger<WorkshopDraftService>>();
         var teacherDraftImagesService = new Mock<IEntityCoverImageInteractionService<TeacherDraft>>();
+        var institutionOptionsMock = new Mock<IOptions<InstitutionOptions>>();
 
         userId = "someUserId";
 
@@ -105,11 +107,14 @@ public class SensitiveWorkshopDraftServiceTests
                    searchStringServiceMock.Object,
                    institutionHierarchyRepositoryMock.Object,
                    codeficatorRepository.Object,
-                   changesLogServiceMock.Object);
+                   changesLogServiceMock.Object,
+                   institutionOptionsMock.Object);
 
         SetupModeratorTestData();
         languageServiceMock.Setup(x => x.GetById(It.Is<long>(id => id == 1)))
                 .ReturnsAsync(new LanguageDto { Id = 1, Name = "English" });
+        institutionOptionsMock.Setup(x => x.Value)
+            .Returns(new InstitutionOptions { MinistryOfSportTitle = "Мінспорт" });
     }
 
     #region FetchByFilterForAdmins    

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -77,8 +77,7 @@ public class WorkshopDraftServiceTests
         codeficatorRepositoryMoq = new Mock<ICodeficatorRepository>();
         languageServiceMoq = new Mock<ILanguageService>();
         changesLogServiceMock = new Mock<IChangesLogService>();
-
-        // Мок для GetByIdWithDetails (корректная сигнатура)
+        
         institutionHierarchyRepositoryMoq.Setup(x => x.GetByIdWithDetails(
             It.IsAny<Guid>(),
             It.IsAny<string>(),

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -26,6 +26,7 @@ using OutOfSchool.BusinessLogic.Services.ProviderServices;
 using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Services.WorkshopDrafts;
+using OutOfSchool.Common.Config;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Enums.Workshop;
 using OutOfSchool.Services.Enums;
@@ -56,6 +57,7 @@ public class WorkshopDraftServiceTests
     private Mock<IInstitutionHierarchyRepository> institutionHierarchyRepositoryMoq;
     private Mock<ICodeficatorRepository> codeficatorRepositoryMoq;
     private Mock<IChangesLogService> changesLogServiceMock;
+    private Mock<IOptions<InstitutionOptions>> institutionOptionsMock;
 
     private string userId;
 
@@ -87,7 +89,8 @@ public class WorkshopDraftServiceTests
         var ministryAdminService = new Mock<IMinistryAdminService>();
         var codeficatorService = new Mock<ICodeficatorService>();
         var searchStringService = new Mock<ISearchStringService>();              
-
+        institutionOptionsMock = new Mock<IOptions<InstitutionOptions>>();
+      
         userId = "someUserId";
         service = new WorkshopDraftService(
                    logger.Object,
@@ -106,8 +109,11 @@ public class WorkshopDraftServiceTests
                    searchStringService.Object,
                    institutionHierarchyRepositoryMoq.Object,
                    codeficatorRepositoryMoq.Object,
-                   changesLogServiceMock.Object);
-
+                   changesLogServiceMock.Object,
+                   institutionOptionsMock.Object);
+        
+        institutionOptionsMock.Setup(x => x.Value)
+            .Returns(new InstitutionOptions { MinistryOfSportTitle = "Мінспорт" });
         SetupInstitutionHierarchy();
     }
 
@@ -990,7 +996,8 @@ public class WorkshopDraftServiceTests
                    searchStringService.Object,
                    institutionHierarchyRepositoryMoq.Object,
                    codeficatorRepositoryMoq.Object,
-                   new Mock<IChangesLogService>().Object);
+                   new Mock<IChangesLogService>().Object,
+                   institutionOptionsMock.Object);
 
         // Act & Assert
         Assert.ThrowsAsync<InvalidOperationException>(() => service.CreateDraftForReactivation(workshop.Id));

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -4,8 +4,11 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OutOfSchool.ExternalFileStore.Models;
 using MockQueryable.Moq;
 using Moq;
 using NUnit.Framework;
@@ -23,6 +26,8 @@ using OutOfSchool.BusinessLogic.Services.ProviderServices;
 using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Services.WorkshopDrafts;
+using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Enums.Workshop;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Enums.WorkshopStatus;
 using OutOfSchool.Services.Models;
@@ -41,6 +46,8 @@ public class WorkshopDraftServiceTests
     private IWorkshopDraftService service;  
     private Mock<IWorkshopDraftRepository> workshopDraftRepoMoq;
     private Mock<IInstitutionHierarchyService> institutionHierarchyServiceMock;
+    private Mock<IImageDependentEntityImagesInteractionService<WorkshopDraft>> workshopDraftImagesServiceMock;
+    private Mock<IEntityCoverImageInteractionService<TeacherDraft>> teacherDraftImagesServiceMock;
     private Mock<ILanguageService> languageServiceMoq;
     private Mock<IProviderService> providerServiceMoq;
     private Mock<ICurrentUserService> currentUserServiceMoq;
@@ -56,7 +63,8 @@ public class WorkshopDraftServiceTests
     public void SetUp()
     {
         workshopDraftRepoMoq = new Mock<IWorkshopDraftRepository>();
-
+        workshopDraftImagesServiceMock = new Mock<IImageDependentEntityImagesInteractionService<WorkshopDraft>>();
+        teacherDraftImagesServiceMock = new Mock<IEntityCoverImageInteractionService<TeacherDraft>>();
         currentUserServiceMoq = new Mock<ICurrentUserService>();
         institutionHierarchyServiceMock = new  Mock<IInstitutionHierarchyService>();
         providerServiceMoq = new Mock<IProviderService>();
@@ -81,7 +89,6 @@ public class WorkshopDraftServiceTests
         var searchStringService = new Mock<ISearchStringService>();              
 
         userId = "someUserId";
-
         service = new WorkshopDraftService(
                    logger.Object,
                    languageServiceMoq.Object,
@@ -133,12 +140,12 @@ public class WorkshopDraftServiceTests
         };
         var workshopResponse = workshopDraft.ToResponseDto();
 
-        institutionHierarchyServiceMock.Setup(x => x.GetById(institutionHierarchyId))
-            .ReturnsAsync(new InstitutionHierarchyDto
+        institutionHierarchyRepositoryMoq.Setup(x => x.GetById(institutionHierarchyId))
+            .ReturnsAsync(new InstitutionHierarchy
             {
-                Institution = new InstitutionDto { Title = "Мінспорт" }
+                Id = institutionHierarchyId,
+                Institution = new Institution { Title = "Мінспорт" },
             });
-        
         languageServiceMoq.Setup(x => x.GetById(workshop.LanguageOfEducationId))
             .ReturnsAsync(new LanguageDto { Id = workshop.LanguageOfEducationId, Name = workshop.LanguageOfEducation.Name });
 
@@ -182,7 +189,153 @@ public class WorkshopDraftServiceTests
         var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await service.Create(workshopV2Dto));
         ex.Message.Should().Contain($"Language with ID = {workshopV2Dto.LanguageOfEducationId}");
     }
+    
+    [Test]
+    public async Task Create_WhenInstitutionIsMinSport_ShouldSetChampionPathAndSectionType()
+    {
+        // Arrange
+        var institutionHierarchyId = Guid.NewGuid();
+        var languageId = 1L;
+        var languageName = "Українська";
 
+        var workshop = WorkshopGenerator.Generate()
+            .WithProvider()
+            .WithTeachers()
+            .WithLanguage(languageId, languageName);
+
+        workshop.InstitutionHierarchyId = institutionHierarchyId;
+
+        var workshopV2Dto = workshop.ToV2Dto();
+        workshopV2Dto.InstitutionHierarchyId = institutionHierarchyId;
+
+        institutionHierarchyRepositoryMoq.Setup(x => x.GetById(institutionHierarchyId))
+            .ReturnsAsync(new InstitutionHierarchy
+            {
+                Id = institutionHierarchyId,
+                Institution = new Institution { Title = "Мінспорт" },
+            });
+
+        languageServiceMoq.Setup(x => x.GetById(languageId))
+            .ReturnsAsync(new LanguageDto
+            {
+                Id = languageId,
+                Name = languageName
+            });
+
+        providerServiceMoq
+            .Setup(x => x.GetLicenseStatusAndOwnershipAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(Tuple.Create(ProviderLicenseStatus.Approved, OwnershipType.State));
+
+        tagRepositoryMoq
+            .Setup(x => x.GetByFilter(
+                It.IsAny<Expression<Func<Tag, bool>>>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<IQueryable<Tag>, IQueryable<Tag>>>()))
+            .ReturnsAsync(Enumerable.Empty<Tag>());
+
+        codeficatorRepositoryMoq.Setup(x => x.Get(It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<Expression<Func<CATOTTG, bool>>>(),
+                It.IsAny<Dictionary<Expression<Func<CATOTTG, object>>, SortDirection>>()))
+            .Returns(new List<CATOTTG>().AsQueryable().BuildMock());
+
+        workshopDraftImagesServiceMock
+            .Setup(x => x.AddCoverImageAsync(It.IsAny<WorkshopDraft>(), It.IsAny<IFormFile>()))
+            .ReturnsAsync(Result<string>.Success("cover-id"));
+
+        teacherDraftImagesServiceMock
+            .Setup(x => x.AddCoverImageAsync(It.IsAny<TeacherDraft>(), It.IsAny<IFormFile>()))
+            .ReturnsAsync(Result<string>.Success("teacher-cover-id"));
+
+        var expectedDraft = new WorkshopDraft
+        {
+            Id = Guid.NewGuid(),
+            WorkshopDraftContent = new WorkshopDraftContent
+            {
+                InstitutionHierarchyId = institutionHierarchyId,
+                IsChampionPath = true,
+                WorkshopType = WorkshopType.Section
+            },
+            Teachers = new List<TeacherDraft>()
+        };
+
+        workshopDraftRepoMoq
+            .Setup(x => x.RunInTransaction(It.IsAny<Func<Task<WorkshopDraft>>>()))
+            .ReturnsAsync(expectedDraft);
+
+        // Act
+        var result = await service.Create(workshopV2Dto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.WorkshopDraft.Should().NotBeNull();
+        
+        var details = result.WorkshopDraft.WorkshopDetails;
+
+        details.IsChampionPath.Should().BeTrue("Institution is Мінспорт");
+        details.WorkshopType.Should().Be(WorkshopType.Section, "Institution is Мінспорт");
+        details.InstitutionHierarchyId.Should().Be(institutionHierarchyId);
+    }
+    
+    [Test]
+    public async Task Create_WhenInstitutionIsNotMinSport_ShouldNotSetIsChampionPathAndWorkshopType()
+    {
+        // Arrange
+        var institutionHierarchyId = Guid.NewGuid();
+        var workshop = WorkshopGenerator.Generate().WithProvider().WithTeachers().WithLanguage();
+        workshop.InstitutionHierarchyId = institutionHierarchyId;
+
+        var workshopV2Dto = workshop.ToV2Dto();
+        workshopV2Dto.InstitutionHierarchyId = institutionHierarchyId;
+        workshopV2Dto.WorkshopType = WorkshopType.Workshop;
+
+        var workshopDraft = workshopV2Dto.ToDraft();
+        workshopDraft.WorkshopDraftContent = new WorkshopDraftContent
+        {
+            InstitutionHierarchyId = institutionHierarchyId
+        };
+
+        var expectedResponse = workshopDraft.ToResponseDto();
+        expectedResponse.WorkshopDetails.IsChampionPath = false;
+        expectedResponse.WorkshopDetails.WorkshopType = WorkshopType.Workshop;
+
+        institutionHierarchyRepositoryMoq.Setup(x => x.GetById(institutionHierarchyId))
+            .ReturnsAsync(new InstitutionHierarchy
+            {
+                Id = institutionHierarchyId,
+                Institution = new Institution { Title = "NotMinSport" },
+            });
+
+        languageServiceMoq.Setup(x => x.GetById(workshop.LanguageOfEducationId))
+            .ReturnsAsync(new LanguageDto
+            {
+                Id = workshop.LanguageOfEducationId,
+                Name = workshop.LanguageOfEducation.Name
+            });
+
+        workshopDraftRepoMoq.Setup(x => x.RunInTransaction(It.IsAny<Func<Task<WorkshopDraft>>>()))
+            .ReturnsAsync(workshopDraft);
+
+        tagRepositoryMoq
+            .Setup(x => x.GetByFilter(
+                It.IsAny<Expression<Func<Tag, bool>>>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<IQueryable<Tag>, IQueryable<Tag>>>()))
+            .ReturnsAsync(Enumerable.Empty<Tag>());
+
+        codeficatorRepositoryMoq.Setup(x => x.Get(It.IsAny<int>(),
+            It.IsAny<int>(),
+            It.IsAny<Expression<Func<CATOTTG, bool>>>(),
+            It.IsAny<Dictionary<Expression<Func<CATOTTG, object>>, SortDirection>>()))
+            .Returns(new List<CATOTTG>().AsQueryable().BuildMock());
+
+        // Act
+        var result = await service.Create(workshopV2Dto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.WorkshopDraft.Should().BeEquivalentTo(expectedResponse);
+    }
     #endregion
 
     #region Update
@@ -204,13 +357,23 @@ public class WorkshopDraftServiceTests
         var workshopV2Dto = workshop.ToV2Dto();
         var workshopDraft = workshopV2Dto.ToDraft();
         var workshopResponse = workshopDraft.ToResponseDto();
-
+        
+        workshopResponse.WorkshopDetails.IsChampionPath = true;
+        workshopResponse.WorkshopDetails.WorkshopType = WorkshopType.Section;
+        
         var workshopUpdateDto = new WorkshopDraftUpdateDto()
         {
             Id = Guid.NewGuid(),
             WorkshopV2Dto = workshopV2Dto
         };
-
+        
+        institutionHierarchyRepositoryMoq.Setup(x => x.GetById(workshop.InstitutionHierarchyId.Value))
+            .ReturnsAsync(new InstitutionHierarchy
+            {
+                Id = workshop.InstitutionHierarchyId.Value,
+                Institution = new Institution { Title = "Мінспорт" },
+            });
+        
         languageServiceMoq.Setup(x => x.GetById(workshopV2Dto.LanguageOfEducationId))
             .ReturnsAsync(new LanguageDto { Id = workshopV2Dto.LanguageOfEducationId, Name = workshopV2Dto.LanguageOfEducationName });
         workshopServiceCombinerV2Moq.Setup(x => x.GetById(It.IsAny<Guid>(), It.IsAny<bool>()))
@@ -275,7 +438,149 @@ public class WorkshopDraftServiceTests
         var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await service.Update(updateDto));
         ex.Message.Should().Contain($"Language with ID = {workshopV2Dto.LanguageOfEducationId}");
     }
+    
+    [Test]
+    public async Task Update_WhenInstitutionIsMinSport_ShouldSetChampionPathAndSectionType()
+    {
+        // Arrange
+        var workshop = WorkshopGenerator.Generate().WithProvider().WithTeachers().WithLanguage();
+        var institutionHierarchyId = Guid.NewGuid();
+        workshop.InstitutionHierarchyId = institutionHierarchyId;
 
+        var workshopV2Dto = workshop.ToV2Dto();
+        workshopV2Dto.Id = Guid.NewGuid(); // simulate update
+        workshopV2Dto.InstitutionHierarchyId = institutionHierarchyId;
+
+        var updateDto = new WorkshopDraftUpdateDto
+        {
+            Id = Guid.NewGuid(),
+            WorkshopV2Dto = workshopV2Dto
+        };
+
+        var updatedDraft = new WorkshopDraft
+        {
+            Id = updateDto.Id,
+            WorkshopDraftContent = new WorkshopDraftContent
+            {
+                InstitutionHierarchyId = institutionHierarchyId,
+                IsChampionPath = true,
+                WorkshopType = WorkshopType.Section
+            },
+            Teachers = new List<TeacherDraft>()
+        };
+        
+        codeficatorRepositoryMoq.Setup(x => x.Get(It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<Expression<Func<CATOTTG, bool>>>(),
+                It.IsAny<Dictionary<Expression<Func<CATOTTG, object>>, SortDirection>>()))
+            .Returns(new List<CATOTTG>().AsQueryable().BuildMock());
+        
+        institutionHierarchyRepositoryMoq.Setup(x => x.GetById(institutionHierarchyId))
+            .ReturnsAsync(new InstitutionHierarchy
+            {
+                Id = institutionHierarchyId,
+                Institution = new Institution { Title = "Мінспорт" }
+            });
+
+        languageServiceMoq.Setup(x => x.GetById(workshopV2Dto.LanguageOfEducationId))
+            .ReturnsAsync(new LanguageDto { Id = workshopV2Dto.LanguageOfEducationId, Name = workshopV2Dto.LanguageOfEducationName });
+
+        workshopDraftRepoMoq
+            .Setup(x => x.GetById(updateDto.Id))
+            .ReturnsAsync(updatedDraft);
+
+        workshopDraftRepoMoq
+            .Setup(x => x.Update(It.IsAny<WorkshopDraft>()))
+            .ReturnsAsync(updatedDraft);
+
+        workshopServiceCombinerV2Moq.Setup(x => x.GetById(It.IsAny<Guid>(), true))
+            .ReturnsAsync(workshopV2Dto);
+
+        workshopDraftRepoMoq
+            .Setup(x => x.RunInTransaction(It.IsAny<Func<Task<(WorkshopDraft, ImageChangingResult, MultipleImageChangingResult, List<TeacherCreateUpdateResultDto>)>>>()))
+            .Returns<Func<Task<(WorkshopDraft, ImageChangingResult, MultipleImageChangingResult, List<TeacherCreateUpdateResultDto>)>>>(f => f());
+
+        // Act
+        var result = await service.Update(updateDto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.WorkshopDraft.Should().NotBeNull();
+        result.WorkshopDraft.WorkshopDetails.IsChampionPath.Should().BeTrue();
+        result.WorkshopDraft.WorkshopDetails.WorkshopType.Should().Be(WorkshopType.Section);
+    }
+
+    [Test]
+    public async Task Update_WhenInstitutionIsNotMinSport_ShouldNotSetIsChampionPathAndWorkshopType()
+    {
+        // Arrange
+        var workshop = WorkshopGenerator.Generate().WithProvider().WithTeachers().WithLanguage();
+        var institutionHierarchyId = Guid.NewGuid();
+        workshop.InstitutionHierarchyId = institutionHierarchyId;
+
+        var workshopV2Dto = workshop.ToV2Dto();
+        workshopV2Dto.Id = Guid.NewGuid(); // simulate update
+        workshopV2Dto.InstitutionHierarchyId = institutionHierarchyId;
+        workshopV2Dto.WorkshopType = WorkshopType.Workshop;
+
+        var updateDto = new WorkshopDraftUpdateDto
+        {
+            Id = Guid.NewGuid(),
+            WorkshopV2Dto = workshopV2Dto
+        };
+
+        var updatedDraft = new WorkshopDraft
+        {
+            Id = updateDto.Id,
+            WorkshopDraftContent = new WorkshopDraftContent
+            {
+                InstitutionHierarchyId = institutionHierarchyId,
+                IsChampionPath = false,
+                WorkshopType = WorkshopType.Workshop
+            },
+            Teachers = new List<TeacherDraft>()
+        };
+
+        codeficatorRepositoryMoq.Setup(x => x.Get(It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<Expression<Func<CATOTTG, bool>>>(),
+                It.IsAny<Dictionary<Expression<Func<CATOTTG, object>>, SortDirection>>()))
+            .Returns(new List<CATOTTG>().AsQueryable().BuildMock());
+
+        institutionHierarchyRepositoryMoq.Setup(x => x.GetById(institutionHierarchyId))
+            .ReturnsAsync(new InstitutionHierarchy
+            {
+                Id = institutionHierarchyId,
+                Institution = new Institution { Title = "NotMinSport" }
+            });
+
+        languageServiceMoq.Setup(x => x.GetById(workshopV2Dto.LanguageOfEducationId))
+            .ReturnsAsync(new LanguageDto { Id = workshopV2Dto.LanguageOfEducationId, Name = workshopV2Dto.LanguageOfEducationName });
+
+        workshopDraftRepoMoq
+            .Setup(x => x.GetById(updateDto.Id))
+            .ReturnsAsync(updatedDraft);
+
+        workshopDraftRepoMoq
+            .Setup(x => x.Update(It.IsAny<WorkshopDraft>()))
+            .ReturnsAsync(updatedDraft);
+
+        workshopServiceCombinerV2Moq.Setup(x => x.GetById(It.IsAny<Guid>(), true))
+            .ReturnsAsync(workshopV2Dto);
+
+        workshopDraftRepoMoq
+            .Setup(x => x.RunInTransaction(It.IsAny<Func<Task<(WorkshopDraft, ImageChangingResult, MultipleImageChangingResult, List<TeacherCreateUpdateResultDto>)>>>()))
+            .Returns<Func<Task<(WorkshopDraft, ImageChangingResult, MultipleImageChangingResult, List<TeacherCreateUpdateResultDto>)>>>(f => f());
+
+        // Act
+        var result = await service.Update(updateDto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.WorkshopDraft.Should().NotBeNull();
+        result.WorkshopDraft.WorkshopDetails.IsChampionPath.Should().BeFalse();
+        result.WorkshopDraft.WorkshopDetails.WorkshopType.Should().Be(WorkshopType.Workshop);
+    }
 
     #endregion
 
@@ -587,7 +892,13 @@ public class WorkshopDraftServiceTests
 
         var workshopDrafts = new List<WorkshopDraft>();
         var workshopDraft = workshopV2Dto.ToDraft();
-
+        
+        institutionHierarchyRepositoryMoq.Setup(x => x.GetById(workshop.InstitutionHierarchyId.Value))
+            .ReturnsAsync(new InstitutionHierarchy
+            {
+                Id = workshop.InstitutionHierarchyId.Value,
+                Institution = new Institution { Title = "Мінспорт" },
+            });
         languageServiceMoq.Setup(x => x.GetById(workshop.LanguageOfEducationId))
             .ReturnsAsync(new LanguageDto { Id = workshop.LanguageOfEducationId, Name = workshop.LanguageOfEducation.Name });
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -13,6 +13,7 @@ using OutOfSchool.BusinessLogic.Common;
 using OutOfSchool.BusinessLogic.Config.Images;
 using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.Images;
+using OutOfSchool.BusinessLogic.Models.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Models.WorkshopDraft;
 using OutOfSchool.BusinessLogic.Models.WorkshopDraft.TeacherDraft;
 using OutOfSchool.BusinessLogic.Models.Workshops;
@@ -20,6 +21,7 @@ using OutOfSchool.BusinessLogic.Services;
 using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.ProviderServices;
 using OutOfSchool.BusinessLogic.Services.SearchString;
+using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Services.WorkshopDrafts;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Enums.WorkshopStatus;
@@ -38,6 +40,7 @@ public class WorkshopDraftServiceTests
 {
     private IWorkshopDraftService service;  
     private Mock<IWorkshopDraftRepository> workshopDraftRepoMoq;
+    private Mock<IInstitutionHierarchyService> institutionHierarchyServiceMock;
     private Mock<ILanguageService> languageServiceMoq;
     private Mock<IProviderService> providerServiceMoq;
     private Mock<ICurrentUserService> currentUserServiceMoq;
@@ -55,6 +58,7 @@ public class WorkshopDraftServiceTests
         workshopDraftRepoMoq = new Mock<IWorkshopDraftRepository>();
 
         currentUserServiceMoq = new Mock<ICurrentUserService>();
+        institutionHierarchyServiceMock = new  Mock<IInstitutionHierarchyService>();
         providerServiceMoq = new Mock<IProviderService>();
         tagRepositoryMoq = new Mock<IEntityRepository<long, Tag>>();
         workshopServiceCombinerV2Moq = new Mock<IWorkshopServicesCombinerV2>();
@@ -96,6 +100,8 @@ public class WorkshopDraftServiceTests
                    institutionHierarchyRepositoryMoq.Object,
                    codeficatorRepositoryMoq.Object,
                    changesLogServiceMock.Object);
+
+        SetupInstitutionHierarchy();
     }
 
     #region Create
@@ -113,12 +119,26 @@ public class WorkshopDraftServiceTests
     public async Task Create_WithValidDto_ShouldReturnCreatedObject()
     {
         // Arrange
-        var workshop = WorkshopGenerator.Generate().WithProvider().WithTeachers().WithLanguage();    
+        var institutionHierarchyId = Guid.NewGuid();
+        var workshop = WorkshopGenerator.Generate().WithProvider().WithTeachers().WithLanguage();
+        workshop.InstitutionHierarchyId = institutionHierarchyId;
+        
         var workshopV2Dto = workshop.ToV2Dto();
-
+        workshopV2Dto.InstitutionHierarchyId = institutionHierarchyId;
+        
         var workshopDraft = workshopV2Dto.ToDraft();
+        workshopDraft.WorkshopDraftContent = new WorkshopDraftContent
+        {
+            InstitutionHierarchyId = institutionHierarchyId
+        };
         var workshopResponse = workshopDraft.ToResponseDto();
 
+        institutionHierarchyServiceMock.Setup(x => x.GetById(institutionHierarchyId))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Мінспорт" }
+            });
+        
         languageServiceMoq.Setup(x => x.GetById(workshop.LanguageOfEducationId))
             .ReturnsAsync(new LanguageDto { Id = workshop.LanguageOfEducationId, Name = workshop.LanguageOfEducation.Name });
 
@@ -723,4 +743,12 @@ public class WorkshopDraftServiceTests
         result.Should().BeNull();
     }
     #endregion
+    private void SetupInstitutionHierarchy()
+    {
+        institutionHierarchyServiceMock.Setup(s => s.GetById(It.IsAny<Guid>()))
+            .ReturnsAsync(new InstitutionHierarchyDto
+            {
+                Institution = new InstitutionDto { Title = "Мінспорт"}
+            });
+    }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -38,6 +38,7 @@ using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.Services.Repository.Base.Api;
 using OutOfSchool.Tests.Common;
 using OutOfSchool.Tests.Common.TestDataGenerators;
+using OutOfSchool.Services.Models.SubordinationStructure;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -77,6 +78,16 @@ public class WorkshopDraftServiceTests
         languageServiceMoq = new Mock<ILanguageService>();
         changesLogServiceMock = new Mock<IChangesLogService>();
 
+        // Мок для GetByIdWithDetails (корректная сигнатура)
+        institutionHierarchyRepositoryMoq.Setup(x => x.GetByIdWithDetails(
+            It.IsAny<Guid>(),
+            It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<OutOfSchool.Services.Models.SubordinationStructure.InstitutionHierarchy>, IQueryable<OutOfSchool.Services.Models.SubordinationStructure.InstitutionHierarchy>>>()
+        )).ReturnsAsync(new OutOfSchool.Services.Models.SubordinationStructure.InstitutionHierarchy
+        {
+            SubDirections = new List<SubDirection>(),
+            Institution = new OutOfSchool.Services.Models.SubordinationStructure.Institution { Title = "Мінспорт" }
+        });
 
         var options = new Mock<IOptions<UploadConcurrencySettings>>();
         var settings = new UploadConcurrencySettings();
@@ -89,7 +100,10 @@ public class WorkshopDraftServiceTests
         var ministryAdminService = new Mock<IMinistryAdminService>();
         var codeficatorService = new Mock<ICodeficatorService>();
         var searchStringService = new Mock<ISearchStringService>();              
+        
         institutionOptionsMock = new Mock<IOptions<InstitutionOptions>>();
+        institutionOptionsMock.Setup(x => x.Value)
+            .Returns(new InstitutionOptions { MinistryOfSportTitle = "Мінспорт" });
       
         userId = "someUserId";
         service = new WorkshopDraftService(
@@ -111,9 +125,6 @@ public class WorkshopDraftServiceTests
                    codeficatorRepositoryMoq.Object,
                    changesLogServiceMock.Object,
                    institutionOptionsMock.Object);
-        
-        institutionOptionsMock.Setup(x => x.Value)
-            .Returns(new InstitutionOptions { MinistryOfSportTitle = "Мінспорт" });
         SetupInstitutionHierarchy();
     }
 
@@ -178,7 +189,8 @@ public class WorkshopDraftServiceTests
         tagRepositoryMoq.VerifyAll();
 
         result.Should().NotBeNull();
-        result.WorkshopDraft.Should().BeEquivalentTo(workshopResponse);
+        result.WorkshopDraft.WorkshopDetails.IsChampionPath.Should().BeFalse();
+        result.WorkshopDraft.WorkshopDetails.WorkshopType.Should().Be(WorkshopType.Workshop);
     }
     [Test]
     public void Create_WithInvalidLanguageId_ShouldThrowInvalidOperationException()
@@ -262,7 +274,8 @@ public class WorkshopDraftServiceTests
                 IsChampionPath = true,
                 WorkshopType = WorkshopType.Section
             },
-            Teachers = new List<TeacherDraft>()
+            Teachers = new List<TeacherDraft>(),
+            
         };
 
         workshopDraftRepoMoq
@@ -298,9 +311,9 @@ public class WorkshopDraftServiceTests
         var workshopDraft = workshopV2Dto.ToDraft();
         workshopDraft.WorkshopDraftContent = new WorkshopDraftContent
         {
-            InstitutionHierarchyId = institutionHierarchyId
+            InstitutionHierarchyId = institutionHierarchyId,
         };
-
+        
         var expectedResponse = workshopDraft.ToResponseDto();
         expectedResponse.WorkshopDetails.IsChampionPath = false;
         expectedResponse.WorkshopDetails.WorkshopType = WorkshopType.Workshop;
@@ -340,7 +353,9 @@ public class WorkshopDraftServiceTests
 
         // Assert
         result.Should().NotBeNull();
-        result.WorkshopDraft.Should().BeEquivalentTo(expectedResponse);
+        result.WorkshopDraft.WorkshopDetails.IsChampionPath.Should().BeFalse();
+        result.WorkshopDraft.WorkshopDetails.WorkshopType.Should().Be(WorkshopType.Workshop);
+       
     }
     #endregion
 
@@ -411,7 +426,8 @@ public class WorkshopDraftServiceTests
         currentUserServiceMoq.VerifyAll();          
 
         result.Should().NotBeNull();
-        result.WorkshopDraft.Should().BeEquivalentTo(workshopResponse);
+        result.WorkshopDraft.WorkshopDetails.IsChampionPath.Should().BeTrue();
+        result.WorkshopDraft.WorkshopDetails.WorkshopType.Should().Be(WorkshopType.Section);
     }
 
     [Test]

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -172,6 +172,7 @@ public static class Startup
         services.Configure<CommunicationConfig>(configuration.GetSection(CommunicationConfig.Name));
         services.Configure<GeocodingConfig>(configuration.GetSection(GeocodingConfig.Name));
         services.Configure<ParentConfig>(configuration.GetSection(ParentConfig.Name));
+        services.Configure<InstitutionOptions>(configuration.GetSection(InstitutionOptions.Name));
 
         services.AddMemoryCache();
 

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -346,6 +346,9 @@
     "ClientId": "",
     "ClientSecret": "",
     "TokenEndpoint": ""
+  },
+  "InstitutionOptions": {
+    "MinistryOfSportTitle": "Мінспорт"
   }
 }
 

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/WorkshopGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/WorkshopGenerator.cs
@@ -35,6 +35,7 @@ public static class WorkshopGenerator
         .RuleFor(x => x.ShortTitle, f => f.Company.CompanyName())
         .RuleFor(x => x.StudyPeriodStartDate, _ => new DateOnly(2000, 9, 1))
         .RuleFor(x => x.StudyPeriodEndDate, _ => new DateOnly(2000, 5, 31))
+        .RuleFor(x => x.InstitutionHierarchyId, f => f.Random.Guid())
         .RuleFor(x => x.Tags, f => []);
 
     public static Workshop Generate() => faker.Generate();

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/WorkshopV2CreateRequestDtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/WorkshopV2CreateRequestDtoGenerator.cs
@@ -59,6 +59,7 @@ public static class WorkshopV2CreateRequestDtoGenerator
             AvailableSeats = model.AvailableSeats,
             Contacts = model.Contacts?.ToDto(),
             LanguageOfEducationId = model.LanguageOfEducationId,
+            IsChampionPath = model.IsChampionPath
         };
 
     public static void Populate(WorkshopV2CreateRequestDto dto) => Faker.Populate(dto);


### PR DESCRIPTION
### 🧩 Summary

This pull request introduces the **"Шлях чемпіонів" (ChampionPath)** functionality to the Workshop domain. It adds an optional checkbox that is visible and applicable only when a Workshop's subordination is set to **"Мінспорт"**. The implementation includes updates across the backend stack—models, validation, database schema, tests, and Elasticsearch indexing.

---

### 🛠️ What's Included

#### ✅ Backend Features
- **Added `IsChampionPath` boolean** field to `Workshop` domain model, DTOs, and Elasticsearch model.
- **Created and applied database migration**: adds a non-nullable `IsChampionPath` column with a default value of `false`.
- **Validation logic implemented**:
  - If `InstitutionHierarchyId` indicates "Мінспорт":
    - `WorkshopType` is enforced to be `"Секція"` and made read-only on UI level.
    - `IsChampionPath` is allowed.
  - If **not** "Мінспорт":
    - Any value sent for `IsChampionPath` is ignored, and stored as `false`.

#### 🔍 Elasticsearch
- `WorkshopES` model extended to support `IsChampionPath`.
- Ensured syncing logic populates the new property correctly.

#### 🧪 Tests
- Added unit tests for:
  - **Validation logic** across `CreateV1`, `CreateV2`, `UpdateV1`, and `UpdateV2`.
  - **WorkshopDraftService** for `createDraft`, `updateDraft`.
  - **Edge cases** involving subordination changes and their effect on `IsChampionPath`.

---
### 🧪 How to Test

1. Create or edit a workshop with `subordination = "Мінспорт"`.
2. Observe that:
   - `WorkshopType` is pre-set to `"Секція"` and disabled.
   - `"Шлях чемпіонів"` checkbox is visible and can be checked.
3. Change subordination to another value:
   - `"Шлях чемпіонів"` disappears.
   - `WorkshopType` becomes editable.
4. Validate changes in the database and Elasticsearch index.


### 📌 Notes

- The UI adjustments for field visibility and interactivity (e.g., disabling `WorkshopType`, showing checkbox) are assumed to be handled on the frontend separately.
- This PR strictly ensures **backend enforcement** for the correctness and integrity of `IsChampionPath`.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new "IsChampionPath" flag for workshops, automatically set for workshops linked to the "Мінспорт" institution.
  * The "IsChampionPath" property is now consistently handled and visible across workshop creation, update, and draft flows.
  * Added configuration support for defining the Ministry of Sport institution title.

* **Bug Fixes**
  * Enhanced validation to ensure correct workshop type and champion path status assignment based on institution hierarchy.

* **Tests**
  * Expanded test coverage to verify behavior of the "IsChampionPath" flag and institution-based workshop type adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->