### PR TITLE
Update DraftStatus check for editing CompetitiveEventDraft

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -808,14 +808,14 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             }
         }
 
-        if (competitiveEventDraft.DraftStatus != CompetitiveEventDraftStatus.Draft)
+        if (competitiveEventDraft.DraftStatus == CompetitiveEventDraftStatus.PendingModeration)
         {
-            logger.LogWarning("Competitive event draft with ID {DraftId} is not in Draft status.", competitiveEventDraftUpdateDto.Id);
+            logger.LogWarning("Competitive event draft with ID {DraftId} can't be updated.", competitiveEventDraftUpdateDto.Id);
             return Result<(CompetitiveEventDraft competitiveEventDraft, ImageChangingResult coverImageResult,
            MultipleImageChangingResult imagesResult)>.Failed(new OperationError
            {
                Code = "400",
-               Description = "Competitive event draft can only be updated when it is in Draft status."
+               Description = "Competitive event draft can't be updated when it is in PendingModeration status."
            });
         }
 


### PR DESCRIPTION
Changed the condition for updating competitive event drafts to check for PendingModeration status instead of Draft status. Updated warning messages and error descriptions to reflect the new logic, ensuring clarity on when drafts can be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded editing for competitive event drafts: you can now update drafts in more statuses; updates are only blocked while a draft is awaiting moderation.
  * Improved user feedback when an update is blocked during moderation, providing clearer messaging on why the action cannot be completed and when editing will be available again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->