### PR TITLE
Hotfix - Added DirectionSubDirectionIds property to the CompetitiveEventDrafts

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
@@ -47,7 +47,14 @@ public static class CompetitiveEventV2DtoExtensions
             CompetitiveSelection = model.CompetitiveSelection,
             Contacts = model.Contacts?.ToDto(),
             SubDirectionIds = model.SubDirections?.Where(s => !s.IsDeleted).Select(s => s.Id).ToList() ?? [],
-            Coverage = model.Coverage?.ToDto(),            
+            Coverage = model.Coverage?.ToDto(),
+            DirectionSubDirectionIds = model.SubDirections?.Where(s => !s.IsDeleted).Select(
+                s => new DirectionSubDirectionIdsDto
+                {
+                    DirectionId = s.DirectionId,
+                    SubDirectionId = s.Id
+                })
+            .ToList() ?? []
         };
 
     public static List<CompetitiveEventV2Dto> ToV2Dto(this IEnumerable<OutOfSchool.Services.Models.CompetitiveEvents.CompetitiveEvent> list)
@@ -86,7 +93,7 @@ public static class CompetitiveEventV2DtoExtensions
             CompetitiveEventAccountingTypeId = draft.CompetitiveEventAccountingTypeId,
             SubDirectionIds = draft.CompetitiveEventDraftContent?.SubDirectionIds ??
                              draft.CompetitiveEvent?.SubDirections?.Select(s => s.Id).ToList() ?? [],
-            CompetitiveEventDescriptionItems = draft.CompetitiveEventDraftContent?.CompetitiveEventDescriptionItems?.ToDto()            
+            CompetitiveEventDescriptionItems = draft.CompetitiveEventDraftContent?.CompetitiveEventDescriptionItems?.ToDto()
         };
     }
 
@@ -107,7 +114,7 @@ public static class CompetitiveEventV2DtoExtensions
             CoverImageId = competitiveEventV2Dto.CoverImageId,
             CoverageId = competitiveEventV2Dto.CoverageId,
             CompetitiveEventAccountingTypeId = competitiveEventV2Dto.CompetitiveEventAccountingTypeId,
-            CompetitiveEventDraftContent = competitiveEventV2Dto.ToDraftContent(),            
+            CompetitiveEventDraftContent = competitiveEventV2Dto.ToDraftContent(),
             // This is needed for search
             CATOTTGId = competitiveEventV2Dto.Contacts.SingleOrDefault(c => c.IsDefault)?.Address?.CATOTTGId ?? 0,
         };
@@ -138,9 +145,9 @@ public static class CompetitiveEventV2DtoExtensions
             ScheduledStartTime = competitiveEventV2Dto.ScheduledStartTime,
             ShortTitle = competitiveEventV2Dto.ShortTitle,
             Title = competitiveEventV2Dto.Title,
-            TermsOfParticipation = competitiveEventV2Dto.TermsOfParticipation,            
+            TermsOfParticipation = competitiveEventV2Dto.TermsOfParticipation,
             VenueName = competitiveEventV2Dto.VenueName,
             SubDirectionIds = competitiveEventV2Dto.SubDirectionIds ?? new List<long>(),
-            CompetitiveEventDescriptionItems = competitiveEventV2Dto.CompetitiveEventDescriptionItems?.ToModel(),            
+            CompetitiveEventDescriptionItems = competitiveEventV2Dto.CompetitiveEventDescriptionItems?.ToModel(),
         };
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -685,7 +685,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
                         DirectionId = s.DirectionId,
                         SubDirectionId = s.Id
                     })
-            .ToList() ?? [];
+            .ToList();
 
         return competitiveEventDraftResponseDto;
     }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -12,6 +12,7 @@ using OutOfSchool.Services.Enums.CompetitiveEventStatus;
 using OutOfSchool.Services.Models.CompetitiveEventDrafts;
 using OutOfSchool.Services.Models.Images;
 using OutOfSchool.Services.Repository.Api;
+using OutOfSchool.Services.Repository.Base.Api;
 
 namespace OutOfSchool.BusinessLogic.Services.CompetitiveEventDrafts;
 public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> logger,
@@ -24,7 +25,8 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
     IRegionAdminService regionAdminService,
     IMinistryAdminService ministryAdminService,
     ICodeficatorService codeficatorService,
