### PR TITLE
Added CompetitiveEventDescriptionItems to moderator dto

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDescriptionItemDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDescriptionItemDto.cs
@@ -1,5 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
-using OutOfSchool.Services.Models.CompetitiveEvents;
+﻿using OutOfSchool.Services.Models.CompetitiveEvents;
+using System.ComponentModel.DataAnnotations;
 
 namespace OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 
@@ -20,6 +20,17 @@ public class CompetitiveEventDescriptionItemDto
 
 public static class CompetitiveEventDescriptionItemDtoExtensions
 {
+    public static CompetitiveEventDescriptionItem ToDraft(this CompetitiveEventDescriptionItemDto dto) => new()
+    {
+        Id = dto.Id,
+        SectionName = dto.SectionName,
+        Description = dto.Description,
+        CompetitiveEventId = dto.CompetitiveEventId,
+    };
+    
+    public static List<CompetitiveEventDescriptionItem> ToDraft(this IEnumerable<CompetitiveEventDescriptionItemDto> list)
+        => list.MapToList(ToDraft);
+
     public static CompetitiveEventDescriptionItem SetToModel(this CompetitiveEventDescriptionItemDto dto, CompetitiveEventDescriptionItem model)
     {
         model.SectionName = dto.SectionName;
@@ -50,5 +61,5 @@ public static class CompetitiveEventDescriptionItemDtoExtensions
         };
 
     public static List<CompetitiveEventDescriptionItemDto> ToDto(this IEnumerable<CompetitiveEventDescriptionItem> list)
-        => list.MapToList(ToDto);
+        => list.MapToList(ToDto);    
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/ModeratorCompetitiveEventDraftEditDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/ModeratorCompetitiveEventDraftEditDto.cs
@@ -1,4 +1,8 @@
-﻿using OutOfSchool.BusinessLogic.Models.ContactInfo;
+﻿using Microsoft.AspNetCore.Mvc;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
+using OutOfSchool.BusinessLogic.Models.ContactInfo;
+using OutOfSchool.BusinessLogic.Util.CustomValidation;
+using OutOfSchool.BusinessLogic.Util.JsonTools;
 using OutOfSchool.Services.Models.ContactInfo;
 using System.ComponentModel.DataAnnotations;
 using CompetitiveEventDraftModel = OutOfSchool.Services.Models.CompetitiveEventDrafts.CompetitiveEventDraft;
@@ -24,6 +28,11 @@ public class ModeratorCompetitiveEventDraftEditDto
 
     public string Benefits { get; set; }
 
+    [ModelBinder(BinderType = typeof(JsonModelBinder))]
+    [CollectionNotEmpty(ErrorMessage = "At least one description item is required")]
+    public IEnumerable<CompetitiveEventDescriptionItemDto> CompetitiveEventDescriptionItems { get; set; }
+
+    [ModelBinder(BinderType = typeof(JsonModelBinder))]
     public IEnumerable<ContactsDto> Contacts { get; set; } = [];
 }
 
@@ -38,7 +47,8 @@ public static class ModeratorCompetitiveEventDraftEditDtoExtensions
         model.CompetitiveEventDraftContent.VenueName = dto.VenueName;
         model.CompetitiveEventDraftContent.TermsOfParticipation = dto.TermsOfParticipation;
         model.CompetitiveEventDraftContent.PreferentialTermsOfParticipation = dto.PreferentialTermsOfParticipation;
-        model.CompetitiveEventDraftContent.Benefits = dto.Benefits;
+        model.CompetitiveEventDraftContent.Benefits = dto.Benefits;       
+        model.CompetitiveEventDraftContent.CompetitiveEventDescriptionItems = dto.CompetitiveEventDescriptionItems.ToDraft();
 
         UpdateContactsForModeration(model.CompetitiveEventDraftContent.Contacts, dto.Contacts);
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
@@ -1,24 +1,25 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
+using OutOfSchool.BusinessLogic.Models.ContactInfo;
+using OutOfSchool.BusinessLogic.Services;
 using OutOfSchool.BusinessLogic.Services.CompetitiveEventDrafts;
 using OutOfSchool.BusinessLogic.Services.Images;
-using OutOfSchool.BusinessLogic.Services;
-using OutOfSchool.Services.Models.CompetitiveEventDrafts;
-using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.BusinessLogic.Services.SearchString;
-using System.Threading.Tasks;
-using System;
-using System.Linq;
-using OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
-using OutOfSchool.Services.Enums.CompetitiveEventStatus;
-using OutOfSchool.Common.Models;
-using OutOfSchool.Services.Models.ContactInfo;
-using System.Collections.Generic;
-using OutOfSchool.BusinessLogic.Models.ContactInfo;
-using OutOfSchool.Services.Models;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Models;
+using OutOfSchool.Services.Enums.CompetitiveEventStatus;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Services.Models.CompetitiveEventDrafts;
+using OutOfSchool.Services.Models.ContactInfo;
+using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.Services.Repository.Base.Api;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -159,7 +160,17 @@ public class SensitiveCompetitiveEventDraftServiceTest
             TermsOfParticipation = "Updated Terms",
             PreferentialTermsOfParticipation = "Updated Preferential Terms",
             Benefits = "Updated Benefits",
-            Contacts = new List<ContactsDto>()
+            Contacts = new List<ContactsDto>(),
+            CompetitiveEventDescriptionItems = new List<CompetitiveEventDescriptionItemDto>
+            {
+                new CompetitiveEventDescriptionItemDto
+                {
+                    Id = Guid.NewGuid(),
+                    SectionName = "Updated Section",
+                    Description = "Updated Description",
+                    CompetitiveEventId = Guid.NewGuid()
+                }
+            }            
         };
 
         var competitiveEventDraft = GetCompetitiveEventDraft(draftId);
@@ -198,7 +209,7 @@ public class SensitiveCompetitiveEventDraftServiceTest
         return new CompetitiveEventDraft
         {
             Id = draftId,
-            DraftStatus = CompetitiveEventDraftStatus.PendingModeration,
+            DraftStatus = CompetitiveEventDraftStatus.PendingModeration,            
             CompetitiveEventDraftContent = new CompetitiveEventDraftContent
             {
                 Title = "Some title",
@@ -252,7 +263,18 @@ public class SensitiveCompetitiveEventDraftServiceTest
                 {
                     Title = "pppp"
                 }
+            },
+            CompetitiveEventDescriptionItems = new List<CompetitiveEventDescriptionItemDto>
+            {
+                new CompetitiveEventDescriptionItemDto
+                {
+                    Id = Guid.NewGuid(),
+                    SectionName = "Test Section",
+                    Description = "Test Description",
+                    CompetitiveEventId = Guid.NewGuid()
+                }
             }
+            
         };
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventDraftController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventDraftController.cs
@@ -453,6 +453,7 @@ public class CompetitiveEventDraftController : ControllerBase
     /// <returns>Returns <see cref="CompetitiveEventDraftResponseDto"/></returns>
     [HttpPut("/api/v{version:apiVersion}/competitions-drafts/{draftId}/moderator-edit")]
     [HasPermission(Permissions.CompetitiveEventApprove)]
+    [Consumes("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CompetitiveEventDraftResponseDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Moderators can add and edit multiple description items for competitive event drafts; these items include id, section name, description, and associated event linkage.
  - Drafts now store description item collections.

- Improvements
  - Moderator edit endpoint now requires application/json content.
  - JSON binding/validation improved for nested fields (contacts and description items); at least one description item is required with a clear error message.

- Tests
  - Updated tests cover creation, retrieval, and updating of draft description items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->