### PR TITLE
Enhance validation for PreferentialTermsOfParticipation property

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -120,6 +120,7 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
     public bool IsChampionPath { get; set; } = false;
 
     [MaxLength(500)]
+    [RequiredIf(nameof(AreThereBenefits), true, ErrorMessage = "PreferentialTermsOfParticipation is required")]
     public string PreferentialTermsOfParticipation { get; set; }
 
     [Required]


### PR DESCRIPTION
## Description

Added validation for PreferentialTermsOfParticipation in the WorkshopBaseDTO model. The changes ensure that when a workshop has benefits (`AreThereBenefits` is true), the `PreferentialTermsOfParticipation` description is required.

## Changes

- Added `RequiredIf` validation attribute to `PreferentialTermsOfParticipation` property
- The field is now required only when `AreThereBenefits` is set to true



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new validation rule requiring users to provide "Preferential Terms of Participation" when benefits are indicated. Users will now see a validation message if this information is missing in such cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->