-    ISearchStringService searchStringService) : ICompetitiveEventDraftService, ISensitiveCompetitiveEventDraftService
+    ISearchStringService searchStringService,
+    IEntityRepositorySoftDeleted<long, SubDirection> subDirectionRepository) : ICompetitiveEventDraftService, ISensitiveCompetitiveEventDraftService
 {
 
     // <inheritdoc/>
@@ -81,7 +83,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
     }
 
     // <inheritdoc/>
-    public async Task<Result<CompetitiveEventDraftResultDto>> Update(Guid id,CompetitiveEventDraftUpdateDto competitiveEventDraftUpdateDto)
+    public async Task<Result<CompetitiveEventDraftResultDto>> Update(Guid id, CompetitiveEventDraftUpdateDto competitiveEventDraftUpdateDto)
     {
         if (competitiveEventDraftUpdateDto == null || competitiveEventDraftUpdateDto.CompetitiveEventV2Dto == null)
         {
@@ -606,7 +608,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         if (dto == null)
         {
             logger.LogError("Parameter '{ParameterName}' is null.", nameof(dto));
-            
+
             return Result<CompetitiveEventDraftResponseDto>.Failed(new OperationError
             {
                 Code = "400",
@@ -614,9 +616,9 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             });
         }
 
-        logger.LogDebug("Updating competitive event as moderator started. CompetitiveEventDraft Id = {Id}.", draftId);        
-        
-        var validation = await ValidateDraftForModerator(draftId);                
+        logger.LogDebug("Updating competitive event as moderator started. CompetitiveEventDraft Id = {Id}.", draftId);
+
+        var validation = await ValidateDraftForModerator(draftId);
 
         if (!validation.Succeeded)
         {
@@ -626,18 +628,18 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         var competitiveEventDraft = validation.Value;
 
         try
-        {            
+        {
             dto.ToDraft(competitiveEventDraft);
             competitiveEventDraft.DraftStatus = CompetitiveEventDraftStatus.EditedByModerator;
 
-            await competitiveEventDraftRepository.Update(competitiveEventDraft);            
+            await competitiveEventDraftRepository.Update(competitiveEventDraft);
             var draftWithDetails = await GetByIdWithProviderDetails(competitiveEventDraft.Id);
 
             logger.LogInformation("Competitive event was updated by moderator.");
 
             return Result<CompetitiveEventDraftResponseDto>.Success(draftWithDetails.ToResponseDto());
         }
-        catch (Exception ex) 
+        catch (Exception ex)
         {
             logger.LogError(ex, "Error occurred while updating CompetitiveEventDraft with ID {DraftId}.", draftId);
             return Result<CompetitiveEventDraftResponseDto>.Failed(new OperationError
@@ -672,6 +674,19 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
                     ?.ToAllAddressPartsDto()
             );
 
+        competitiveEventDraftResponseDto.CompetitiveEventDetails.DirectionSubDirectionIds = (await subDirectionRepository
+            .GetByFilter(
+                         whereExpression: sd => competitiveEventDraftResponseDto.CompetitiveEventDetails.SubDirectionIds.Contains(sd.Id) && !sd.IsDeleted,
+                         includeExpression: q => q.Include(sd => sd.Direction))
+            .ConfigureAwait(false))
+            .Select(
+                    s => new DirectionSubDirectionIdsDto
+                    {
+                        DirectionId = s.DirectionId,
+                        SubDirectionId = s.Id
+                    })
+            .ToList() ?? [];
+
         return competitiveEventDraftResponseDto;
     }
 
@@ -680,11 +695,11 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         var competitiveEventDraft = competitiveEventV2Dto.ToDraft();
 
         competitiveEventDraft.DraftStatus = CompetitiveEventDraftStatus.Draft;
-        
+
         var createdDraft = await competitiveEventDraftRepository
             .Create(competitiveEventDraft)
             .ConfigureAwait(false);
-        
+
         return createdDraft;
     }
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -23,6 +23,7 @@ using OutOfSchool.Services.Enums.CompetitiveEventStatus;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Models.CompetitiveEventDrafts;
 using OutOfSchool.Services.Repository.Api;
+using OutOfSchool.Services.Repository.Base.Api;
 using OutOfSchool.Tests.Common;
 using OutOfSchool.Tests.Common.TestDataGenerators;
 
@@ -39,6 +40,7 @@ public class CompetitiveEventDraftServiceTests
     private Mock<IImageDependentEntityImagesInteractionService<CompetitiveEventDraft>> mockImageService;
     private Mock<ICodeficatorRepository> mockCodeficatorRepository;
     private Mock<IChangesLogService> mockChangesLogService;
+    private Mock<IEntityRepositorySoftDeleted<long, SubDirection>> mockSubDirectionRepository;
 
 
 [SetUp]
@@ -51,6 +53,7 @@ public class CompetitiveEventDraftServiceTests
         mockImageService = new Mock<IImageDependentEntityImagesInteractionService<CompetitiveEventDraft>>();
         mockCodeficatorRepository = new Mock<ICodeficatorRepository>();
         mockChangesLogService = new Mock<IChangesLogService>();
+        mockSubDirectionRepository = new Mock<IEntityRepositorySoftDeleted<long, SubDirection>>();
 
         competitiveEventDraftService = new CompetitiveEventDraftService(
             mockLogger.Object,
@@ -63,7 +66,8 @@ public class CompetitiveEventDraftServiceTests
             new Mock<IRegionAdminService>().Object,
             new Mock<IMinistryAdminService>().Object,
             new Mock<ICodeficatorService>().Object,
-            new Mock<ISearchStringService>().Object);
+            new Mock<ISearchStringService>().Object,
+            mockSubDirectionRepository.Object);
     }
 
     #region Create

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -43,7 +43,7 @@ public class CompetitiveEventDraftServiceTests
     private Mock<IEntityRepositorySoftDeleted<long, SubDirection>> mockSubDirectionRepository;
 
 
-[SetUp]
+    [SetUp]
     public void SetUp()
     {
         mockLogger = new Mock<ILogger<CompetitiveEventDraftService>>();
@@ -79,7 +79,7 @@ public class CompetitiveEventDraftServiceTests
         CompetitiveEventV2Dto dto = null;
 
         // Act & Assert
-        Assert.ThrowsAsync<ArgumentNullException>( async () => await competitiveEventDraftService.Create(dto));
+        Assert.ThrowsAsync<ArgumentNullException>(async () => await competitiveEventDraftService.Create(dto));
     }
 
     [Test]
@@ -103,6 +103,17 @@ public class CompetitiveEventDraftServiceTests
         {
             new() { Id = 1, Name = "Test Codeficator" }
         };
+
+        var directionSubDirectionIds = new List<DirectionSubDirectionIdsDto>
+        {
+            new() { DirectionId = 14, SubDirectionId = 54  }
+        };
+
+        var subDirections = new List<SubDirection>
+        {
+            new() { Id = 54, DirectionId = 14, Description = "description", IsDeleted = true, Title = "title"  }
+        };
+
         mockCompetitiveEventService.Setup(service => service.GetById(dto.Id))
             .ReturnsAsync((CompetitiveEventDto)null);
         mockUserService.Setup(service => service.UserHasRights(It.IsAny<IUserRights[]>()))
@@ -119,12 +130,19 @@ public class CompetitiveEventDraftServiceTests
             It.IsAny<Dictionary<Expression<Func<CATOTTG, object>>, SortDirection>>()))
             .Returns(catottgs.AsTestAsyncEnumerableQuery);
 
