### PR TITLE
Fix: noAgeRestriction flag is  saved correctly in workshop draft

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
@@ -68,7 +68,8 @@ public static class WorkshopV2DtoExtensions
             Website = dto.Website,
             Facebook = dto.Facebook,
             Instagram = dto.Instagram,
-            IsChampionPath = dto.IsChampionPath
+            IsChampionPath = dto.IsChampionPath,
+            NoAgeRestrictions = dto.NoAgeRestrictions,
         };
 
     public static void SetToDraft(this WorkshopV2Dto dto, OutOfSchool.Services.Models.WorkshopDrafts.WorkshopDraft model)


### PR DESCRIPTION
### What was fixed
The `noAgeRestriction` flag was not saved when editing or creating a workshop draft. This caused the "No limit" radio button to appear unselected even when intended.

### What was changed
- Added `noAgeRestriction` field to the `ToDraftContent()` mapping method in `WorkshopV2Dto`.
- Now the flag is properly persisted in the draft object.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the workshop draft content to include the "No Age Restrictions" property when converting workshop details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->