### PR TITLE
Bugfix: Eager loading for Contacts.Address.CATOTTG in ChangesLogService

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChangesLogService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ChangesLogService.cs
@@ -128,7 +128,7 @@ public class ChangesLogService(
 
         var changesLog = await GetChangesLogAsync(changeLogFilter).ConfigureAwait(false);
 
-        var providers = providerRepository.Get(whereExpression: predicate);
+        var providers = providerRepository.Get(whereExpression: predicate).IncludeContactsWithCodeficatorHierarchy();
 
         var query = changesLog
                 .Join(
@@ -199,7 +199,9 @@ public class ChangesLogService(
 
         var changesLog = await GetChangesLogAsync(changeLogFilter).ConfigureAwait(false);
 
-        var applications = applicationRepository.Get(whereExpression: predicate);
+        var applications = applicationRepository
+            .Get(whereExpression: predicate)
+            .IncludeNavigationPropertyContactsWithCodeficatorHierarchy(a => a.Workshop);
 
         var query = changesLog
                 .Join(


### PR DESCRIPTION
## Description

This pull request fixes a bug that caused a 500 Internal Server Error when accessing changes log endpoints for Providers and Applications. The root cause was the use of lazy loading for navigation properties on owned types (`Contacts.Address.CATOTTG`), which is not supported by EF Core and resulted in proxy errors.

## Changes

- Updated `GetProviderChangesLogAsync` and `GetApplicationChangesLogAsync` to use eager loading for the full `Contacts.Address.CATOTTG` hierarchy.
- Applied the `IncludeContactsWithCodeficatorHierarchy` and `IncludeNavigationPropertyContactsWithCodeficatorHierarchy` extension methods to ensure all required navigation properties are loaded up front.
- This prevents runtime errors related to lazy loading proxies for owned types and ensures all related data is available for DTO mapping.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the display of provider and application change logs by including more detailed contact and codeficator hierarchy information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->