+        mockSubDirectionRepository.Setup(repo => repo.GetByFilter(
+            It.IsAny<Expression<Func<SubDirection, bool>>>(),
+            It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<SubDirection>, IQueryable<SubDirection>>>())).ReturnsAsync(subDirections);
+
         // Act
         var result = await competitiveEventDraftService.Create(dto);
 
         // Assert
         Assert.IsNotNull(result);
         Assert.IsInstanceOf<CompetitiveEventDraftResultDto>(result);
+        Assert.AreEqual(result.CompetitiveEventDraft.CompetitiveEventDetails.DirectionSubDirectionIds[0].DirectionId, directionSubDirectionIds[0].DirectionId);
+        Assert.AreEqual(result.CompetitiveEventDraft.CompetitiveEventDetails.DirectionSubDirectionIds[0].SubDirectionId, directionSubDirectionIds[0].SubDirectionId);
     }
 
     #endregion
@@ -257,9 +275,11 @@ public class CompetitiveEventDraftServiceTests
         };
         var coverImageResult = new ImageChangingResult();
         var imagesResult = new MultipleImageChangingResult();
-        var expectedResult = Result<(CompetitiveEventDraft, ImageChangingResult, MultipleImageChangingResult)>.Failed(new OperationError() { 
+        var expectedResult = Result<(CompetitiveEventDraft, ImageChangingResult, MultipleImageChangingResult)>.Failed(new OperationError()
+        {
             Code = "500",
-            Description = "Some error occurred" });
+            Description = "Some error occurred"
+        });
 
         mockCompetitiveEventDraftRepository
             .Setup(repo => repo.RunInTransaction(It.IsAny<Func<Task<Result<(CompetitiveEventDraft, ImageChangingResult, MultipleImageChangingResult)>>>>()))
