### PR TITLE
TKyryk/Add Codeficator and SportKindId mapping to SportsSectionPostRequest

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftToSportSectionExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftToSportSectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using OutOfSchool.Common.Enums;
 using OutOfSchool.Services.Enums;
+using OutOfSchool.Services.Models.Images; // ??
 using OutOfSchool.SportsRegistryApiClient.Models.Enums;
 using OutOfSchool.SportsRegistryApiClient.Models.Requests;
 using System.Diagnostics.CodeAnalysis;
@@ -16,14 +17,15 @@ public static class WorkshopDraftToSportSectionExtensions
             OrganizationCode = draft.Provider.Edrpou,
             SectionName = content.Title,
 
-            SectionSportKindDictIdCode = 55,
+            //SectionSportKindDictIdCode = 55,
 
             SectionAgeFrom = content.MinAge,
             SectionAgeTo = content.MaxAge,
 
             SectionIsInShlyahProject = content.IsChampionPath,
 
-            SectionAddressLocalityDictIdCode = "UA26100070020012343", /*defaultContact?.Address?.CATOTTGId.ToString() , // is it OK?*/
+           
+            SectionAddressLocalityDictIdCode = draft.CATOTTGId.ToString(),// "123456" defaultContact?.Address?.CATOTTGId.ToString(), // "UA26100070020012343",
             SectionAddressStreet = defaultContact?.Address?.Street,
             SectionAddressHouse = defaultContact?.Address?.BuildingNumber,
 
@@ -36,12 +38,12 @@ public static class WorkshopDraftToSportSectionExtensions
                 .Distinct().ToList() ?? new(),
 
             SectionEmail = content.Contacts?
-                .FirstOrDefault(c => c.IsDefault)?
+                .FirstOrDefault(c => c.IsDefault)? // defaultContact
                 .Emails?
                 .FirstOrDefault()?
                 .Address,
 
-            SectionRegistrationFormUrl = "https://forms.example.com/football-registration",
+            SectionRegistrationFormUrl = "https://forms.example.com/football-registration", // replace with actual URL if available
             SectionUrl = defaultContact?.SocialNetworks
             .FirstOrDefault(s => s.Type == SocialNetworkContactType.Website)?.Url,
 
@@ -60,41 +62,25 @@ public static class WorkshopDraftToSportSectionExtensions
             SectionMaxStudentsAmount = content.AvailableSeats == uint.MaxValue
             ? 1000 : (int)content.AvailableSeats,
 
-            SectionTitlePhoto = string.IsNullOrEmpty(draft.CoverImageId) 
+            SectionTitlePhoto = string.IsNullOrEmpty(draft.CoverImageId)
             ? null
             : CombineImageUrl(baseImageUrl, draft.CoverImageId),
 
-            /*SectionPhotos = draft.Images?
-            .Where(img => !string.IsNullOrWhiteSpace(img.ExternalStorageId))
-            .Select(img => CombineImageUrl(baseImageUrl, img.ExternalStorageId))
-            .ToList() ?? new(),
-            */
-            SectionPhotos = [
-                "https://images.unsplash.com/photo-1529778873920-4da4926a72c2?fm=jpg&q=60&w=3000&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8Y3V0ZSUyMGNhdHxlbnwwfHwwfHx8MA%3D%3D",
-                "https://www.gstatic.com/images/branding/googlelogo/svg/googlelogo2_clr_160x56px.svg",
-                "https://www.gstatic.com/images/branding/googlelogo/svg/googlelogo3_clr_160x56px.svg"
-            ],
+            SectionPhotos = MapSectionPhotos(draft.Images, baseImageUrl),
+
             SectionTrainers = [], // TODO: make mapping when teachers will be added to the draft
 
             SectionPracticePeriodDateFrom = content.StudyPeriodStartDate.ToString("dd':'MM", CultureInfo.InvariantCulture),
             SectionPracticePeriodDateTo   = content.StudyPeriodEndDate.ToString("dd':'MM", CultureInfo.InvariantCulture),
 
