### PR TITLE
Tkyryk/Add BaseImageUrl support and improve DaysBitMask mapping

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftToSportSectionExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftToSportSectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using OutOfSchool.Common.Enums;
+using OutOfSchool.Services.Enums;
 using OutOfSchool.SportsRegistryApiClient.Models.Enums;
 using OutOfSchool.SportsRegistryApiClient.Models.Requests;
 
@@ -13,7 +14,7 @@ public static class WorkshopDraftToSportSectionExtensions
         {
             OrganizationCode = draft.Provider.Edrpou,
             SectionName = content.Title,
-            
+
             //SectionSportKindDictIdCode = 1,  не мапити //Ідентифікатор виду спорту з довідника 
 
             SectionAgeFrom = content.MinAge,
@@ -29,10 +30,10 @@ public static class WorkshopDraftToSportSectionExtensions
 
             SectionRegistrationFlow = content.EnrollmentProcedureDescription,
 
-            SectionPhones = defaultContact?.Phones.Select(p => p.Number).Distinct().ToList()?? [],
+            SectionPhones = defaultContact?.Phones.Select(p => p.Number).Distinct().ToList() ?? [],
 
             SectionEmail = content.Contacts.Where(c => c.IsDefault).FirstOrDefault().Emails.FirstOrDefault().Address,
-            
+
             SectionRegistrationFormUrl = null, // what field does it map from?
 
             SectionUrl = defaultContact?.SocialNetworks
@@ -43,14 +44,14 @@ public static class WorkshopDraftToSportSectionExtensions
 
             SectionInstagramUrl = defaultContact?.SocialNetworks
             .FirstOrDefault(s => s.Type == SocialNetworkContactType.Instagram)?.Url,
-            
+
             SectionPracticeFormat = content.FormOfLearning.ToSectionPracticeFormat(), // ONLINE / OFFLINE / HYBRID
 
             SectionSelectionCriteria = content.CompetitiveSelectionDescription,
 
             SectionPracticeCost = content.Price,
 
-            SectionMaxStudentsAmount = content.AvailableSeats == uint.MaxValue 
+            SectionMaxStudentsAmount = content.AvailableSeats == uint.MaxValue
             ? 1000 : (int)content.AvailableSeats,
 
             //SectionTitlePhoto = string.IsNullOrEmpty(draft.CoverImageId) // TODO
@@ -66,14 +67,23 @@ public static class WorkshopDraftToSportSectionExtensions
             SectionPracticePeriodDateFrom = content.StudyPeriodStartDate.ToString("dd:MM"),
             SectionPracticePeriodDateTo = content.StudyPeriodEndDate.ToString("dd:MM"),
 
-            SectionSchedule = content.DateTimeRanges?
-            .SelectMany(r => r.Workdays.Select(day => new SectionScheduleRequest
-            {
-                SectionScheduleWeekday = Enum.Parse<Weekday>(day.ToString(), ignoreCase: true),
-                SectionScheduleTimeFrom = r.StartTime.ToString("HH:mm:ss"),
-                SectionScheduleTimeTo = r.EndTime.ToString("HH:mm:ss"),
-            }))
-            .ToList() ?? new(),
+            //SectionSchedule = content.DateTimeRanges?
+            //.SelectMany(r => r.Workdays.Select(day => new SectionScheduleRequest
+            //{
+            //    SectionScheduleWeekday = Enum.Parse<Weekday>(day.ToString(), ignoreCase: true),
+            //    SectionScheduleTimeFrom = r.StartTime.ToString("HH:mm:ss"),
+            //    SectionScheduleTimeTo = r.EndTime.ToString("HH:mm:ss"),
+            //}))
+            //.ToList() ?? new(),
+            SectionSchedule = content.DateTimeRanges?.SelectMany(r =>
+                 r.Workdays
+                .SelectMany(flags => DecomposeFlags(flags)
+                .Select(day => new SectionScheduleRequest
+                {
+                    SectionScheduleWeekday = Enum.Parse<Weekday>(day.ToString(), ignoreCase: true),
+                    SectionScheduleTimeFrom = r.StartTime.ToString("HH:mm:ss"),
+                    SectionScheduleTimeTo = r.EndTime.ToString("HH:mm:ss"),
+                }))).ToList() ?? new(),
         };
     }
     public static SectionPracticeFormat ToSectionPracticeFormat(this FormOfLearning formOfLearning)
