### PR TITLE
Retain existing images when approving a raft of a new workshop

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2CreateRequestDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2CreateRequestDto.cs
@@ -60,6 +60,8 @@ public static class WorkshopV2CreateRequestDtoExtensions
             Contacts = dto.Contacts?.ToModel() ?? [],
             LanguageOfEducationId = dto.LanguageOfEducationId,
             IsChampionPath = dto.IsChampionPath,
+            // If we're converting from draft, we need to keep cover image
+            CoverImageId = dto.CoverImageId.IsNullOrEmpty() ? null : dto.CoverImageId,
         };
 
     public static WorkshopV2CreateRequestDto ToV2CreateRequestDto(this OutOfSchool.Services.Models.WorkshopDrafts.WorkshopDraft draft)
@@ -104,6 +106,7 @@ public static class WorkshopV2CreateRequestDtoExtensions
             Teachers = draft.Teachers?.Where(x => !x.IsDefaultTeacher).ToDto() ?? [],
 
             CoverImageId = draft.CoverImageId,
+            ImageIds = draft.Images?.Select(i => i.ExternalStorageId).ToList() ?? [],
             IsChampionPath = draft.WorkshopDraftContent?.IsChampionPath ?? default,
         };
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -136,9 +136,15 @@ public class WorkshopService(
 
             if (dto.ImageFiles?.Count > 0)
             {
-                workshop.Images = new List<Image<Workshop>>();
+                workshop.Images = [];
                 imagesUploadingResult = await workshopImagesService.AddManyImagesAsync(workshop, dto.ImageFiles)
                     .ConfigureAwait(false);
+            }
+            // we are saving draft as new workshop
+            else if(dto.ImageIds?.Count > 0)
+            {
+                workshop.Images = [];
+                workshop.Images.AddRange(dto.ImageIds.Select(id => new Image<Workshop>{ ExternalStorageId = id }));
             }
 
             Result<string> uploadingCoverImageResult = null;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -141,10 +141,11 @@ public class WorkshopService(
                     .ConfigureAwait(false);
             }
             // we are saving draft as new workshop
-            else if(dto.ImageIds?.Count > 0)
+            else if (dto.ImageIds?.Count > 0)
             {
-                workshop.Images = [];
-                workshop.Images.AddRange(dto.ImageIds.Select(id => new Image<Workshop>{ ExternalStorageId = id }));
+                workshop.Images ??= [];
+                workshop.Images.AddRange(dto.ImageIds.Where(id => !string.IsNullOrWhiteSpace(id)).Distinct()
+                    .Select(id => new Image<Workshop> {ExternalStorageId = id}));
             }
 
             Result<string> uploadingCoverImageResult = null;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -331,7 +331,7 @@ public class WorkshopDraftService(
 
         logger.LogDebug("Approving WorkshopDraft started. WorkshopDraft Id = {Id}.", id);
 
-        var workshopDraft = await GetWorkshopDraftById(id);
+        var workshopDraft = await GetWorkshopDraftByIdWithImages(id);
 
         if (workshopDraft.DraftStatus != WorkshopDraftStatus.PendingModeration &&
             workshopDraft.DraftStatus != WorkshopDraftStatus.EditedByModerator)
@@ -826,7 +826,26 @@ public class WorkshopDraftService(
                 paramName: $"There are no records in workshopDrafts table with such id - {id}.");
         }
 
-        logger.LogDebug("Got a WorkshopDraft with Id = {Id}.", id);
+        logger.LogDebug("Got a WorkshopDraft with Id = {Id}", id);
+
+        return workshopDraft;
+    }
+    
+    private async Task<WorkshopDraft> GetWorkshopDraftByIdWithImages(Guid id)
+    {
+        logger.LogDebug("Getting WorkshopDraft by Id started. Looking Id = {Id}.", id);
+
+        var workshopDraft = await workshopDraftRepository.GetByIdWithDetails(id, includeExpression: query =>
+            query.Include(wd => wd.Images));
+
+        if (workshopDraft == null)
+        {
+            throw new ArgumentException(
+                nameof(id),
+                paramName: $"There are no records in workshopDrafts table with such id - {id}.");
+        }
+
+        logger.LogDebug("Got a WorkshopDraft with Id = {Id}", id);
 
         return workshopDraft;
     }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -291,7 +291,7 @@ public class WorkshopDraftService(
     {
         logger.LogDebug("Deleting WorkshopDraft started. WorkshopDraft Id = {Id}.", id);
 
-        var workshopDraft = await GetWorkshopDraftById(id);
+        var workshopDraft = await this.GetWorkshopDraftByIdWithImages(id);
 
         await currentUserService.UserHasRights(new ProviderRights(workshopDraft.ProviderId), new EmployeeRights(workshopDraft.ProviderId)).ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/WorkshopDraftRepository/WorkshopDraftRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/WorkshopDraftRepository/WorkshopDraftRepository.cs
@@ -31,6 +31,7 @@ public class WorkshopDraftRepository : EntityRepository<Guid, WorkshopDraft>, IW
     {
        try
        {
+            entity.Images.ForEach(i => dbContext.Entry(i).State = EntityState.Deleted);
             dbContext.Entry(entity).State = EntityState.Deleted;
 
             await dbContext.SaveChangesAsync()
@@ -42,7 +43,7 @@ public class WorkshopDraftRepository : EntityRepository<Guid, WorkshopDraft>, IW
             {
                 throw;
             }
-        }
+       }
     }
 
     /// <inheritdoc/>

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/WorkshopDraftRepository/WorkshopDraftRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/WorkshopDraftRepository/WorkshopDraftRepository.cs
@@ -31,7 +31,7 @@ public class WorkshopDraftRepository : EntityRepository<Guid, WorkshopDraft>, IW
     {
        try
        {
-            entity.Images.ForEach(i => dbContext.Entry(i).State = EntityState.Deleted);
+            entity.Images?.ForEach(i => dbContext.Entry(i).State = EntityState.Deleted);
             dbContext.Entry(entity).State = EntityState.Deleted;
 
             await dbContext.SaveChangesAsync()

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -611,7 +611,7 @@ public class WorkshopDraftServiceTests
         var workshopV2Dto = workshop.ToV2Dto();
         var workshopDraft = workshopV2Dto.ToDraft();
 
-        workshopDraftRepoMoq.Setup(x => x.GetById(It.IsAny<Guid>()))
+        workshopDraftRepoMoq.Setup(x => x.GetByIdWithDetails(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Func<IQueryable<WorkshopDraft>,IQueryable<WorkshopDraft>>>()))
             .ReturnsAsync(workshopDraft).Verifiable(Times.Once);
         workshopDraftRepoMoq.Setup(x => x.Delete(It.IsAny<WorkshopDraft>()))
             .Returns(Task.CompletedTask).Verifiable(Times.Once);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -1,4 +1,9 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -31,11 +36,6 @@ using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.Services.Repository.Base.Api;
 using OutOfSchool.Tests.Common;
 using OutOfSchool.Tests.Common.TestDataGenerators;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -78,11 +78,11 @@ public class WorkshopDraftServiceTests
         institutionHierarchyRepositoryMoq.Setup(x => x.GetByIdWithDetails(
             It.IsAny<Guid>(),
             It.IsAny<string>(),
-            It.IsAny<Func<IQueryable<OutOfSchool.Services.Models.SubordinationStructure.InstitutionHierarchy>, IQueryable<OutOfSchool.Services.Models.SubordinationStructure.InstitutionHierarchy>>>()
-        )).ReturnsAsync(new OutOfSchool.Services.Models.SubordinationStructure.InstitutionHierarchy
+            It.IsAny<Func<IQueryable<InstitutionHierarchy>, IQueryable<InstitutionHierarchy>>>()
+        )).ReturnsAsync(new InstitutionHierarchy
         {
             SubDirections = new List<SubDirection>(),
-            Institution = new OutOfSchool.Services.Models.SubordinationStructure.Institution { Title = "Мінспорт" }
+            Institution = new Institution { Title = "Мінспорт" }
         });
 
         var options = new Mock<IOptions<UploadConcurrencySettings>>();
@@ -659,7 +659,7 @@ public class WorkshopDraftServiceTests
         workshopDraft.DraftStatus = WorkshopDraftStatus.PendingModeration;
         workshopDraft.WorkshopId = null;
 
-        workshopDraftRepoMoq.Setup(x => x.GetById(It.IsAny<Guid>()))
+        workshopDraftRepoMoq.Setup(x => x.GetByIdWithDetails(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Func<IQueryable<WorkshopDraft>,IQueryable<WorkshopDraft>>>()))
             .ReturnsAsync(workshopDraft).Verifiable(Times.Once);
         workshopDraftRepoMoq.Setup(x => x.Delete(It.IsAny<WorkshopDraft>()))
             .Returns(Task.CompletedTask).Verifiable(Times.Once);
@@ -683,7 +683,7 @@ public class WorkshopDraftServiceTests
         var workshopDraft = workshopV2Dto.ToDraft();
         workshopDraft.DraftStatus = WorkshopDraftStatus.PendingModeration;   
 
-        workshopDraftRepoMoq.Setup(x => x.GetById(It.IsAny<Guid>()))
+        workshopDraftRepoMoq.Setup(x => x.GetByIdWithDetails(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Func<IQueryable<WorkshopDraft>,IQueryable<WorkshopDraft>>>()))
             .ReturnsAsync(workshopDraft).Verifiable(Times.Once);
         workshopDraftRepoMoq.Setup(x => x.Delete(It.IsAny<WorkshopDraft>()))
             .Returns(Task.CompletedTask).Verifiable(Times.Once);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for preserving and transferring multiple image references when creating or approving workshop drafts.
  * Workshop drafts now retain their cover image and associated images when converted or approved.

* **Bug Fixes**
  * Deleting a workshop draft now also removes all its associated images.

* **Tests**
  * Updated tests to reflect changes in how workshop drafts and their images are fetched and handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->