### PR TITLE
Edit competitive event by moderator

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/ModeratorCompetitiveEventDraftEditDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/ModeratorCompetitiveEventDraftEditDto.cs
@@ -10,9 +10,19 @@ public class ModeratorCompetitiveEventDraftEditDto
     public string Title { get; set; }
 
     [Required(ErrorMessage = "ShortTitle is required")]    
-    public string ShortTitle { get; set; }
+    public string ShortTitle { get; set; }    
 
     public string DescriptionOfTheEnrollmentProcedure { get; set; }
+
+    public string AdditionalDescription { get; set; }
+
+    public string VenueName { get; set; }
+
+    public string TermsOfParticipation { get; set; }
+
+    public string PreferentialTermsOfParticipation { get; set; }
+
+    public string Benefits { get; set; }
 
     public IEnumerable<ContactsDto> Contacts { get; set; } = [];
 }
@@ -24,6 +34,11 @@ public static class ModeratorCompetitiveEventDraftEditDtoExtensions
         model.CompetitiveEventDraftContent.Title = dto.Title;
         model.CompetitiveEventDraftContent.ShortTitle = dto.ShortTitle;
         model.CompetitiveEventDraftContent.DescriptionOfTheEnrollmentProcedure = dto.DescriptionOfTheEnrollmentProcedure;
