### PR TITLE
Fixed enum naming for sync with an external platform

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Exported/Workshops/WorkshopInfoDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Exported/Workshops/WorkshopInfoDto.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using OutOfSchool.BusinessLogic.Models.Exported.Contacts;
-using OutOfSchool.BusinessLogic.Models.Exported.Providers;
 using OutOfSchool.BusinessLogic.Util.CustomValidation;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Enums.Workshop;
@@ -49,7 +48,7 @@ public class WorkshopInfoDto : WorkshopInfoBaseDto, IExternalRatingInfo
     public decimal? Price { get; set; } = default;
 
     [EnumDataType(typeof(PayRateType), ErrorMessage = Constants.EnumErrorMessage)]
-    public PayRateType? PayRate { get; set; } = PayRateType.Classes;
+    public PayRateType? PayRate { get; set; } = PayRateType.Class;
 
     [Required(ErrorMessage = "Form of learning is required")]
     [EnumDataType(typeof(FormOfLearning), ErrorMessage = Constants.EnumErrorMessage)]

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/TempSave/WorkshopRequiredPropertiesDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/TempSave/WorkshopRequiredPropertiesDto.cs
@@ -39,7 +39,7 @@ public class WorkshopRequiredPropertiesDto : WorkshopMainRequiredPropertiesDto
 
     [EnumDataType(typeof(PayRateType), ErrorMessage = Constants.EnumErrorMessage)]
     [RequiredIf(nameof(IsPaid), true, ErrorMessage = "PayRate is required")]
-    public PayRateType? PayRate { get; set; } = PayRateType.Classes;
+    public PayRateType? PayRate { get; set; } = PayRateType.Class;
 
     public bool AreThereBenefits { get; set; } = default;
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
 using OutOfSchool.BusinessLogic.Util.CustomValidation;
@@ -7,8 +9,6 @@ using OutOfSchool.BusinessLogic.Validators;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Enums.Workshop;
 using OutOfSchool.Services.Enums;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace OutOfSchool.BusinessLogic.Models.Workshops;
 
@@ -48,7 +48,7 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
     public decimal? Price { get; set; } = default;
 
     [EnumDataType(typeof(PayRateType), ErrorMessage = Constants.EnumErrorMessage)]
-    public PayRateType? PayRate { get; set; } = PayRateType.Classes;
+    public PayRateType? PayRate { get; set; } = PayRateType.Class;
 
     [Required(ErrorMessage = "Form of learning is required")]
     [EnumDataType(typeof(FormOfLearning), ErrorMessage = Constants.EnumErrorMessage)]

--- a/OutOfSchool/OutOfSchool.Common/Enums/PayRateType.cs
+++ b/OutOfSchool/OutOfSchool.Common/Enums/PayRateType.cs
@@ -6,7 +6,7 @@ namespace OutOfSchool.Common.Enums;
 public enum PayRateType
 {
     None,
-    Classes,
+    Class,
     Month,
     Day,
     Year,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the "Classes" option in the pay rate selection to "Class" across all relevant sections.
  * Updated default pay rate values to use "Class" instead of "Classes" in workshop-related forms and data.
* **Style**
  * Minor improvements to code organization (no impact on user experience).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->