### PR TITLE
Fix(validation): prevent invalid price/payRate for paid workshops

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -183,5 +183,31 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
         {
             yield return new ValidationResult("Min age should be less than or equal to Max age", new[] { nameof(MinAge), nameof(MaxAge) });
         }
+
+        // validate Price and PayRate when IsPaid is true
+        if (IsPaid)
+        {
+            if (PayRate == null || PayRate == PayRateType.None)
+            {
+                yield return new ValidationResult("Pay rate must be specified when the workshop is paid.", new[] { nameof(PayRate) });
+            }
+
+            if (!Price.HasValue)
+            {
+                yield return new ValidationResult("Price must be specified when the workshop is paid.", new[] { nameof(Price) });
+            }
+            else
+            {
+                if (Price < 1.00m)
+                {
+                    yield return new ValidationResult("Price must be at least 1.00 if the workshop is paid.", new[] { nameof(Price) });
+                }
+
+                if (Price > 100000.00m)
+                {
+                    yield return new ValidationResult("Price must be less than or equal to 100000.00.", new[] { nameof(Price) });
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds validation logic to prevent invalid pricing and pay rate configurations for paid workshops.
Changes
Added validation:
- Price must be specified, ≥ 1.00, ≤ 100000.00, and a multiple of 0.5 when IsPaid is true.
- PayRate must not be null or None when IsPaid is true.

Fixed bugs
- Allowed price values below 1.00 or above 100000.00 were accepted
- Missing Price and PayRate fields didn’t trigger validation errors
- PayRate could be None even when the workshop was marked as paid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for paid workshops to ensure that pay rate and price are correctly specified and within acceptable ranges. Users will now receive clearer error messages if these fields are missing or invalid when creating or editing a paid workshop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->