@@ -86,4 +96,10 @@ public static class WorkshopDraftToSportSectionExtensions
             _ => throw new ArgumentOutOfRangeException(nameof(formOfLearning), formOfLearning, "Unsupported learning format. Must be Online, Offline or Mixed."),
         };
     }
+    public static IEnumerable<DaysBitMask> DecomposeFlags(DaysBitMask flags)
+    {
+        return Enum.GetValues<DaysBitMask>()
+            .Where(d => d != DaysBitMask.None && flags.HasFlag(d));
+    }
+
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftToSportSectionExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftToSportSectionExtensions.cs
@@ -2,11 +2,12 @@
 using OutOfSchool.Services.Enums;
 using OutOfSchool.SportsRegistryApiClient.Models.Enums;
 using OutOfSchool.SportsRegistryApiClient.Models.Requests;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OutOfSchool.BusinessLogic.Models.WorkshopDraft;
 public static class WorkshopDraftToSportSectionExtensions
 {
-    public static SportsSectionPostRequest ToSportSectionPostRequest(this OutOfSchool.Services.Models.WorkshopDrafts.WorkshopDraft draft, string baseImageUrl)
+    public static SportsSectionPostRequest ToSportSectionPostRequest(this OutOfSchool.Services.Models.WorkshopDrafts.WorkshopDraft draft, [NotNull] string baseImageUrl) // check not null
     {
         var content = draft.WorkshopDraftContent;
         var defaultContact = content.Contacts?.FirstOrDefault(c => c.IsDefault);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftToSportSectionExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftToSportSectionExtensions.cs
@@ -6,7 +6,7 @@ using OutOfSchool.SportsRegistryApiClient.Models.Requests;
 namespace OutOfSchool.BusinessLogic.Models.WorkshopDraft;
 public static class WorkshopDraftToSportSectionExtensions
 {
-    public static SportsSectionPostRequest ToSportSectionPostRequest(this OutOfSchool.Services.Models.WorkshopDrafts.WorkshopDraft draft)
+    public static SportsSectionPostRequest ToSportSectionPostRequest(this OutOfSchool.Services.Models.WorkshopDrafts.WorkshopDraft draft, string baseImageUrl)
     {
         var content = draft.WorkshopDraftContent;
         var defaultContact = content.Contacts?.FirstOrDefault(c => c.IsDefault);
@@ -54,12 +54,13 @@ public static class WorkshopDraftToSportSectionExtensions
             SectionMaxStudentsAmount = content.AvailableSeats == uint.MaxValue
             ? 1000 : (int)content.AvailableSeats,
 
-            //SectionTitlePhoto = string.IsNullOrEmpty(draft.CoverImageId) // TODO
-            //? null
-            //: $"{baseUrl}{draft.CoverImageId}", //  add full url (baseurl)
+            SectionTitlePhoto = string.IsNullOrEmpty(draft.CoverImageId) // TODO
+            ? null
+            : CombineImageUrl(baseImageUrl, draft.CoverImageId),
 
             SectionPhotos = draft.Images? // TODO
-            .Select(img => img.ExternalStorageId)
+            .Where(img => !string.IsNullOrWhiteSpace(img.ExternalStorageId))
+            .Select(img => CombineImageUrl(baseImageUrl, img.ExternalStorageId))
             .ToList() ?? new(),
 
             SectionTrainers = [], // TODO: make mapping when teachers will be added to the draft
@@ -101,5 +102,8 @@ public static class WorkshopDraftToSportSectionExtensions
         return Enum.GetValues<DaysBitMask>()
             .Where(d => d != DaysBitMask.None && flags.HasFlag(d));
     }
-
+    private static string CombineImageUrl(string baseUrl, string imageId)
+    {
+        return $"{baseUrl.TrimEnd('/')}/{imageId.TrimStart('/')}";  //$"{baseImageUrl}{draft.CoverImageId}"
+    }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -347,9 +347,8 @@ public class WorkshopDraftService(
             // push sport Api
             // <- section ID 
             // workshopDraft.sectionID = sectionId;
-            var options = imageStorageOptions.Value.BaseImageUrl;
-            var sportSectionPostRequest = workshopDraft.ToSportSectionPostRequest(options);
-
+            //var baseUrl = imageStorageOptions.Value.BaseImageUrl;
+            //var sportSectionPostRequest = workshopDraft.ToSportSectionPostRequest(baseUrl);
             await workshopServicesCombinerV2.Create(workshopDraft.ToV2CreateRequestDto());
         }
         else

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -64,7 +64,8 @@ public class WorkshopDraftService(
     IInstitutionHierarchyRepository institutionHierarchyRepository,
     ICodeficatorRepository codeficatorRepository,
     IChangesLogService changesLogService,
-    IOptions<InstitutionOptions> institutionSettings
+    IOptions<InstitutionOptions> institutionSettings,
+    IOptions<ImageStorageOptions> imageStorageOptions
 ) : IWorkshopDraftService, ISensitiveWorkshopDraftService
 {
     private readonly int maxParallelUploads = options.Value.MaxParallelImageUploads;
@@ -342,12 +343,13 @@ public class WorkshopDraftService(
 
         if (workshopDraft.WorkshopId == null)
         {
-            
             // draft -> sport registry
             // push sport Api
             // <- section ID 
             // workshopDraft.sectionID = sectionId;
-            
+            var options = imageStorageOptions.Value.BaseImageUrl;
+            var sportSectionPostRequest = workshopDraft.ToSportSectionPostRequest(options);
+
             await workshopServicesCombinerV2.Create(workshopDraft.ToV2CreateRequestDto());
         }
         else

--- a/OutOfSchool/OutOfSchool.Common/Config/ImageStorageOptions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Config/ImageStorageOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace OutOfSchool.Common.Config;
+public class ImageStorageOptions
+{
+    public const string Name = "ImageStorage";
+    public string BaseImageUrl { get; set; } = string.Empty;
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveWorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveWorkshopDraftServiceTests.cs
@@ -88,6 +88,7 @@ public class SensitiveWorkshopDraftServiceTests
         var logger = new Mock<ILogger<WorkshopDraftService>>();
         var teacherDraftImagesService = new Mock<IEntityCoverImageInteractionService<TeacherDraft>>();
         var institutionOptionsMock = new Mock<IOptions<InstitutionOptions>>();
+        var imageStorageOptionsMock = new Mock<IOptions<ImageStorageOptions>>();
 
         userId = "someUserId";
 
@@ -109,7 +110,8 @@ public class SensitiveWorkshopDraftServiceTests
                    institutionHierarchyRepositoryMock.Object,
                    codeficatorRepository.Object,
                    changesLogServiceMock.Object,
-                   institutionOptionsMock.Object);
+                   institutionOptionsMock.Object,
+                   imageStorageOptionsMock.Object);
 
         SetupModeratorTestData();
         languageServiceMock.Setup(x => x.GetById(It.Is<long>(id => id == 1)))

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -56,6 +56,7 @@ public class WorkshopDraftServiceTests
     private Mock<ICodeficatorRepository> codeficatorRepositoryMoq;
     private Mock<IChangesLogService> changesLogServiceMock;
     private Mock<IOptions<InstitutionOptions>> institutionOptionsMock;
+    private Mock<IOptions<ImageStorageOptions>> imageStorageOptionsMock;
 
     private string userId;
 
@@ -120,7 +121,8 @@ public class WorkshopDraftServiceTests
                    institutionHierarchyRepositoryMoq.Object,
                    codeficatorRepositoryMoq.Object,
                    changesLogServiceMock.Object,
-                   institutionOptionsMock.Object);
+                   institutionOptionsMock.Object,
+                   imageStorageOptionsMock.Object);
         SetupInstitutionHierarchy();
     }
 
@@ -1009,7 +1011,8 @@ public class WorkshopDraftServiceTests
                    institutionHierarchyRepositoryMoq.Object,
                    codeficatorRepositoryMoq.Object,
                    new Mock<IChangesLogService>().Object,
-                   institutionOptionsMock.Object);
+                   institutionOptionsMock.Object,
+                   imageStorageOptionsMock.Object);
 
         // Act & Assert
         Assert.ThrowsAsync<InvalidOperationException>(() => service.CreateDraftForReactivation(workshop.Id));

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -56,6 +56,7 @@ public class WorkshopDraftServiceTests
     private Mock<ICodeficatorRepository> codeficatorRepositoryMoq;
     private Mock<IChangesLogService> changesLogServiceMock;
     private Mock<IOptions<InstitutionOptions>> institutionOptionsMock;
