### PR TITLE
remove Dto suffix from property name

### DIFF
--- a/OutOfSchool/Directory.Packages.props
+++ b/OutOfSchool/Directory.Packages.props
@@ -124,6 +124,6 @@
     <PackageVersion Include="Elastic.Apm.Elasticsearch" Version="$(ElasticApmVersion)" />
     <PackageVersion Include="Elastic.Apm.StackExchange.Redis" Version="$(ElasticApmVersion)" />
     <!-- Ecryption Library -->
-    <PackageVersion Include="IIT.EUSignCP" Version="1.3.1.2" />
+    <PackageVersion Include="IIT.EUSignCP" Version="1.3.1.4" />
   </ItemGroup>
 </Project>

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/AddressDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/AddressDto.cs
@@ -25,7 +25,7 @@ public class AddressDto
     [Required(ErrorMessage = "CATOTTGId is required")]
     public long CATOTTGId { get; set; }
 
-    public AllAddressPartsDto CodeficatorAddressDto { get; set; }
+    public AllAddressPartsDto CodeficatorAddress { get; set; }
 
     // Note: implementation taken from the OutOfSchool.Services.Models.Address
     public override int GetHashCode()
@@ -89,7 +89,7 @@ public static class AddressDtoExtensions
             Latitude = address.Point.GetLatitude() ?? default,
             Longitude = address.Point.GetLongitude() ?? default,
             CATOTTGId = address.CATOTTGId,
-            CodeficatorAddressDto = address.CodeficatorAddressES?.ToAllAddressPartsDto(),
+            CodeficatorAddress = address.CodeficatorAddressES?.ToAllAddressPartsDto(),
         };
 
     public static AddressDto ToDto(this ContactsAddress contactsAddress)
@@ -100,7 +100,7 @@ public static class AddressDtoExtensions
             Latitude = contactsAddress.Latitude,
             Longitude = contactsAddress.Longitude,
             CATOTTGId = contactsAddress.CATOTTGId,
-            CodeficatorAddressDto = contactsAddress.CATOTTG?.ToAllAddressPartsDto()
+            CodeficatorAddress = contactsAddress.CATOTTG?.ToAllAddressPartsDto()
         };
 
     public static List<AddressDto> ToDto(this IEnumerable<ContactsAddress> list)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Codeficator/CodeficatorDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Codeficator/CodeficatorDto.cs
@@ -59,7 +59,7 @@ public static class CodeficatorDtoExtensions
     public static List<CodeficatorDto> ToCodeficatorDto(this IEnumerable<CATOTTG> list)
         => list.MapToList(ToCodeficatorDto);
 
-    public static CodeficatorAddressDto ToCodeficatorAddressDto(this OutOfSchool.Services.Models.CATOTTG catottg)
+    public static CodeficatorAddressDto ToCodeficatorAddressDto(this CATOTTG catottg)
         => new()
         {
             Id = catottg.Id,
@@ -74,6 +74,6 @@ public static class CodeficatorDtoExtensions
             Order = catottg.Order,
         };
 
-    public static List<CodeficatorAddressDto> ToCodeficatorAddressDto(this IEnumerable<OutOfSchool.Services.Models.CATOTTG> list)
+    public static List<CodeficatorAddressDto> ToCodeficatorAddressDto(this IEnumerable<CATOTTG> list)
         => list.MapToList(ToCodeficatorAddressDto);
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/ContactsAddressDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/ContactsAddressDto.cs
@@ -23,7 +23,7 @@ public sealed class ContactsAddressDto : IContentComparable<ContactsAddress>, IE
     [Required(ErrorMessage = "CATOTTGId is required")]
     public long CATOTTGId { get; set; }
 
-    public AllAddressPartsDto CodeficatorAddressDto { get; set; }
+    public AllAddressPartsDto CodeficatorAddress { get; set; }
 
     // Note: implementation taken from the OutOfSchool.Services.Models.Address
     [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
@@ -90,11 +90,11 @@ public static class ContactsAddressDtoExtensions
         => new()
         {
             // Id - ignored in original AM mapper
-            City = contactsAddress.CodeficatorAddressDto?.Settlement,
+            City = contactsAddress.CodeficatorAddress?.Settlement,
             Latitude = contactsAddress.Latitude,
             Longitude = contactsAddress.Longitude,
             CATOTTGId = contactsAddress.CATOTTGId,
-            CodeficatorAddressES = contactsAddress.CodeficatorAddressDto?.ToCodeficatorAddressES(),
+            CodeficatorAddressES = contactsAddress.CodeficatorAddress?.ToCodeficatorAddressES(),
             Street = contactsAddress.Street,
             BuildingNumber = contactsAddress.BuildingNumber,
             Point = GeoLocation.LatitudeLongitude(new LatLonGeoLocation()
@@ -136,7 +136,7 @@ public static class ContactsAddressDtoExtensions
             Latitude = contactsAddress.Latitude,
             Longitude = contactsAddress.Longitude,
             CATOTTGId = contactsAddress.CATOTTGId,
-            CodeficatorAddressDto = contactsAddress.CATOTTG?.ToAllAddressPartsDto()
+            CodeficatorAddress = contactsAddress.CATOTTG?.ToAllAddressPartsDto()
         };
 
     public static List<ContactsAddressDto> ToContactsDto(this IEnumerable<ContactsAddress> list)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -5,8 +5,6 @@ using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.V2;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
 using OutOfSchool.BusinessLogic.Models.Images;
-using OutOfSchool.BusinessLogic.Models.WorkshopDraft;
-using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Enums.CompetitiveEventStatus;
 using OutOfSchool.Services.Models.CompetitiveEventDrafts;
@@ -552,7 +550,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             .Select(c => c.Address)
             .ToList()
             .ForEach(address =>
-                address.CodeficatorAddressDto = catottgs
+                address.CodeficatorAddress = catottgs
                     .FirstOrDefault(c => c.Id == address.CATOTTGId)
                     ?.ToAllAddressPartsDto()
             );

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -1081,7 +1081,7 @@ public class WorkshopDraftService(
             .Select(c => c.Address)
             .ToList()
             .ForEach(address =>
-                address.CodeficatorAddressDto = catottgs
+                address.CodeficatorAddress = catottgs
                     .FirstOrDefault(c => c.Id == address.CATOTTGId)
                     ?.ToAllAddressPartsDto()
             );
@@ -1136,7 +1136,7 @@ public class WorkshopDraftService(
                 .Select(c => c.Address)
                 .ToList()
                 .ForEach(address =>
-                    address.CodeficatorAddressDto = catottgs
+                    address.CodeficatorAddress = catottgs
                         .FirstOrDefault(c => c.Id == address.CATOTTGId)
                         ?.ToAllAddressPartsDto()
                 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the property `CodeficatorAddressDto` to `CodeficatorAddress` in address-related data displayed to users.
  * Updated all references to the renamed property for consistency in address and contact information.
  * Simplified type references in address conversion methods, with no impact on user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->