+        model.CompetitiveEventDraftContent.AdditionalDescription = dto.AdditionalDescription;
+        model.CompetitiveEventDraftContent.VenueName = dto.VenueName;
+        model.CompetitiveEventDraftContent.TermsOfParticipation = dto.TermsOfParticipation;
+        model.CompetitiveEventDraftContent.PreferentialTermsOfParticipation = dto.PreferentialTermsOfParticipation;
+        model.CompetitiveEventDraftContent.Benefits = dto.Benefits;
 
         UpdateContactsForModeration(model.CompetitiveEventDraftContent.Contacts, dto.Contacts);
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/ModeratorCompetitiveEventDraftEditDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/ModeratorCompetitiveEventDraftEditDto.cs
@@ -1,0 +1,57 @@
+﻿using OutOfSchool.BusinessLogic.Models.ContactInfo;
+using OutOfSchool.Services.Models.ContactInfo;
+using System.ComponentModel.DataAnnotations;
+using CompetitiveEventDraftModel = OutOfSchool.Services.Models.CompetitiveEventDrafts.CompetitiveEventDraft;
+
+namespace OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
+public class ModeratorCompetitiveEventDraftEditDto
+{
+    [Required(ErrorMessage = "Title is required")]
+    public string Title { get; set; }
+
+    [Required(ErrorMessage = "ShortTitle is required")]    
+    public string ShortTitle { get; set; }
+
+    public string DescriptionOfTheEnrollmentProcedure { get; set; }
+
+    public IEnumerable<ContactsDto> Contacts { get; set; } = [];
+}
+
+public static class ModeratorCompetitiveEventDraftEditDtoExtensions
+{
+    public static CompetitiveEventDraftModel ToDraft(this ModeratorCompetitiveEventDraftEditDto dto, CompetitiveEventDraftModel model)
+    { 
+        model.CompetitiveEventDraftContent.Title = dto.Title;
+        model.CompetitiveEventDraftContent.ShortTitle = dto.ShortTitle;
+        model.CompetitiveEventDraftContent.DescriptionOfTheEnrollmentProcedure = dto.DescriptionOfTheEnrollmentProcedure;
+
+        UpdateContactsForModeration(model.CompetitiveEventDraftContent.Contacts, dto.Contacts);
+
+        return model;
+    }
+
+    private static void UpdateContactsForModeration(
+        List<Contacts> existingContacts,
+        IEnumerable<ContactsDto> moderationContacts)
+    {
+        if (existingContacts == null || moderationContacts == null)
+            return;
+
+        foreach (var moderationContact in moderationContacts)
+        {
+            // Find existing contact by Title + Address combination
+            var existingContact = existingContacts.FirstOrDefault(c =>
+                c.Title == moderationContact.Title &&
+                c.Address != null &&
+                moderationContact.Address != null &&
+                c.Address.Equals(moderationContact.Address.ToModel()));
+
+            if (existingContact != null)
+            {
+                existingContact.Phones = moderationContact.Phones?.ToModel() ?? [];
+                existingContact.Emails = moderationContact.Emails?.ToModel() ?? [];
+                existingContact.SocialNetworks = moderationContact.SocialNetworks?.ToModel() ?? [];
+            }
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -603,8 +603,19 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
     // <inheritdoc/>
     public async Task<Result<CompetitiveEventDraftResponseDto>> UpdateDraftAsModeratorAsync(Guid draftId, ModeratorCompetitiveEventDraftEditDto dto)
     {
-        logger.LogDebug("Updating competitive event as moderator started. CompetitiveEventDraft Id = {Id}.", draftId);
+        if (dto == null)
+        {
+            logger.LogError("Parameter '{ParameterName}' is null.", nameof(dto));
+            
+            return Result<CompetitiveEventDraftResponseDto>.Failed(new OperationError
+            {
+                Code = "400",
+                Description = "Dto must not be null."
+            });
+        }
 
+        logger.LogDebug("Updating competitive event as moderator started. CompetitiveEventDraft Id = {Id}.", draftId);        
+        
         var validation = await ValidateDraftForModerator(draftId);                
 
         if (!validation.Succeeded)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -600,6 +600,43 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         }
     }
 
+    // <inheritdoc/>
+    public async Task<Result<CompetitiveEventDraftResponseDto>> UpdateDraftAsModeratorAsync(Guid draftId, ModeratorCompetitiveEventDraftEditDto dto)
+    {
+        logger.LogDebug("Updating competitive event as moderator started. CompetitiveEventDraft Id = {Id}.", draftId);
+
+        var validation = await ValidateDraftForModerator(draftId);                
+
+        if (!validation.Succeeded)
+        {
+            return validation.ToFailedResult<CompetitiveEventDraftResponseDto>();
+        }
+
+        var competitiveEventDraft = validation.Value;
+
+        try
+        {            
+            dto.ToDraft(competitiveEventDraft);
+            competitiveEventDraft.DraftStatus = CompetitiveEventDraftStatus.EditedByModerator;
+
+            await competitiveEventDraftRepository.Update(competitiveEventDraft);            
+            var draftWithDetails = await GetByIdWithProviderDetails(competitiveEventDraft.Id);
+
+            logger.LogInformation("Competitive event was updated by moderator.");
+
+            return Result<CompetitiveEventDraftResponseDto>.Success(draftWithDetails.ToResponseDto());
+        }
+        catch (Exception ex) 
+        {
+            logger.LogError(ex, "Error occurred while updating CompetitiveEventDraft with ID {DraftId}.", draftId);
+            return Result<CompetitiveEventDraftResponseDto>.Failed(new OperationError
+            {
+                Code = "500",
+                Description = "An error occurred while updating CompetitiveEventDraft."
+            });
+        }
+    }
+
     private async Task<CompetitiveEventDraftResponseDto> MapCompetitiveEventDraftWithDetails(CompetitiveEventDraft draft)
     {
         var competitiveEventDraftResponseDto = draft.ToResponseDto();

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/ISensitiveCompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/ISensitiveCompetitiveEventDraftService.cs
@@ -30,4 +30,12 @@ public interface ISensitiveCompetitiveEventDraftService
     /// <param name="imageIds">A collection of externalStorageIds of images to delete.</param>
     /// <returns>A <see cref="Result{CompetitiveEventDraftResponseDto}"/> with the updated draft or error information.</returns>
     Task<Result<CompetitiveEventDraftResponseDto>> DeleteImagesAsModeratorAsync(Guid draftId, IEnumerable<string> imageIds);
-} 
+
+    /// <summary>
+    /// Updates competitive event draft on behalf of a moderator.
+    /// </summary>
+    /// <param name="draftId">The ID of the competitive event draft.</param>
+    /// <param name="dto">Edited competitive event daraft.</param>
+    /// <returns>A <see cref="Result{CompetitiveEventDraftResponseDto}"/> with the updated draft or error information.</returns>
+    Task<Result<CompetitiveEventDraftResponseDto>> UpdateDraftAsModeratorAsync(Guid draftId, ModeratorCompetitiveEventDraftEditDto dto);
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventDraftControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventDraftControllerTests.cs
@@ -341,9 +341,9 @@ public class CompetitiveEventDraftControllerTests
         var dto = new ModeratorCompetitiveEventDraftEditDto
         {
             Title = "Test title",
-            ShortTitle = "Short title",            
+            ShortTitle = "Short title",
         };
-
+        
         var responseDto = new CompetitiveEventDraftResponseDto
         {
             CompetitiveEventDraftId = id,
@@ -361,10 +361,79 @@ public class CompetitiveEventDraftControllerTests
         // Assert
         Assert.That(result, Is.InstanceOf<OkObjectResult>());
         var okResult = result as OkObjectResult;
-        Assert.That(okResult?.Value, Is.InstanceOf<Result<CompetitiveEventDraftResponseDto>>());
-        var response = okResult?.Value as Result<CompetitiveEventDraftResponseDto>;
-        Assert.That(response.Succeeded, Is.True);
-        Assert.That(response.Value.CompetitiveEventDraftId, Is.EqualTo(id));
+        
+        Assert.That(okResult?.Value, Is.InstanceOf<CompetitiveEventDraftResponseDto>());
+        var response = okResult?.Value as CompetitiveEventDraftResponseDto;
+
+        Assert.That(response, Is.Not.Null);
+        Assert.That(response.CompetitiveEventDraftId, Is.EqualTo(id));
+        Assert.That(response.DraftStatus, Is.EqualTo(CompetitiveEventDraftStatus.EditedByModerator));
+
+        sensitiveCompetitiveEventDraftServiceMock.Verify(
+            s => s.UpdateDraftAsModeratorAsync(id, dto),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateAsModerator_ReturnsNotFound_WhenDraftDoesNotExist()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var dto = new ModeratorCompetitiveEventDraftEditDto
+        {
+            Title = "Test title",
+            ShortTitle = "Short title"
+        };
+
+        sensitiveCompetitiveEventDraftServiceMock
+            .Setup(s => s.UpdateDraftAsModeratorAsync(id, dto))
+            .ReturnsAsync(Result<CompetitiveEventDraftResponseDto>.Failed(new OperationError
+            {
+                Code = "404",
+                Description = "Draft not found."
+            }));
+
+        // Act
+        var result = await controller.UpdateAsModerator(id, dto);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
+
+        sensitiveCompetitiveEventDraftServiceMock.Verify(
+            s => s.UpdateDraftAsModeratorAsync(id, dto),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateAsModerator_ReturnsInternalServerError_WhenServiceThrowsException()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var dto = new ModeratorCompetitiveEventDraftEditDto
+        {
+            Title = "Test title",
+            ShortTitle = "Short title"
+        };
+
+        sensitiveCompetitiveEventDraftServiceMock
+            .Setup(s => s.UpdateDraftAsModeratorAsync(id, dto))
+            .ReturnsAsync(Result<CompetitiveEventDraftResponseDto>.Failed(new OperationError
+            {
+                Code = "500",
+                Description = "An error occurred while updating CompetitiveEventDraft."
+            }));
+
+        // Act
+        var result = await controller.UpdateAsModerator(id, dto);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<ObjectResult>());
+        var objectResult = result as ObjectResult;
+        Assert.That(objectResult?.StatusCode, Is.EqualTo(500));
+
+        sensitiveCompetitiveEventDraftServiceMock.Verify(
+            s => s.UpdateDraftAsModeratorAsync(id, dto),
+            Times.Once);
     }
 
     #endregion

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventDraftControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventDraftControllerTests.cs
@@ -12,6 +12,7 @@ using OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
 using OutOfSchool.BusinessLogic.Services.CompetitiveEventDrafts;
 using OutOfSchool.BusinessLogic.Services.ProviderServices;
 using OutOfSchool.Services.Common.Exceptions;
+using OutOfSchool.Services.Enums.CompetitiveEventStatus;
 using OutOfSchool.WebApi.Controllers.V2;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
@@ -330,6 +331,40 @@ public class CompetitiveEventDraftControllerTests
         Assert.That(internalError?.StatusCode, Is.EqualTo(409));
         var errorDescription = internalError.Value;
         Assert.That(errorDescription, Does.Contain("Service error"));
+    }
+
+    [Test]
+    public async Task UpdateAsModerator_ReturnsOk_WhenSuccessful()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var dto = new ModeratorCompetitiveEventDraftEditDto
+        {
+            Title = "Test title",
+            ShortTitle = "Short title",            
+        };
+
+        var responseDto = new CompetitiveEventDraftResponseDto
+        {
+            CompetitiveEventDraftId = id,
+            DraftStatus = CompetitiveEventDraftStatus.EditedByModerator,
+            CompetitiveEventDetails = new CompetitiveEventV2Dto { Id = id }
+        };
+
+        sensitiveCompetitiveEventDraftServiceMock
+            .Setup(s => s.UpdateDraftAsModeratorAsync(id, dto))
+            .ReturnsAsync(Result<CompetitiveEventDraftResponseDto>.Success(responseDto));
+
+        // Act
+        var result = await controller.UpdateAsModerator(id, dto);
+
+        // Assert
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        var okResult = result as OkObjectResult;
+        Assert.That(okResult?.Value, Is.InstanceOf<Result<CompetitiveEventDraftResponseDto>>());
+        var response = okResult?.Value as Result<CompetitiveEventDraftResponseDto>;
+        Assert.That(response.Succeeded, Is.True);
+        Assert.That(response.Value.CompetitiveEventDraftId, Is.EqualTo(id));
     }
 
     #endregion

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.BusinessLogic.Models;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -142,6 +143,100 @@ public class SensitiveCompetitiveEventDraftServiceTest
            Times.Once);
     }
     