@@ -514,7 +534,7 @@ public class CompetitiveEventDraftServiceTests
         mockUserService.Setup(service => service.UserHasRights(It.IsAny<IUserRights[]>()))
             .Returns(Task.CompletedTask);
         mockCodeficatorRepository.Setup(repo => repo.Get(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Expression<Func<CATOTTG, bool>>>(),
-            It.IsAny<Dictionary<Expression<Func<CATOTTG,object>>, SortDirection>>()))
+            It.IsAny<Dictionary<Expression<Func<CATOTTG, object>>, SortDirection>>()))
             .Returns(catottgs.AsTestAsyncEnumerableQuery);
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
 using OutOfSchool.Services.Models;
 using OutOfSchool.Common.Enums;
+using OutOfSchool.Services.Repository.Base.Api;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -32,6 +33,7 @@ public class SensitiveCompetitiveEventDraftServiceTest
     private Mock<IImageDependentEntityImagesInteractionService<CompetitiveEventDraft>> imageServiceMock;
     private Mock<IChangesLogService> changesLogServiceMock;
     private Mock<ICodeficatorRepository> codeficatorRepoMock;
+    private Mock<IEntityRepositorySoftDeleted<long, SubDirection>> mockSubDirectionRepository;
 
     Guid draftId = Guid.NewGuid();
 
@@ -45,7 +47,7 @@ public class SensitiveCompetitiveEventDraftServiceTest
         imageServiceMock = new Mock<IImageDependentEntityImagesInteractionService<CompetitiveEventDraft>>();
         changesLogServiceMock = new Mock<IChangesLogService>();
         codeficatorRepoMock = new Mock<ICodeficatorRepository>();
-
+        mockSubDirectionRepository = new Mock<IEntityRepositorySoftDeleted<long, SubDirection>>();
 
         service = new CompetitiveEventDraftService(
             loggerMock.Object,
@@ -58,7 +60,8 @@ public class SensitiveCompetitiveEventDraftServiceTest
             new Mock<IRegionAdminService>().Object,
             new Mock<IMinistryAdminService>().Object,
             new Mock<ICodeficatorService>().Object,
-            new Mock<ISearchStringService>().Object);
+            new Mock<ISearchStringService>().Object,
+            mockSubDirectionRepository.Object);
     }
 
     [Test]


### PR DESCRIPTION
1) Added mapping for the DirectionSubDirectionIds property in the ToV2Dto() extension method.

2) Changed the CompetitiveEventDraftService class:
- added the subDirectionRepository parameter (with type - IEntityRepositorySoftDeleted<long, SubDirection>) to the constructor;
- changed the MapCompetitiveEventDraftWithDetails() private method - added code to fill the DirectionSubDirectionIds property. 

3) Fixed test classes (CompetitiveEventDraftServiceTests and SensitiveCompetitiveEventDraftServiceTest) - added the subDirectionRepository parameter (with type - IEntityRepositorySoftDeleted<long, SubDirection>) to the constructor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Competitive event details and drafts now include direction–subdirection pairs, showing only active subdirections. This information is returned in v2 responses for improved clarity when viewing or editing events.

* **Tests**
  * Expanded test coverage to validate the new direction–subdirection mapping in draft responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->