-            //SectionSchedule = content.DateTimeRanges?
-            //.SelectMany(r => r.Workdays.Select(day => new SectionScheduleRequest
-            //{
-            //    SectionScheduleWeekday = Enum.Parse<Weekday>(day.ToString(), ignoreCase: true),
-            //    SectionScheduleTimeFrom = r.StartTime.ToString("HH:mm:ss"),
-            //    SectionScheduleTimeTo = r.EndTime.ToString("HH:mm:ss"),
-            //}))
-            //.ToList() ?? new(),
             SectionSchedule = content.DateTimeRanges?.SelectMany(r =>
                  r.Workdays
                 .SelectMany(flags => DecomposeFlags(flags)
                 .Select(day => new SectionScheduleRequest
                 {
                     SectionScheduleWeekday = Enum.Parse<Weekday>(day.ToString(), ignoreCase: true),
-                    SectionScheduleTimeFrom = r.StartTime.ToString("HH:mm:ss"),
-                    SectionScheduleTimeTo = r.EndTime.ToString("HH:mm:ss"),
+                    SectionScheduleTimeFrom = r.StartTime.ToString("HH':'mm':'ss", CultureInfo.InvariantCulture),
+                    SectionScheduleTimeTo = r.EndTime.ToString("HH':'mm':'ss", CultureInfo.InvariantCulture),
                 }))).ToList() ?? new(),
         };
     }
@@ -115,6 +101,17 @@ public static class WorkshopDraftToSportSectionExtensions
     }
     private static string CombineImageUrl(string baseUrl, string imageId)
     {
-        return $"{baseUrl.TrimEnd('/')}/{imageId.TrimStart('/')}";  //$"{baseImageUrl}{draft.CoverImageId}"
+        return $"{baseUrl?.TrimEnd().TrimEnd('/')}/{imageId?.TrimStart().TrimStart('/')}"; // need this stronger check?
+        //return $"{baseUrl.TrimEnd('/')}/{imageId.TrimStart('/')}";
+    }
+    private static List<string> MapSectionPhotos<T>(IEnumerable<Image<T>> images, string baseUrl)
+    {
+        if (images == null) return new();
+
+        return images
+            .Where(img => !string.IsNullOrWhiteSpace(img.ExternalStorageId))
+            .Select(img => CombineImageUrl(baseUrl, img.ExternalStorageId))
+            .Distinct()
+            .ToList();
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CodeficatorService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CodeficatorService.cs
@@ -99,6 +99,12 @@ public class CodeficatorService(ICodeficatorRepository codeficatorRepository) : 
         return result;
     }
 
