### PR TITLE
Hotfix - Addition to fixing the Added DirectionSubDirectionIds property to the CompetitiveEventDrafts

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -675,9 +675,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             );
 
         competitiveEventDraftResponseDto.CompetitiveEventDetails.DirectionSubDirectionIds = (await subDirectionRepository
-            .GetByFilter(
-                         whereExpression: sd => competitiveEventDraftResponseDto.CompetitiveEventDetails.SubDirectionIds.Contains(sd.Id) && !sd.IsDeleted,
-                         includeExpression: q => q.Include(sd => sd.Direction))
+            .GetByFilter(whereExpression: sd => competitiveEventDraftResponseDto.CompetitiveEventDetails.SubDirectionIds.Contains(sd.Id) && !sd.IsDeleted)
             .ConfigureAwait(false))
             .Select(
                     s => new DirectionSubDirectionIdsDto

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -111,7 +111,8 @@ public class CompetitiveEventDraftServiceTests
 
         var subDirections = new List<SubDirection>
         {
-            new() { Id = 54, DirectionId = 14, Description = "description", IsDeleted = true, Title = "title"  }
+            new() { Id = 54, DirectionId = 14, Description = "description1", IsDeleted = false, Title = "title1"  },
+            new() { Id = 9, DirectionId = 10, Description = "description2", IsDeleted = true, Title = "title2"  }
         };
 
         mockCompetitiveEventService.Setup(service => service.GetById(dto.Id))
@@ -133,7 +134,8 @@ public class CompetitiveEventDraftServiceTests
         mockSubDirectionRepository.Setup(repo => repo.GetByFilter(
             It.IsAny<Expression<Func<SubDirection, bool>>>(),
             It.IsAny<string>(),
-            It.IsAny<Func<IQueryable<SubDirection>, IQueryable<SubDirection>>>())).ReturnsAsync(subDirections);
+            It.IsAny<Func<IQueryable<SubDirection>, IQueryable<SubDirection>>>()))
+            .ReturnsAsync(subDirections.Where(sd => !sd.IsDeleted));
 
         // Act
         var result = await competitiveEventDraftService.Create(dto);
@@ -141,8 +143,9 @@ public class CompetitiveEventDraftServiceTests
         // Assert
         Assert.IsNotNull(result);
         Assert.IsInstanceOf<CompetitiveEventDraftResultDto>(result);
-        Assert.AreEqual(result.CompetitiveEventDraft.CompetitiveEventDetails.DirectionSubDirectionIds[0].DirectionId, directionSubDirectionIds[0].DirectionId);
-        Assert.AreEqual(result.CompetitiveEventDraft.CompetitiveEventDetails.DirectionSubDirectionIds[0].SubDirectionId, directionSubDirectionIds[0].SubDirectionId);
+        Assert.That(result.CompetitiveEventDraft.CompetitiveEventDetails.DirectionSubDirectionIds, Has.Count.EqualTo(1));
+        Assert.That(result.CompetitiveEventDraft.CompetitiveEventDetails.DirectionSubDirectionIds
+              .Select(x => (x.DirectionId, x.SubDirectionId)), Is.EqualTo(directionSubDirectionIds.Select(x => (x.DirectionId, x.SubDirectionId))));
     }
 
     #endregion


### PR DESCRIPTION
1) Fixed the MapCompetitiveEventDraftWithDetails() private method of …CompetitiveEventDraftService -
removed the includeExpression parameter in the GetByFilter() method. 

2) Improved the Create_ReturnsDraftResultDto_WhenDtoIsValid() of the CompetitiveEventDraftServiceTests class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted sub-directions are no longer included in competitive event drafts, ensuring only active options appear.
* **Performance**
  * Reduced unnecessary data loading when mapping competitive event draft details, improving responsiveness in relevant flows.
* **Tests**
  * Updated tests to validate exclusion of deleted sub-directions and adjusted expectations to match the refined filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->