### PR TITLE
Add sports registry fields

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/SubordinationStructure/InstitutionHierarchyDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/SubordinationStructure/InstitutionHierarchyDto.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace OutOfSchool.BusinessLogic.Models.SubordinationStructure;
 
@@ -20,6 +21,10 @@ public class InstitutionHierarchyDto
     public InstitutionDto Institution { get; set; }
 
     public List<SubDirectionDto> SubDirections { get; set; }
+    
+    // Not needed on frontend, used in service logic
+    [JsonIgnore]
+    public long? SportRegistryIdCode { get; set; }
 }
 
 public static class InstitutionHierarchyDtoExtensions
@@ -52,12 +57,13 @@ public static class InstitutionHierarchyDtoExtensions
         => new()
         {
             Id = model.Id,
-            Title = model.Title,
+            Title = model.SportsSectionNumeral.IsNullOrEmpty() ? model.Title : $"{model.SportsSectionNumeral}. {model.Title}",
             HierarchyLevel = model.HierarchyLevel,
             ParentId = model.ParentId,
             InstitutionId = model.InstitutionId,
             Institution = model.Institution?.ToDto(),
-            SubDirections = model.SubDirections?.ToDto() ?? []
+            SubDirections = model.SubDirections?.ToDto() ?? [],
+            SportRegistryIdCode = model.SportRegistryIdCode,
         };
 
     public static List<InstitutionHierarchyDto> ToDto(this IEnumerable<InstitutionHierarchy> list)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/TeacherDraft/TeacherDraftDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/TeacherDraft/TeacherDraftDto.cs
@@ -1,9 +1,8 @@
-﻿using Newtonsoft.Json;
+﻿using System.ComponentModel.DataAnnotations;
 using OutOfSchool.Common.Validators;
 using OutOfSchool.Services.Enums;
-using System.ComponentModel.DataAnnotations;
 
-namespace OutOfSchool.BusinessLogic.Models.WorkshopDraft.TeacherDrafts;
+namespace OutOfSchool.BusinessLogic.Models.WorkshopDraft.TeacherDraft;
 
 public class TeacherDraftDto
 {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/TeacherDraft/TeacherDraftResponseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/TeacherDraft/TeacherDraftResponseDto.cs
@@ -1,4 +1,6 @@
-﻿namespace OutOfSchool.BusinessLogic.Models.WorkshopDraft.TeacherDrafts;
+﻿using OutOfSchool.BusinessLogic.Models.WorkshopDraft.TeacherDraft;
+
+namespace OutOfSchool.BusinessLogic.Models.WorkshopDraft.TeacherDrafts;
 
 public class TeacherDraftResponseDto : TeacherDraftDto
 {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/AreaAdminService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/AreaAdminService.cs
@@ -1,7 +1,6 @@
 using System.Linq.Expressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.Common.Communication;
@@ -129,8 +128,8 @@ public class AreaAdminService(
                     Message = r.Message,
                 })
             .Map(result => result.Result is not null
-                ? JsonConvert
-                    .DeserializeObject<AreaAdminBaseDto>(result.Result.ToString())
+                ? JsonSerializerHelper
+                    .Deserialize<AreaAdminBaseDto>(result.Result.ToString())
                 : null);
     }
 
@@ -270,7 +269,7 @@ public class AreaAdminService(
                     Message = r.Message,
                 })
             .Map(result => result.Result is not null
-                ? JsonConvert.DeserializeObject<AreaAdminBaseDto>(result.Result.ToString()).ToDto()
+                ? JsonSerializerHelper.Deserialize<AreaAdminBaseDto>(result.Result.ToString()).ToDto()
                 : null);
     }
 
@@ -319,8 +318,8 @@ public class AreaAdminService(
                     Message = r.Message,
                 })
             .Map(result => result.Result is not null
-                ? JsonConvert
-                    .DeserializeObject<ActionResult>(result.Result.ToString())
+                ? JsonSerializerHelper
+                    .Deserialize<ActionResult>(result.Result.ToString())
                 : null);
     }
 
@@ -374,8 +373,8 @@ public class AreaAdminService(
                     Message = r.Message,
                 })
             .Map(result => result.Result is not null
-                ? JsonConvert
-                    .DeserializeObject<ActionResult>(result.Result.ToString())
+                ? JsonSerializerHelper
+                    .Deserialize<ActionResult>(result.Result.ToString())
                 : null);
     }
 
@@ -438,8 +437,8 @@ public class AreaAdminService(
                     Message = r.Message,
                 })
             .Map(result => result.Result is not null
-                ? JsonConvert
-                    .DeserializeObject<ActionResult>(result.Result.ToString())
+                ? JsonSerializerHelper
+                    .Deserialize<ActionResult>(result.Result.ToString())
                 : null);
     }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Logging/NestedObjectChangeLogger.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Logging/NestedObjectChangeLogger.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using System.Collections;
+﻿using System.Collections;
 
 namespace OutOfSchool.BusinessLogic.Services.Logging;
 