+    [Test]
+    public async Task UpdateDraftAsModeratorAsync_UpdatesContactsCorrectly_WhenContactsProvided()
+    {
+        // Arrange
+        var existingAddress = new Address { Street = "123 Main St" };
+        var existingContact = new Contacts{};
+
+        var competitiveEventDraft = GetCompetitiveEventDraft(draftId);
+        competitiveEventDraft.CompetitiveEventDraftContent.Contacts.Add(existingContact);
+
+        var addressDto = new AddressDto { Street = "123 Main St" };
+        var contactDto = new ContactsDto{};
+
+        var dto = GetModeratorCompetitiveEventDraftEditDto();
+        dto.Contacts = new List<ContactsDto> { contactDto };
+
+        currentUserServiceMock
+            .Setup(x => x.UserHasRights(It.IsAny<ModeratorRights>(), It.IsAny<TechAdminRights>()))
+            .Returns(Task.CompletedTask);
+
+        draftRepoMock
+            .Setup(x => x.GetById(It.IsAny<Guid>()))
+            .ReturnsAsync(competitiveEventDraft);
+
+        draftRepoMock.Setup(repo => repo.GetByIdWithDetails(draftId, It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<CompetitiveEventDraft>, IQueryable<CompetitiveEventDraft>>>()))
+            .ReturnsAsync(competitiveEventDraft);
+
+        // Act
+        var result = await service.UpdateDraftAsModeratorAsync(draftId, dto);
+
+        // Assert
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(CompetitiveEventDraftStatus.EditedByModerator, competitiveEventDraft.DraftStatus);
+        
+        var updatedContact = competitiveEventDraft.CompetitiveEventDraftContent.Contacts
+            .FirstOrDefault(c => c.Title == "Main Office");
+
+        Assert.NotNull(updatedContact, "Contact should be found");
+        Assert.AreEqual("Main Office", updatedContact.Title);
+        
+        draftRepoMock.Verify(x => x.Update(It.IsAny<CompetitiveEventDraft>()), Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateDraftAsModeratorAsync_DoesNotUpdateNonMatchingContacts_WhenContactsProvided()
+    {
+        // Arrange
+        var existingContact = new Contacts
+        {
+            Title = "Main Office",            
+        };
+
+        var competitiveEventDraft = GetCompetitiveEventDraft(draftId);
+        competitiveEventDraft.CompetitiveEventDraftContent.Contacts.Add(existingContact);
+        
+        var nonMatchingContactDto = new ContactsDto
+        {
+            Title = "Branch Office", 
+        };
+
+        var dto = GetModeratorCompetitiveEventDraftEditDto();
+        dto.Contacts = new List<ContactsDto> { nonMatchingContactDto };
+
+        currentUserServiceMock
+            .Setup(x => x.UserHasRights(It.IsAny<ModeratorRights>(), It.IsAny<TechAdminRights>()))
+            .Returns(Task.CompletedTask);
+
+        draftRepoMock
+            .Setup(x => x.GetById(It.IsAny<Guid>()))
+            .ReturnsAsync(competitiveEventDraft);
+
+        draftRepoMock.Setup(repo => repo.GetByIdWithDetails(draftId, It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<CompetitiveEventDraft>, IQueryable<CompetitiveEventDraft>>>()))
+            .ReturnsAsync(competitiveEventDraft);
+
+        var originalPhone = existingContact.Phones.First().Number;        
+
+        // Act
+        var result = await service.UpdateDraftAsModeratorAsync(draftId, dto);
+
+        // Assert
+        Assert.IsTrue(result.Succeeded);
+
+        // Verify that the original contact was NOT updated (since title didn't match)
+        var unchangedContact = competitiveEventDraft.CompetitiveEventDraftContent.Contacts
+            .FirstOrDefault(c => c.Title == "Main Office");
+
+        Assert.NotNull(unchangedContact, "Original contact should still exist");
+        Assert.AreEqual(originalPhone, unchangedContact.Phones.First().Number, "Phone should remain unchanged");        
+
+        draftRepoMock.Verify(x => x.Update(It.IsAny<CompetitiveEventDraft>()), Times.Once);
+    }
+
     private CompetitiveEventDraft GetCompetitiveEventDraft(Guid draftId)
     {
         return new CompetitiveEventDraft

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Common.Enums;
-using OutOfSchool.BusinessLogic.Models;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -142,101 +141,55 @@ public class SensitiveCompetitiveEventDraftServiceTest
                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
            Times.Once);
     }
+
+    [Test]
+    public async Task UpdateDraftAsModeratorAsync_UpdatesAllDtoProperties_WhenSuccessful()
+    {
+        // Arrange
+        var dto = new ModeratorCompetitiveEventDraftEditDto
+        {
+            Title = "Updated Title",
+            ShortTitle = "Updated Short Title",
+            DescriptionOfTheEnrollmentProcedure = "Updated Procedure",
+            AdditionalDescription = "Updated Additional Description",
+            VenueName = "Updated Venue",
+            TermsOfParticipation = "Updated Terms",
+            PreferentialTermsOfParticipation = "Updated Preferential Terms",
+            Benefits = "Updated Benefits",
+            Contacts = new List<ContactsDto>()
+        };
+
+        var competitiveEventDraft = GetCompetitiveEventDraft(draftId);
+
+        currentUserServiceMock
+            .Setup(x => x.UserHasRights(It.IsAny<ModeratorRights>(), It.IsAny<TechAdminRights>()))
+            .Returns(Task.CompletedTask);
+
+        draftRepoMock
+            .Setup(x => x.GetById(It.IsAny<Guid>()))
+            .ReturnsAsync(competitiveEventDraft);
+
+        draftRepoMock.Setup(repo => repo.GetByIdWithDetails(draftId, It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<CompetitiveEventDraft>, IQueryable<CompetitiveEventDraft>>>()))
+            .ReturnsAsync(competitiveEventDraft);
+
+        // Act
+        var result = await service.UpdateDraftAsModeratorAsync(draftId, dto);
+
+        // Assert
+        Assert.IsTrue(result.Succeeded);
+
+        // Verify all properties were updated via ToDraft extension method
+        Assert.AreEqual("Updated Title", competitiveEventDraft.CompetitiveEventDraftContent.Title);
+        Assert.AreEqual("Updated Short Title", competitiveEventDraft.CompetitiveEventDraftContent.ShortTitle);
+        Assert.AreEqual("Updated Procedure", competitiveEventDraft.CompetitiveEventDraftContent.DescriptionOfTheEnrollmentProcedure);
+        Assert.AreEqual("Updated Additional Description", competitiveEventDraft.CompetitiveEventDraftContent.AdditionalDescription);
+        Assert.AreEqual("Updated Venue", competitiveEventDraft.CompetitiveEventDraftContent.VenueName);
+        Assert.AreEqual("Updated Terms", competitiveEventDraft.CompetitiveEventDraftContent.TermsOfParticipation);
+        Assert.AreEqual("Updated Preferential Terms", competitiveEventDraft.CompetitiveEventDraftContent.PreferentialTermsOfParticipation);
+        Assert.AreEqual("Updated Benefits", competitiveEventDraft.CompetitiveEventDraftContent.Benefits);
+    }
     
-    [Test]
-    public async Task UpdateDraftAsModeratorAsync_UpdatesContactsCorrectly_WhenContactsProvided()
-    {
-        // Arrange
-        var existingAddress = new Address { Street = "123 Main St" };
-        var existingContact = new Contacts{};
-
-        var competitiveEventDraft = GetCompetitiveEventDraft(draftId);
-        competitiveEventDraft.CompetitiveEventDraftContent.Contacts.Add(existingContact);
-
-        var addressDto = new AddressDto { Street = "123 Main St" };
-        var contactDto = new ContactsDto{};
-
-        var dto = GetModeratorCompetitiveEventDraftEditDto();
-        dto.Contacts = new List<ContactsDto> { contactDto };
-
-        currentUserServiceMock
-            .Setup(x => x.UserHasRights(It.IsAny<ModeratorRights>(), It.IsAny<TechAdminRights>()))
-            .Returns(Task.CompletedTask);
-
-        draftRepoMock
-            .Setup(x => x.GetById(It.IsAny<Guid>()))
-            .ReturnsAsync(competitiveEventDraft);
-
-        draftRepoMock.Setup(repo => repo.GetByIdWithDetails(draftId, It.IsAny<string>(),
-            It.IsAny<Func<IQueryable<CompetitiveEventDraft>, IQueryable<CompetitiveEventDraft>>>()))
-            .ReturnsAsync(competitiveEventDraft);
-
-        // Act
-        var result = await service.UpdateDraftAsModeratorAsync(draftId, dto);
-
-        // Assert
-        Assert.IsTrue(result.Succeeded);
-        Assert.AreEqual(CompetitiveEventDraftStatus.EditedByModerator, competitiveEventDraft.DraftStatus);
-        
-        var updatedContact = competitiveEventDraft.CompetitiveEventDraftContent.Contacts
-            .FirstOrDefault(c => c.Title == "Main Office");
-
-        Assert.NotNull(updatedContact, "Contact should be found");
-        Assert.AreEqual("Main Office", updatedContact.Title);
-        
-        draftRepoMock.Verify(x => x.Update(It.IsAny<CompetitiveEventDraft>()), Times.Once);
-    }
-
-    [Test]
-    public async Task UpdateDraftAsModeratorAsync_DoesNotUpdateNonMatchingContacts_WhenContactsProvided()
-    {
-        // Arrange
-        var existingContact = new Contacts
-        {
-            Title = "Main Office",            
-        };
-
-        var competitiveEventDraft = GetCompetitiveEventDraft(draftId);
-        competitiveEventDraft.CompetitiveEventDraftContent.Contacts.Add(existingContact);
-        
-        var nonMatchingContactDto = new ContactsDto
-        {
-            Title = "Branch Office", 
-        };
-
-        var dto = GetModeratorCompetitiveEventDraftEditDto();
-        dto.Contacts = new List<ContactsDto> { nonMatchingContactDto };
-
-        currentUserServiceMock
-            .Setup(x => x.UserHasRights(It.IsAny<ModeratorRights>(), It.IsAny<TechAdminRights>()))
-            .Returns(Task.CompletedTask);
-
-        draftRepoMock
-            .Setup(x => x.GetById(It.IsAny<Guid>()))
-            .ReturnsAsync(competitiveEventDraft);
-
-        draftRepoMock.Setup(repo => repo.GetByIdWithDetails(draftId, It.IsAny<string>(),
-            It.IsAny<Func<IQueryable<CompetitiveEventDraft>, IQueryable<CompetitiveEventDraft>>>()))
-            .ReturnsAsync(competitiveEventDraft);
-
-        var originalPhone = existingContact.Phones.First().Number;        
-
-        // Act
-        var result = await service.UpdateDraftAsModeratorAsync(draftId, dto);
-
-        // Assert
-        Assert.IsTrue(result.Succeeded);
-
-        // Verify that the original contact was NOT updated (since title didn't match)
-        var unchangedContact = competitiveEventDraft.CompetitiveEventDraftContent.Contacts
-            .FirstOrDefault(c => c.Title == "Main Office");
-
-        Assert.NotNull(unchangedContact, "Original contact should still exist");
-        Assert.AreEqual(originalPhone, unchangedContact.Phones.First().Number, "Phone should remain unchanged");        
-
-        draftRepoMock.Verify(x => x.Update(It.IsAny<CompetitiveEventDraft>()), Times.Once);
-    }
-
     private CompetitiveEventDraft GetCompetitiveEventDraft(Guid draftId)
     {
         return new CompetitiveEventDraft

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
@@ -1,0 +1,207 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using OutOfSchool.BusinessLogic.Services.CompetitiveEventDrafts;
+using OutOfSchool.BusinessLogic.Services.Images;
+using OutOfSchool.BusinessLogic.Services;
+using OutOfSchool.Services.Models.CompetitiveEventDrafts;
+using OutOfSchool.Services.Repository.Api;
+using OutOfSchool.BusinessLogic.Services.SearchString;
+using System.Threading.Tasks;
+using System;
+using System.Linq;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
+using OutOfSchool.Services.Enums.CompetitiveEventStatus;
+using OutOfSchool.Common.Models;
+using OutOfSchool.Services.Models.ContactInfo;
+using System.Collections.Generic;
+using OutOfSchool.BusinessLogic.Models.ContactInfo;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Common.Enums;
+
+namespace OutOfSchool.WebApi.Tests.Services;
+
+[TestFixture]
+public class SensitiveCompetitiveEventDraftServiceTest
+{
+    private CompetitiveEventDraftService service;
+    private Mock<ILogger<CompetitiveEventDraftService>> loggerMock;
+    private Mock<ICompetitiveEventDraftRepository> draftRepoMock;
+    private Mock<ICurrentUserService> currentUserServiceMock;
+    private Mock<ICompetitiveEventServiceV2> competitiveEventServiceMock;
+    private Mock<IImageDependentEntityImagesInteractionService<CompetitiveEventDraft>> imageServiceMock;
+    private Mock<IChangesLogService> changesLogServiceMock;
+    private Mock<ICodeficatorRepository> codeficatorRepoMock;
+
+    Guid draftId = Guid.NewGuid();
+
+    [SetUp]
+    public void Setup()
+    {
+        loggerMock = new Mock<ILogger<CompetitiveEventDraftService>>();
+        draftRepoMock = new Mock<ICompetitiveEventDraftRepository>();
+        currentUserServiceMock = new Mock<ICurrentUserService>();
+        competitiveEventServiceMock = new Mock<ICompetitiveEventServiceV2>();
+        imageServiceMock = new Mock<IImageDependentEntityImagesInteractionService<CompetitiveEventDraft>>();
+        changesLogServiceMock = new Mock<IChangesLogService>();
+        codeficatorRepoMock = new Mock<ICodeficatorRepository>();
+
+
+        service = new CompetitiveEventDraftService(
+            loggerMock.Object,
+            currentUserServiceMock.Object,
+            competitiveEventServiceMock.Object,
+            draftRepoMock.Object,
+            imageServiceMock.Object,
+            changesLogServiceMock.Object,
+            codeficatorRepoMock.Object,
+            new Mock<IRegionAdminService>().Object,
+            new Mock<IMinistryAdminService>().Object,
+            new Mock<ICodeficatorService>().Object,
+            new Mock<ISearchStringService>().Object);
+    }
+
+    [Test]
+    public async Task UpdateDraftAsModeratorAsync_ReturnsFailed_WhenDtoIsNull()
+    {        
+        // Act
+        var result = await service.UpdateDraftAsModeratorAsync(draftId, null);
+
+        // Assert
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual("400", result.OperationResult.Errors.First().Code);
+        Assert.That(result.OperationResult.Errors.First().Description, Does.Contain("Dto must not be null"));
+    }
+
+    [Test]
+    public async Task UpdateDraftAsModeratorAsync_ReturnsSuccess_WhenDtoIsValid()
+    {
+        // Arrange        
+        var dto = GetModeratorCompetitiveEventDraftEditDto();
+
+        var competitiveEventDraft = GetCompetitiveEventDraft(draftId);
+
+        currentUserServiceMock
+            .Setup(x => x.UserHasRights(It.IsAny<ModeratorRights>(), It.IsAny<TechAdminRights>()))
+            .Returns(Task.CompletedTask);
+
+        draftRepoMock
+            .Setup(x => x.GetById(It.IsAny<Guid>()))
+            .ReturnsAsync(competitiveEventDraft);
+
+        draftRepoMock.Setup(repo => repo.GetByIdWithDetails(draftId, It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<CompetitiveEventDraft>, IQueryable<CompetitiveEventDraft>>>()))
+            .ReturnsAsync(competitiveEventDraft);
+
+        // Act
+        var result = await service.UpdateDraftAsModeratorAsync(draftId, dto);
+
+        // Assert
+        Assert.IsTrue(result.Succeeded);
+        Assert.AreEqual(CompetitiveEventDraftStatus.EditedByModerator, competitiveEventDraft.DraftStatus);
+        Assert.NotNull(result.Value);
+        draftRepoMock.Verify(x => x.Update(It.IsAny<CompetitiveEventDraft>()), Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateDraftAsModeratorAsync_UpdatingError_ReturnsMessage()
+    {
+        // Arrange
+        var dto = GetModeratorCompetitiveEventDraftEditDto();
+        var competitiveEventDraft = GetCompetitiveEventDraft(draftId);
+
+        currentUserServiceMock
+            .Setup(x => x.UserHasRights(It.IsAny<ModeratorRights>(), It.IsAny<TechAdminRights>()))
+            .Returns(Task.CompletedTask);
+
+        draftRepoMock
+            .Setup(x => x.GetById(It.IsAny<Guid>()))
+            .ReturnsAsync(competitiveEventDraft);
+
+        draftRepoMock.Setup(repo => repo.GetByIdWithDetails(draftId, It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<CompetitiveEventDraft>, IQueryable<CompetitiveEventDraft>>>()))
+            .ReturnsAsync(competitiveEventDraft);
+        
+        draftRepoMock
+            .Setup(x => x.Update(It.IsAny<CompetitiveEventDraft>()))
+            .ThrowsAsync(new Exception("Database update failed"));
+
+        // Act
+        var result = await service.UpdateDraftAsModeratorAsync(draftId, dto);
+
+        // Assert
+        Assert.IsFalse(result.Succeeded);
+
+        loggerMock.Verify(
+           x => x.Log(
+               LogLevel.Error,
+               It.IsAny<EventId>(),
+               It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Error occurred while updating CompetitiveEventDraft")),
+               It.IsAny<Exception>(),
+               It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+           Times.Once);
+    }
+    
+    private CompetitiveEventDraft GetCompetitiveEventDraft(Guid draftId)
+    {
+        return new CompetitiveEventDraft
+        {
+            Id = draftId,
+            DraftStatus = CompetitiveEventDraftStatus.PendingModeration,
+            CompetitiveEventDraftContent = new CompetitiveEventDraftContent
+            {
+                Title = "Some title",
+                ShortTitle = "Short title",
+                DescriptionOfTheEnrollmentProcedure = "Procedure",
+                Contacts = new List<Contacts>
+                {
+                    new Contacts
+                    {
+
+                    }
+                }
+            },
+            Provider = new Provider
+            {
+                Edrpou = "12345678",
+                Positions = new List<Position>
+                {
+                    new Position
+                    {
+                        FullName = "ddd",
+                        Officials = new List<Official>
+                        {
+                            new Official
+                            {
+                                Position = new Position { PositionType = PositionType.Director},
+                                Individual = new Individual
+                                {
+                                    FirstName = "aaa",
+                                    LastName = "aaa",
+                                    MiddleName = "aaa"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    private ModeratorCompetitiveEventDraftEditDto GetModeratorCompetitiveEventDraftEditDto()
+    {
+        return new ModeratorCompetitiveEventDraftEditDto
+        {
+            Title = "Title",
+            ShortTitle = "Title",
+            DescriptionOfTheEnrollmentProcedure = "Description",
+            Contacts = new List<ContactsDto>
+            {
+                new ContactsDto
+                {
+                    Title = "pppp"
+                }
+            }
+        };
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventDraftController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventDraftController.cs
@@ -444,6 +444,28 @@ public class CompetitiveEventDraftController : ControllerBase
         return this.ToActionResult(result);
     }
 
+    /// <summary>
+    /// Updates competitive event draft  by a user with permission to moderate drafts.
+    /// </summary>
+    /// <param name="draftId">The ID of the draft.</param>
+    /// <param name="dto">The competitive event draft dto to update</param>
+    /// <returns>Returns <see cref="CompetitiveEventDraftResponseDto"/></returns>
+    [HttpPut("/api/v{version:apiVersion}/competitions-drafts/{draftId}/moderator-edit")]
+    [HasPermission(Permissions.CompetitiveEventApprove)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CompetitiveEventDraftResponseDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> UpdateAsModerator(Guid draftId, [FromBody] ModeratorCompetitiveEventDraftEditDto dto)
+    {
+        var result = await sensitiveCompetitiveEventDraftService.UpdateDraftAsModeratorAsync(draftId, dto);
+
+        return this.ToActionResult(result);
+    }
+
     private async Task<IActionResult> ValidateProvider(Guid providerId)
     {
         var isBlocked = await providerService.IsBlocked(providerId).ConfigureAwait(false);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint allowing moderators to update competitive event drafts, including detailed contact and descriptive information.
  * Moderators can now edit drafts with enhanced validation and status tracking.
* **Bug Fixes**
  * Improved error handling and validation for moderator updates to event drafts.
* **Tests**
  * Introduced comprehensive unit tests for moderator draft editing, covering success, validation failures, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->