+    private Mock<IOptions<ImageStorageOptions>> imageStorageOptionsMock;
 
     private string userId;
 
@@ -101,6 +102,13 @@ public class WorkshopDraftServiceTests
         institutionOptionsMock.Setup(x => x.Value)
             .Returns(new InstitutionOptions { MinistryOfSportTitle = "Мінспорт" });
       
+        imageStorageOptionsMock = new Mock<IOptions<ImageStorageOptions>>();
+        imageStorageOptionsMock.Setup(x => x.Value)
+            .Returns(new ImageStorageOptions
+            {
+                BaseImageUrl = "https://replace_me.com/images/"
+            });
+
         userId = "someUserId";
         service = new WorkshopDraftService(
                    logger.Object,
@@ -120,7 +128,8 @@ public class WorkshopDraftServiceTests
                    institutionHierarchyRepositoryMoq.Object,
                    codeficatorRepositoryMoq.Object,
                    changesLogServiceMock.Object,
-                   institutionOptionsMock.Object);
+                   institutionOptionsMock.Object,
+                   imageStorageOptionsMock.Object);
         SetupInstitutionHierarchy();
     }
 
@@ -1009,7 +1018,8 @@ public class WorkshopDraftServiceTests
                    institutionHierarchyRepositoryMoq.Object,
                    codeficatorRepositoryMoq.Object,
                    new Mock<IChangesLogService>().Object,