@@ -52,11 +51,11 @@ public class NestedObjectChangeLogger : INestedObjectChangeLogger
             {
                 var oldValueStr = Truncate(
                     valueProjector?.ProjectValue(prop.PropertyType, oldValue)
-                    ?? JsonConvert.SerializeObject(oldValue));
+                    ?? JsonSerializerHelper.Serialize(oldValue));
 
                 var newValueStr = Truncate(
                     valueProjector?.ProjectValue(prop.PropertyType, newValue)
-                    ?? JsonConvert.SerializeObject(newValue));
+                    ?? JsonSerializerHelper.Serialize(newValue));
 
                 // Add a new change log entry
                 logs.Add(new ChangesLog

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/MinistryAdminService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/MinistryAdminService.cs
@@ -1,14 +1,13 @@
 ﻿using System.Linq.Expressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
+using OutOfSchool.BusinessLogic.Models;
+using OutOfSchool.BusinessLogic.Services.SearchString;
+using OutOfSchool.Common.Communication;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Enums;
-using OutOfSchool.BusinessLogic.Models;
-using OutOfSchool.Common.Communication;
 using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.Services.Repository.Base.Api;
-using OutOfSchool.BusinessLogic.Services.SearchString;
 
 namespace OutOfSchool.BusinessLogic.Services;
 
@@ -100,8 +99,8 @@ public class MinistryAdminService(
                     Message = r.Message,
                 })
             .Map(result => result.Result is not null
-                ? JsonConvert
-                    .DeserializeObject<MinistryAdminBaseDto>(result.Result.ToString())
+                ? JsonSerializerHelper
+                    .Deserialize<MinistryAdminBaseDto>(result.Result.ToString())
                 : null);
     }
 
@@ -223,7 +222,7 @@ public class MinistryAdminService(
                     Message = r.Message,
                 })
             .Map(result => result.Result is not null
-                ? JsonConvert.DeserializeObject<MinistryAdminBaseDto>(result.Result.ToString()).ToMinistryAdminDto()
+                ? JsonSerializerHelper.Deserialize<MinistryAdminBaseDto>(result.Result.ToString()).ToMinistryAdminDto()
                 : null);
     }
 
@@ -269,8 +268,8 @@ public class MinistryAdminService(
                     Message = r.Message,
                 })
             .Map(result => result.Result is not null
-                ? JsonConvert
-                    .DeserializeObject<ActionResult>(result.Result.ToString())
+                ? JsonSerializerHelper
+                    .Deserialize<ActionResult>(result.Result.ToString())
                 : null);
     }
 
@@ -320,8 +319,8 @@ public class MinistryAdminService(
                     Message = r.Message,
                 })
             .Map(result => result.Result is not null
-                ? JsonConvert
-                    .DeserializeObject<ActionResult>(result.Result.ToString())
+                ? JsonSerializerHelper
+                    .Deserialize<ActionResult>(result.Result.ToString())
                 : null);
     }
 
@@ -385,8 +384,8 @@ public class MinistryAdminService(
                     Message = r.Message,
                 })
             .Map(result => result.Result is not null
-                ? JsonConvert
-                    .DeserializeObject<ActionResult>(result.Result.ToString())
+                ? JsonSerializerHelper
+                    .Deserialize<ActionResult>(result.Result.ToString())
                 : null);
     }
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/SubordinationStructure/InstitutionHierarchy.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/SubordinationStructure/InstitutionHierarchy.cs
@@ -28,4 +28,13 @@ public class InstitutionHierarchy : IKeyedEntity<Guid>, ISoftDeleted
     public virtual Institution Institution { get; set; }
 
     public virtual List<SubDirection> SubDirections { get; set; }
+
+    #region Sports Registry Fields
+
+    public long? SportRegistryIdCode { get; set; }
+
+    [MaxLength(10)]
+    public string? SportsSectionNumeral { get; set; }
+
+    #endregion
 }

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250812171431_AddSportsRegistryFields.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250812171431_AddSportsRegistryFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
@@ -11,9 +12,11 @@ using OutOfSchool.Services;
 namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250812171431_AddSportsRegistryFields")]
+    partial class AddSportsRegistryFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250812171431_AddSportsRegistryFields.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250812171431_AddSportsRegistryFields.cs
@@ -1,0 +1,40 @@
+﻿#nullable disable
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+{
+    /// <inheritdoc />
+    public partial class AddSportsRegistryFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "SportRegistryIdCode",
+                table: "InstitutionHierarchies",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SportsSectionNumeral",
+                table: "InstitutionHierarchies",
+                type: "varchar(10)",
+                maxLength: 10,
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SportRegistryIdCode",
+                table: "InstitutionHierarchies");
+
+            migrationBuilder.DropColumn(
+                name: "SportsSectionNumeral",
+                table: "InstitutionHierarchies");
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Institution titles now include the sports section numeral when present (e.g., “III. Title”), improving clarity in lists and details.
  - Backend support added for sports registry identifiers to enable future functionality; no immediate UI changes.

- Chores
  - Internal JSON handling switched to a consolidated serializer across services and logging.
  - Namespace and type-resolution cleanup for workshop teacher DTOs; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->