+    public async Task<string> GetCodeById(long id)
+    {
+        var entity = await codeficatorRepository.GetById(id);
+        return entity?.Code;
+    }
+
     #region privateMethods
 
     private static Expression<Func<CATOTTG, bool>> GetFilter(long? parentId, CodeficatorCategory level)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -1382,7 +1382,7 @@ public class WorkshopService(
         var institutionHierarchyDto = await institutionHierarchyService.GetById(institutionHierarchyId.Value).ConfigureAwait(false);
 
         // If the institution is "Мінспорт", set workshopType and isChampionPath; otherwise, use default values
-        var isChampionPath = institutionHierarchyDto.Institution.Title.Equals(institutionOptions.Value.MinistryOfSportTitle, StringComparison.OrdinalIgnoreCase);
+        var isChampionPath = institutionHierarchyDto.Institution.Title.Equals(institutionOptions.Value.MinistryOfSportId, StringComparison.OrdinalIgnoreCase);
         if (isChampionPath)
         {
             workshopType = WorkshopType.Section;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ICodeficatorService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ICodeficatorService.cs
@@ -53,4 +53,7 @@ public interface ICodeficatorService
     /// <param name="catottgId">CATOTTG id</param>
     /// <returns>The task result contains a <see cref="List{TResult}"/> that contains subsettlements ids.</returns>
     public Task<IEnumerable<long>> GetAllChildrenIdsByParentIdAsync(long catottgId);
+
+    public Task<string> GetCodeById(long id); // add comments later
+
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -65,6 +65,7 @@ public class WorkshopDraftService(
     IInstitutionHierarchyRepository institutionHierarchyRepository,
     ICodeficatorRepository codeficatorRepository,
     IChangesLogService changesLogService,
+    IInstitutionHierarchyService institutionHierarchyService,
     IOptions<InstitutionOptions> institutionSettings,
     IOptions<ImageStorageOptions> imageStorageOptions
 ) : IWorkshopDraftService, ISensitiveWorkshopDraftService
@@ -344,12 +345,24 @@ public class WorkshopDraftService(
 
         if (workshopDraft.WorkshopId == null)
         {
-            if (string.Equals(workshopDraft.Provider?.Institution?.Title,
-                institutionSettings.Value.MinistryOfSportTitle,
+            if (string.Equals(workshopDraft.Provider?.Institution?.Id.ToString(),
+                institutionSettings.Value.MinistryOfSportId,
                  StringComparison.OrdinalIgnoreCase))
             {
 
                 var sectionRequest = workshopDraft.ToSportSectionPostRequest(imageStorageOptions.Value.BaseImageUrl);
+
+                if (!long.TryParse(sectionRequest.SectionAddressLocalityDictIdCode, out var catottgId))
+                {
+                    //  works, when no catottgId is provided, for safety
+                    throw new InvalidOperationException(
+                        $"Invalid CATOTTG Id: {sectionRequest.SectionAddressLocalityDictIdCode}");
+                }
+
+                sectionRequest.SectionAddressLocalityDictIdCode = await codeficatorService.GetCodeById(catottgId);
+
+                sectionRequest.SectionSportKindDictIdCode = await GetSectionSportKindDictIdCodeAsync(workshopDraft);
+
                 var result = await sportsRegistryApiService.RegisterSectionAsync(sectionRequest);
 
                 result.Match(
@@ -1342,7 +1355,7 @@ public class WorkshopDraftService(
         }
         
         dto.IsChampionPath = institutionHierarchy.Institution.Title.Equals(
-            institutionSettings.Value.MinistryOfSportTitle,
+            institutionSettings.Value.MinistryOfSportId,
             StringComparison.OrdinalIgnoreCase);
 
         if (dto.IsChampionPath)
@@ -1396,4 +1409,35 @@ public class WorkshopDraftService(
             dto.PreferentialTermsOfParticipation = null;
         }
     }
+    /// <summary>
+    /// Asynchronously retrieves the sport kind dictionary ID code associated with the specified workshop draft.
+    /// </summary>
+    /// <param name="workshopDraft">The workshop draft containing the necessary data to determine the sport kind dictionary ID code.</param>
+    /// <returns>The sport kind dictionary ID code as an integer.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the <paramref name="workshopDraft"/> is missing a valid InstitutionHierarchyId, if the corresponding
+    /// institution hierarchy cannot be found, or if the SportRegistryIdCode is not set.</exception>
+    private async Task<int> GetSectionSportKindDictIdCodeAsync(WorkshopDraft workshopDraft)
+    {
+        if (workshopDraft.WorkshopDraftContent?.InstitutionHierarchyId is not Guid institutionHierarchyId ||
+            institutionHierarchyId == Guid.Empty)
+        {
+            throw new InvalidOperationException("InstitutionHierarchyId is missing in WorkshopDraftContent.");
+        }
+
+        var institutionHierarchyDto = await institutionHierarchyService.GetById(institutionHierarchyId);
+
+        if (institutionHierarchyDto is null)
+        {
+            throw new InvalidOperationException($"InstitutionHierarchy with Id {institutionHierarchyId} not found.");
+        }
+
+        if (institutionHierarchyDto.SportRegistryIdCode is null)
+        {
+            throw new InvalidOperationException(
+                $"SportRegistryIdCode is missing for InstitutionHierarchy with Id {institutionHierarchyId}.");
+        }
+
+        return (int)institutionHierarchyDto.SportRegistryIdCode;
+    }
+
 }

--- a/OutOfSchool/OutOfSchool.Common/Config/InstitutionOptions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Config/InstitutionOptions.cs
@@ -3,5 +3,5 @@ namespace OutOfSchool.Common.Config;
 public class InstitutionOptions
 {
     public const string Name = "InstitutionOptions";
-    public string MinistryOfSportTitle { get; set; }
+    public string MinistryOfSportId { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Validators/PhoneListValidationAttribute.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Validators/PhoneListValidationAttribute.cs
@@ -2,7 +2,7 @@
 using System.Text.RegularExpressions;
 
 namespace OutOfSchool.SportsRegistryApiClient.Validators;
-public class PhoneListValidationAttribute :ValidationAttribute
+public class PhoneListValidationAttribute : ValidationAttribute
 {
     override protected ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -178,7 +178,7 @@
     }
   },
   "ImageStorage": {
-    "BaseImageUrl": "https://www.gstatic.com/images/"
+    "BaseImageUrl": "https://minio.pozashkillia-test.iea.gov.ua/outofschool/"
   },
   "FeatureManagement": {
     "Release1": true,
@@ -358,8 +358,6 @@
     "ClientSecret": ""
   },
   "InstitutionOptions": {
-    "MinistryOfSportTitle": "Мінспорт"
+    "MinistryOfSportId": "b929a4cd-ee3d-4bad-b2f0-d40aedf656c4" //temporary MON now, replace later to "b67a4f29-728e-4bb0-bb42-4a9d7e0bd90a"
   }
 }
-
-


### PR DESCRIPTION
Changes
- Added mapping of Codeficator (CATOTTG) from WorkshopDraft to SectionAddressLocalityDictIdCode.
- Added mapping of SportKindId from InstitutionHierarchy to SectionSportKindDictIdCode.
- Updated logic in Approve method to validate and fetch Codeficator code and SportKindId.
- Improved image mapping (SectionTitlePhoto, SectionPhotos) .

Configuration
- Replaced MinistryOfSportTitle config value with MinistryOfSportId.