-                   institutionOptionsMock.Object);
+                   institutionOptionsMock.Object,
+                   imageStorageOptionsMock.Object);
 
         // Act & Assert
         Assert.ThrowsAsync<InvalidOperationException>(() => service.CreateDraftForReactivation(workshop.Id));

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -177,6 +177,7 @@ public static class Startup
         services.Configure<GeocodingConfig>(configuration.GetSection(GeocodingConfig.Name));
         services.Configure<ParentConfig>(configuration.GetSection(ParentConfig.Name));
         services.Configure<InstitutionOptions>(configuration.GetSection(InstitutionOptions.Name));
+        services.Configure<ImageStorageOptions>(configuration.GetSection(ImageStorageOptions.Name));
 
         services.AddMemoryCache();
 

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Development.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Development.json
@@ -83,5 +83,8 @@
     "TokenUrl": "https://platform-keycloak.apps.sandbox.edu.registry.eua.gov.ua/auth/realms/mkcons-dev-external-system/protocol/openid-connect/token",
     "ClientId": "after-school",
     "ClientSecret": "replace_me"
+  },
+  "ImageStorage": {
+    "BaseImageUrl": "https:/replace_me.com/images/"
   }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Development.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Development.json
@@ -83,8 +83,5 @@
     "TokenUrl": "https://platform-keycloak.apps.sandbox.edu.registry.eua.gov.ua/auth/realms/mkcons-dev-external-system/protocol/openid-connect/token",
     "ClientId": "after-school",
     "ClientSecret": "replace_me"
-  },
-  "ImageStorage": {
-    "BaseImageUrl": "https:/replace_me.com/images/"
   }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -357,6 +357,9 @@
   },
   "InstitutionOptions": {
     "MinistryOfSportTitle": "Мінспорт"
+  },
+  "ImageStorage": {
+    "BaseImageUrl": "https:/replace_me.com/images/"
   }
 }
 

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -177,7 +177,9 @@
       }
     }
   },
-
+  "ImageStorage": {
+    "BaseImageUrl": "https:/replace_me.com/images/"
+  },
   "FeatureManagement": {
     "Release1": true,
     "Release2": true,
@@ -357,9 +359,6 @@
   },
   "InstitutionOptions": {
     "MinistryOfSportTitle": "Мінспорт"
-  },
-  "ImageStorage": {
-    "BaseImageUrl": "https:/replace_me.com/images/"
   }
 }
 


### PR DESCRIPTION
Added support for building full image URLs using BaseImageUrl from config (ImageStorageOptions via IOptions).
Updated mapping of SectionTitlePhoto to use full image URL.
Improved SectionSchedule mapping: now supports flag enum DaysBitMask (e.g. Monday | Wednesday).
Updated appsettings.json with ImageStorage.BaseImageUrl.