### PR TITLE
Implement Title Filter for Competitive Events and Drafts

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventFilterTitle.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventFilterTitle.cs
@@ -1,0 +1,8 @@
+﻿namespace OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
+public class CompetitiveEventFilterTitle : ExcludeIdFilter
+{
+    /// <summary>
+    /// Gets all entries by entered substring from current competitive events
+    /// </summary>
+    public string SearchText { get; set; } = string.Empty;
+}

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/CompetitiveEventDraftFilterTitle.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/CompetitiveEventDraftFilterTitle.cs
@@ -1,0 +1,8 @@
+﻿namespace OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
+public class CompetitiveEventDraftFilterTitle : ExcludeIdFilter
+{
+    /// <summary>
+    /// Gets all entries by entered substring from current competitive event drafts
+    /// </summary>
+    public string SearchText { get; set; } = string.Empty;
+}

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftFilterTitle.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftFilterTitle.cs
@@ -1,0 +1,8 @@
+﻿namespace OutOfSchool.BusinessLogic.Models.WorkshopDraft;
+public class WorkshopDraftFilterTitle : ExcludeIdFilter
+{
+    /// <summary>
+    /// Gets all entries by entered substring from current workshop drafts
+    /// </summary>
+    public string SearchText { get; set; } = string.Empty;
+}

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -235,27 +235,24 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
     }
 
     // <inheritdoc/>
-    public async Task<SearchResult<CompetitiveEventDraftViewCardDto>> GetByProviderId(Guid id, ExcludeIdFilter filter)
+    public async Task<SearchResult<CompetitiveEventDraftViewCardDto>> GetByProviderId(Guid id, CompetitiveEventDraftFilterTitle filter)
     {
         logger.LogDebug("Retrieving competitive event drafts for provider with ID: {ProviderId}", id);
 
         await currentUserService.UserHasRights(new ProviderRights(id), new EmployeeRights(id)).ConfigureAwait(false);
 
-        filter ??= new ExcludeIdFilter();
-        ModelValidationHelper.ValidateExcludedIdFilter(filter);
+        filter ??= new CompetitiveEventDraftFilterTitle();
+        ValidateCompetitiveEventDraftTitleFilter(filter);
+
+        var predicate = BuildPredicate(filter, id);
 
         var competitiveEventCardsCount = await competitiveEventDraftRepository
-            .Count(whereExpression: x =>
-            filter.ExcludedId == null
-            ? (x.ProviderId == id)
-            : (x.ProviderId == id && x.Id != filter.ExcludedId)).ConfigureAwait(false);
+            .Count(whereExpression: predicate).ConfigureAwait(false);
 
         var competitiveEventDrafts = await competitiveEventDraftRepository.Get(
             skip: filter.From,
             take: filter.Size,
-            whereExpression: x => filter.ExcludedId == null
-                ? (x.ProviderId == id)
-                : (x.ProviderId == id && x.Id != filter.ExcludedId)).ToListAsync().ConfigureAwait(false);
+            whereExpression: predicate).ToListAsync().ConfigureAwait(false);
 
         var competitiveEventDraftResponseDtos = new List<CompetitiveEventDraftViewCardDto>();
 
@@ -648,6 +645,27 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
                 Description = "An error occurred while updating CompetitiveEventDraft."
             });
         }
+    }
+
+    private static void ValidateCompetitiveEventDraftTitleFilter(CompetitiveEventDraftFilterTitle filter)
+        => ModelValidationHelper.ValidateCompetitiveEventDraftTitleFilter(filter);
+
+    private static Expression<Func<CompetitiveEventDraft, bool>> BuildPredicate(CompetitiveEventDraftFilterTitle filter, Guid providerId)
+    {
+        var predicate = PredicateBuilder.True<CompetitiveEventDraft>();
+        predicate = predicate.And(x => x.ProviderId == providerId);
+
+        if (filter.ExcludedId.HasValue)
+        {
+            predicate = predicate.And(x => x.Id != filter.ExcludedId.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.SearchText))
+        {
+            predicate = predicate.And(x => x.CompetitiveEventDraftContent.Title.Contains(filter.SearchText, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        return predicate;
     }
 
     private async Task<CompetitiveEventDraftResponseDto> MapCompetitiveEventDraftWithDetails(CompetitiveEventDraft draft)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/ICompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/ICompetitiveEventDraftService.cs
@@ -70,7 +70,7 @@ public interface ICompetitiveEventDraftService
     /// <param name="filter">Filter to get a certain portion of all entities Or/And exclude by CompetitiveEvent id.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.
     /// The task result contains a <see cref="SearchResult{CompetitiveEventDraftViewCardDto}"/> that contains elements from the input sequence.</returns>
-    Task<SearchResult<CompetitiveEventDraftViewCardDto>> GetByProviderId(Guid id, ExcludeIdFilter filter);
+    Task<SearchResult<CompetitiveEventDraftViewCardDto>> GetByProviderId(Guid id, CompetitiveEventDraftFilterTitle filter);
 
     /// <summary>
     /// Get all competitive event drafts by provider Id.

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventService.cs
@@ -8,6 +8,7 @@ using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Models.CompetitiveEvents;
 using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.Services.Repository.Base.Api;
+using System.Linq.Expressions;
 
 namespace OutOfSchool.BusinessLogic.Services;
 
@@ -122,7 +123,7 @@ public class CompetitiveEventService(
     }
 
     /// <inheritdoc/>
-    public async Task<SearchResult<CompetitiveEventViewCardDto>> GetByProviderId(Guid id, ExcludeIdFilter filter)
+    public async Task<SearchResult<CompetitiveEventViewCardDto>> GetByProviderId(Guid id, CompetitiveEventFilterTitle filter)
     {
         if (id == Guid.Empty)
         {
@@ -134,16 +135,10 @@ public class CompetitiveEventService(
 
         logger.LogDebug("Getting Competitive events by organization started. Looking ProviderId = {Id}.", id);
 
-        filter ??= new ExcludeIdFilter();
-        ValidateExcludedIdFilter(filter);
+        filter ??= new CompetitiveEventFilterTitle();
+        ValidateCompetitiveEventTitleFilter(filter);
 
-        var predicate = PredicateBuilder.True<CompetitiveEvent>();
-        predicate = predicate.And(x => x.OrganizerOfTheEventId == id);
-
-        if (filter.ExcludedId is not null && filter.ExcludedId != Guid.Empty)
-        {
-            predicate = predicate.And(x => x.Id != filter.ExcludedId);
-        }
+        var predicate = BuildPredicate(filter, id);
 
         var competitiveEventCardsCount = await competitiveEventRepository.Count(
             whereExpression: predicate).ConfigureAwait(false);
@@ -173,8 +168,26 @@ public class CompetitiveEventService(
         return await competitiveEventRepository.GetByIds(ids).ConfigureAwait(false);
     }
 
-    private static void ValidateExcludedIdFilter(ExcludeIdFilter filter)
-        => ModelValidationHelper.ValidateExcludedIdFilter(filter);
+    private static Expression<Func<CompetitiveEvent, bool>> BuildPredicate(CompetitiveEventFilterTitle filter, Guid providerId)
+    {
+        var predicate = PredicateBuilder.True<CompetitiveEvent>();
+        predicate = predicate.And(x => x.OrganizerOfTheEventId == providerId);
+
+        if (filter.ExcludedId.HasValue)
+        {
+            predicate = predicate.And(x => x.Id != filter.ExcludedId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.SearchText))
+        {
+            predicate = predicate.And(x => x.Title.Contains(filter.SearchText, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        return predicate;
+    }
+
+    private static void ValidateCompetitiveEventTitleFilter(CompetitiveEventFilterTitle filter)
+        => ModelValidationHelper.ValidateCompetitiveEventTitleFilter(filter);
 
     private async Task ChangeCompetitiveEventDescriptionItems(CompetitiveEvent currentCompetitiveEvent, List<CompetitiveEventDescriptionItemDto> descriptionItemsDtoList)
     {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ICompetitiveEventService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ICompetitiveEventService.cs
@@ -44,7 +44,7 @@ public interface ICompetitiveEventService
     /// <param name="filter">Filter to get a certain portion of all entities or exclude some entities by excluded ids.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.
     /// The task result contains a <see cref="List{CompetitiveEventViewCard}"/> that contains elements from the input sequence.</returns>
-    Task<SearchResult<CompetitiveEventViewCardDto>> GetByProviderId(Guid id, ExcludeIdFilter filter);
+    Task<SearchResult<CompetitiveEventViewCardDto>> GetByProviderId(Guid id, CompetitiveEventFilterTitle filter);
 
     /// <summary>
     /// Get multiple competitive events by their identifiers.

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/IWorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/IWorkshopDraftService.cs
@@ -80,7 +80,7 @@ public interface IWorkshopDraftService
     /// <param name="filter">Filter to get a certain portion of all entities Or/And exclude by Workshop id.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.
     /// The task result contains a <see cref="SearchResult{WorkshopDraftViewCardDto}"/> that contains elements from the input sequence.</returns>
-    Task<SearchResult<WorkshopDraftViewCardDto>> GetByProviderId(Guid id, ExcludeIdFilter filter);
+    Task<SearchResult<WorkshopDraftViewCardDto>> GetByProviderId(Guid id, WorkshopDraftFilterTitle filter);
 
     /// <summary>
     /// Get all workshop drafts by provider Id.

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -373,26 +373,23 @@ public class WorkshopDraftService(
     }
 
     // <inheritdoc/>
-    public async Task<SearchResult<WorkshopDraftViewCardDto>> GetByProviderId(Guid id, ExcludeIdFilter filter)
+    public async Task<SearchResult<WorkshopDraftViewCardDto>> GetByProviderId(Guid id, WorkshopDraftFilterTitle filter)
     {
         logger.LogDebug("Getting Workshop Draft by organization started. Looking ProviderId = {Id}.", id);
 
         await currentUserService.UserHasRights(new ProviderRights(id), new EmployeeRights(id)).ConfigureAwait(false);
 
-        filter ??= new ExcludeIdFilter();
-        ValidateExcludedIdFilter(filter);
+        filter ??= new WorkshopDraftFilterTitle();
+        ValidateWorkshopDraftTitleFilter(filter);
 
-        var workshopBaseCardsCount = await workshopDraftRepository.Count(whereExpression: x =>
-            filter.ExcludedId == null
-                ? (x.ProviderId == id)
-                : (x.ProviderId == id && x.Id != filter.ExcludedId)).ConfigureAwait(false);
+        var predicate = BuildPredicate(filter, id);
+
+        var workshopBaseCardsCount = await workshopDraftRepository.Count(whereExpression: predicate).ConfigureAwait(false);
 
         var workshopDrafts = await workshopDraftRepository.Get(
                 skip: filter.From,
                 take: filter.Size,
-                whereExpression: x => filter.ExcludedId == null
-                    ? (x.ProviderId == id)
-                    : (x.ProviderId == id && x.Id != filter.ExcludedId),
+                whereExpression: predicate,
                 orderBy: new Dictionary<Expression<Func<WorkshopDraft, object>>, SortDirection>()
                 {
                     {wd => wd.CreatedAt, SortDirection.Descending},
@@ -815,6 +812,25 @@ public class WorkshopDraftService(
         }
     }
 
+    private static Expression<Func<WorkshopDraft, bool>> BuildPredicate(WorkshopDraftFilterTitle filter, Guid providerId)
+    {
+        var predicate = PredicateBuilder.True<WorkshopDraft>();
+
+        predicate = predicate.And(x => x.ProviderId == providerId);
+
+        if (filter.ExcludedId.HasValue)
+        {
+            predicate = predicate.And(x => x.Id != filter.ExcludedId.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.SearchText))
+        {
+            predicate = predicate.And(x => x.WorkshopDraftContent.Title.Contains(filter.SearchText, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        return predicate;
+    }
+
     private async Task<WorkshopDraft> GetWorkshopDraftById(Guid id)
     {
         logger.LogDebug("Getting WorkshopDraft by Id started. Looking Id = {Id}.", id);
@@ -999,8 +1015,8 @@ public class WorkshopDraftService(
         return task.Result;
     }
 
-    private static void ValidateExcludedIdFilter(ExcludeIdFilter filter)
-        => ModelValidationHelper.ValidateExcludedIdFilter(filter);
+    private static void ValidateWorkshopDraftTitleFilter(WorkshopDraftFilterTitle filter)
+        => ModelValidationHelper.ValidateWorkshopDraftTitleFilter(filter);
 
     private async Task<(Guid InstitutionId, long CatottgId)> GetAdminInstitutionAndCatottgIds()
     {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/ModelValidationHelper.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/ModelValidationHelper.cs
@@ -1,5 +1,8 @@
 ﻿using System.Text;
 using OutOfSchool.BusinessLogic.Models;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
+using OutOfSchool.BusinessLogic.Models.WorkshopDraft;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 
 namespace OutOfSchool.BusinessLogic.Util;
@@ -62,6 +65,36 @@ public static class ModelValidationHelper
     }
 
     public static void ValidateWorkshopTitleFilter(WorkshopFilterTitle filter)
+    {
+        if (filter == null)
+        {
+            throw new ArgumentNullException(nameof(filter));
+        }
+
+        ValidateExcludedIdFilter(filter);
+    }
+
+    public static void ValidateWorkshopDraftTitleFilter(WorkshopDraftFilterTitle filter)
+    {
+        if (filter == null)
+        {
+            throw new ArgumentNullException(nameof(filter));
+        }
+
+        ValidateExcludedIdFilter(filter);
+    }
+
+    public static void ValidateCompetitiveEventTitleFilter(CompetitiveEventFilterTitle filter)
+    {
+        if (filter == null)
+        {
+            throw new ArgumentNullException(nameof(filter));
+        }
+
+        ValidateExcludedIdFilter(filter);
+    }
+
+    public static void ValidateCompetitiveEventDraftTitleFilter(CompetitiveEventDraftFilterTitle filter)
     {
         if (filter == null)
         {

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventControllerTests.cs
@@ -274,9 +274,9 @@ public class CompetitiveEventControllerTests
 
         var providerId = Guid.NewGuid();
 
-        var filter = new ExcludeIdFilter();
+        var filter = new CompetitiveEventFilterTitle();
 
-        competitiveEventService.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+        competitiveEventService.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<CompetitiveEventFilterTitle>()))
            .ReturnsAsync(searchResult);
 
         // Act
@@ -303,9 +303,9 @@ public class CompetitiveEventControllerTests
 
         var providerId = Guid.NewGuid();
 
-        var filter = new ExcludeIdFilter();
+        var filter = new CompetitiveEventFilterTitle();
 
-        competitiveEventService.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+        competitiveEventService.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<CompetitiveEventFilterTitle>()))
            .ReturnsAsync(searchResult);
 
         // Act
@@ -320,9 +320,9 @@ public class CompetitiveEventControllerTests
     public async Task GetCompetitiveEventViewcardByProviderId_WhenCompetitiveEventsExist_ReturnsOkResultObject()
     {
         // Arrange
-        var filter = new ExcludeIdFilter() { From = 0, Size = int.MaxValue };
+        var filter = new CompetitiveEventFilterTitle() { From = 0, Size = int.MaxValue };
         var searchResult = new SearchResult<CompetitiveEventViewCardDto>() { TotalAmount = 5, Entities = competitiveEventViewCardList };
-        competitiveEventService.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+        competitiveEventService.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<CompetitiveEventFilterTitle>()))
             .ReturnsAsync(searchResult);
 
         // Act
@@ -333,17 +333,6 @@ public class CompetitiveEventControllerTests
         Assert.That(result, Is.Not.Null);
         Assert.AreEqual(StatusCodes.Status200OK, result.StatusCode);
         Assert.AreEqual(competitiveEventViewCardList.Count, (result.Value as SearchResult<CompetitiveEventViewCardDto>).TotalAmount);
-    }
-
-    [Test]
-    public async Task GetCompetitiveEventViewcardByProviderId_WhenGuidIsEmpty_ReturnsBadRequest()
-    {
-        // Act
-        var result = await controller.GetCompetitiveEventViewCardByProviderId(Guid.Empty, null).ConfigureAwait(false) as BadRequestObjectResult;
-
-        // Assert
-        Assert.IsInstanceOf<BadRequestObjectResult>(result);
-        Assert.AreEqual("Provider id is empty.", (result as BadRequestObjectResult).Value);
     }
 
     [Test]
@@ -364,14 +353,14 @@ public class CompetitiveEventControllerTests
         // Arrange
         var expectedCompetitiveEventCardsCount = this.competitiveEventViewCardList.Count - 1;
         var excludedId = competitiveEventViewCardList.FirstOrDefault().Id;
-        var filter = new ExcludeIdFilter() { From = 0, Size = int.MaxValue, ExcludedId = excludedId };
+        var filter = new CompetitiveEventFilterTitle() { From = 0, Size = int.MaxValue, ExcludedId = excludedId };
         var searchResult = new SearchResult<CompetitiveEventViewCardDto>() 
         {
             TotalAmount = 4,
             Entities = competitiveEventViewCardList.Skip(1).ToList() 
         };
         
-        competitiveEventService.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+        competitiveEventService.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<CompetitiveEventFilterTitle>()))
             .ReturnsAsync(searchResult);
 
         // Act
@@ -390,14 +379,14 @@ public class CompetitiveEventControllerTests
     {
         // Arrange
         var expectedCount = 1;
-        var filter = new ExcludeIdFilter() { From = 0, Size = expectedCount };
+        var filter = new CompetitiveEventFilterTitle() { From = 0, Size = expectedCount };
         var expectedTotalAmount = 5;
         var searchResult = new SearchResult<CompetitiveEventViewCardDto>() 
         {
             TotalAmount = expectedTotalAmount,
             Entities = competitiveEventViewCardList.Take(expectedCount).ToList(),
         };
-        competitiveEventService.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+        competitiveEventService.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<CompetitiveEventFilterTitle>()))
             .ReturnsAsync(searchResult);
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventDraftControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventDraftControllerTests.cs
@@ -690,7 +690,7 @@ public class CompetitiveEventDraftControllerTests
     {
         // Arrange
         var id = Guid.NewGuid();
-        var filter = new ExcludeIdFilter();
+        var filter = new CompetitiveEventDraftFilterTitle();
         var resultDto = new SearchResult<CompetitiveEventDraftViewCardDto> { TotalAmount = 1, Entities = new List<CompetitiveEventDraftViewCardDto> { new() } };
         competitiveEventDraftServiceMock.Setup(s => s.GetByProviderId(id, filter)).ReturnsAsync(resultDto);
 
@@ -706,7 +706,7 @@ public class CompetitiveEventDraftControllerTests
     {
         // Arrange
         var id = Guid.NewGuid();
-        var filter = new ExcludeIdFilter();
+        var filter = new CompetitiveEventDraftFilterTitle();
         var emptyResult = new SearchResult<CompetitiveEventDraftViewCardDto> { TotalAmount = 0, Entities = new List<CompetitiveEventDraftViewCardDto>() };
 
         competitiveEventDraftServiceMock.Setup(s => s.GetByProviderId(id, filter)).ReturnsAsync(emptyResult);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventsV2ControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventsV2ControllerTests.cs
@@ -65,7 +65,7 @@ public class CompetitiveEventsV2ControllerTests
     public async Task GetByProviderId_ReturnsOk_WhenResultsExist()
     {
         var id = Guid.NewGuid();
-        var filter = new ExcludeIdFilter();
+        var filter = new CompetitiveEventFilterTitle();
         var resultDto = new SearchResult<CompetitiveEventViewCardDto> { TotalAmount = 1, Entities = new List<CompetitiveEventViewCardDto> { new() } };
 
         competitiveEventServiceMock.Setup(s => s.GetByProviderId(id, filter)).ReturnsAsync(resultDto);
@@ -79,7 +79,7 @@ public class CompetitiveEventsV2ControllerTests
     public async Task GetByProviderId_ReturnsNoContent_WhenNoResultsFound()
     {
         var id = Guid.NewGuid();
-        var filter = new ExcludeIdFilter();
+        var filter = new CompetitiveEventFilterTitle();
         var emptyResult = new SearchResult<CompetitiveEventViewCardDto> { TotalAmount = 0, Entities = new List<CompetitiveEventViewCardDto>() };
 
         competitiveEventServiceMock.Setup(s => s.GetByProviderId(id, filter)).ReturnsAsync(emptyResult);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopDraftControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopDraftControllerTests.cs
@@ -242,7 +242,7 @@ public class WorkshopDraftControllerTests
             },            
         };
 
-        workshopDraftServiceMoq.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+        workshopDraftServiceMoq.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<WorkshopDraftFilterTitle>()))
             .ReturnsAsync(searchResult).Verifiable(Times.Once);
 
         // Act
@@ -257,14 +257,14 @@ public class WorkshopDraftControllerTests
     public async Task GetByProviderId_WhenThereIsNoWorkshopDrafts_ShouldReturnNoContentResult()
     {
         // Arrange
-        var filter = new ExcludeIdFilter() { From = 0, Size = int.MaxValue };
+        var filter = new WorkshopDraftFilterTitle() { From = 0, Size = int.MaxValue };
         var emptySearchResult = new SearchResult<WorkshopDraftViewCardDto>() 
         { 
             TotalAmount = 0, 
             Entities = new List<WorkshopDraftViewCardDto>() 
         };
 
-        workshopDraftServiceMoq.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<ExcludeIdFilter>()))
+        workshopDraftServiceMoq.Setup(x => x.GetByProviderId(It.IsAny<Guid>(), It.IsAny<WorkshopDraftFilterTitle>()))
             .ReturnsAsync(emptySearchResult);
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -462,7 +462,7 @@ public class CompetitiveEventDraftServiceTests
     {
         // Arrange
         Guid providerId = Guid.NewGuid();
-        var filter = new ExcludeIdFilter();
+        var filter = new CompetitiveEventDraftFilterTitle();
         var drafts = new List<CompetitiveEventDraft>
         {
             new CompetitiveEventDraft

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using OutOfSchool.BusinessLogic.Common;
@@ -26,6 +21,11 @@ using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.Services.Repository.Base.Api;
 using OutOfSchool.Tests.Common;
 using OutOfSchool.Tests.Common.TestDataGenerators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -468,6 +468,7 @@ public class CompetitiveEventDraftServiceTests
             new CompetitiveEventDraft
             {
                 Id = Guid.NewGuid(),
+                ProviderId = providerId,
                 DraftStatus = CompetitiveEventDraftStatus.Draft,
                 CompetitiveEventDraftContent = new CompetitiveEventDraftContent { Title = "Test Event" },
                 CoverImageId = "coverImageId"
@@ -483,9 +484,15 @@ public class CompetitiveEventDraftServiceTests
             .Returns(Task.CompletedTask);
         mockCompetitiveEventDraftRepository.Setup(repo => repo.Count(It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>()))
             .ReturnsAsync(searchResult.TotalAmount);
-        mockCompetitiveEventDraftRepository.Setup(repo => repo.Get(filter.From, filter.Size, It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
+        mockCompetitiveEventDraftRepository
+            .Setup(repo => repo.Get(
+            filter.From,
+            filter.Size,
+            It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
             It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
-            .Returns(drafts.AsTestAsyncEnumerableQuery);
+            .Returns((int from, int size, Expression<Func<CompetitiveEventDraft, bool>> predicate,
+            Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection> sort)
+                => drafts.AsQueryable().Where(predicate).AsTestAsyncEnumerableQuery());
 
         // Act
         var result = await competitiveEventDraftService.GetByProviderId(providerId, filter);
@@ -507,6 +514,7 @@ public class CompetitiveEventDraftServiceTests
             new CompetitiveEventDraft
             {
                 Id = Guid.NewGuid(),
+                ProviderId = providerId,
                 DraftStatus = CompetitiveEventDraftStatus.Draft,
                 CompetitiveEventDraftContent = new CompetitiveEventDraftContent { Title = "Test Event" },
                 CoverImageId = "coverImageId"
@@ -521,9 +529,15 @@ public class CompetitiveEventDraftServiceTests
             .Returns(Task.CompletedTask);
         mockCompetitiveEventDraftRepository.Setup(repo => repo.Count(It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>()))
             .ReturnsAsync(searchResult.TotalAmount);
-        mockCompetitiveEventDraftRepository.Setup(repo => repo.Get(filter.From, filter.Size, It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
+        mockCompetitiveEventDraftRepository
+            .Setup(repo => repo.Get(
+            filter.From,
+            filter.Size,
+            It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
             It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
-            .Returns(drafts.AsTestAsyncEnumerableQuery);
+            .Returns((int from, int size, Expression<Func<CompetitiveEventDraft, bool>> predicate,
+            Dictionary < Expression<Func<CompetitiveEventDraft, object>>, SortDirection > sort)
+                => drafts.AsQueryable().Where(predicate).AsTestAsyncEnumerableQuery());
 
         // Act
         var result = await competitiveEventDraftService.GetByProviderId(providerId, filter);
@@ -531,7 +545,7 @@ public class CompetitiveEventDraftServiceTests
         // Assert
         Assert.IsNotNull(result);
         Assert.IsInstanceOf<SearchResult<CompetitiveEventDraftViewCardDto>>(result);
-        Assert.AreEqual(1, result.TotalAmount);
+        Assert.AreEqual(1, result.Entities.Count);
         Assert.AreEqual(result.Entities.First().Title, drafts.First().CompetitiveEventDraftContent.Title);
     }
 
@@ -547,6 +561,7 @@ public class CompetitiveEventDraftServiceTests
             new CompetitiveEventDraft
             {
                 Id = excludedId,
+                ProviderId = providerId,
                 DraftStatus = CompetitiveEventDraftStatus.Draft,
                 CompetitiveEventDraftContent = new CompetitiveEventDraftContent { Title = "Test Event" },
                 CoverImageId = "coverImageId"
@@ -554,6 +569,7 @@ public class CompetitiveEventDraftServiceTests
             new CompetitiveEventDraft
             {
                 Id = Guid.NewGuid(),
+                ProviderId = providerId,
                 DraftStatus = CompetitiveEventDraftStatus.Draft,
                 CompetitiveEventDraftContent = new CompetitiveEventDraftContent { Title = "Another Test Event" },
                 CoverImageId = "coverImageId2"
@@ -568,9 +584,15 @@ public class CompetitiveEventDraftServiceTests
             .Returns(Task.CompletedTask);
         mockCompetitiveEventDraftRepository.Setup(repo => repo.Count(It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>()))
             .ReturnsAsync(searchResult.TotalAmount);
-        mockCompetitiveEventDraftRepository.Setup(repo => repo.Get(filter.From, filter.Size, It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
+        mockCompetitiveEventDraftRepository
+            .Setup(repo => repo.Get(
+            filter.From,
+            filter.Size,
+            It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
             It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
-            .Returns(drafts.AsTestAsyncEnumerableQuery);
+            .Returns((int from, int size, Expression<Func<CompetitiveEventDraft, bool>> predicate,
+            Dictionary <Expression<Func<CompetitiveEventDraft, object>>, SortDirection> sort)
+                => drafts.AsQueryable().Where(predicate).AsTestAsyncEnumerableQuery());
 
         // Act
         var result = await competitiveEventDraftService.GetByProviderId(providerId, filter);
@@ -578,8 +600,9 @@ public class CompetitiveEventDraftServiceTests
         // Assert
         Assert.IsNotNull(result);
         Assert.IsInstanceOf<SearchResult<CompetitiveEventDraftViewCardDto>>(result);
-        Assert.AreEqual(1, result.TotalAmount);
-        Assert.AreEqual(result.Entities.First().Title, drafts.First().CompetitiveEventDraftContent.Title);
+        Assert.AreEqual(1, result.Entities.Count);
+        Assert.AreEqual(result.Entities.First().Title, drafts.First(x => x.Id != excludedId).CompetitiveEventDraftContent.Title);
+        Assert.IsFalse(result.Entities.Any(e => e.CompetitiveEventDraftId == excludedId));
     }
 
     #endregion GetByProviderId

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -532,13 +532,61 @@ public class CompetitiveEventDraftServiceTests
         Assert.IsNotNull(result);
         Assert.IsInstanceOf<SearchResult<CompetitiveEventDraftViewCardDto>>(result);
         Assert.AreEqual(1, result.TotalAmount);
-        Assert.AreEqual(result.Entities.First().Title, drafts.First().CompetitiveEventDraftContent.Title);  
+        Assert.AreEqual(result.Entities.First().Title, drafts.First().CompetitiveEventDraftContent.Title);
     }
-        #endregion GetByProviderId
 
-        #region GetCompetitiveEventDraftByIdMapped
+    [Test]
+    public async Task GetByProviderId_ReturnsValidResult_WhenFilterHasExcludedId()
+    {
+        // Arrange
+        Guid providerId = Guid.NewGuid();
+        Guid excludedId = Guid.NewGuid();
+        var filter = new CompetitiveEventDraftFilterTitle { ExcludedId = excludedId };
+        var drafts = new List<CompetitiveEventDraft>
+        {
+            new CompetitiveEventDraft
+            {
+                Id = excludedId,
+                DraftStatus = CompetitiveEventDraftStatus.Draft,
+                CompetitiveEventDraftContent = new CompetitiveEventDraftContent { Title = "Test Event" },
+                CoverImageId = "coverImageId"
+            },
+            new CompetitiveEventDraft
+            {
+                Id = Guid.NewGuid(),
+                DraftStatus = CompetitiveEventDraftStatus.Draft,
+                CompetitiveEventDraftContent = new CompetitiveEventDraftContent { Title = "Another Test Event" },
+                CoverImageId = "coverImageId2"
+            }
+        };
+        var searchResult = new SearchResult<CompetitiveEventDraftViewCardDto>
+        {
+            Entities = new[] { drafts.FirstOrDefault(x => x.Id != excludedId).ToCardDto() },
+            TotalAmount = 1
+        };
+        mockUserService.Setup(service => service.UserHasRights(It.IsAny<IUserRights[]>()))
+            .Returns(Task.CompletedTask);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Count(It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>()))
+            .ReturnsAsync(searchResult.TotalAmount);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Get(filter.From, filter.Size, It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
+            It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
+            .Returns(drafts.AsTestAsyncEnumerableQuery);
 
-        [Test]
+        // Act
+        var result = await competitiveEventDraftService.GetByProviderId(providerId, filter);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOf<SearchResult<CompetitiveEventDraftViewCardDto>>(result);
+        Assert.AreEqual(1, result.TotalAmount);
+        Assert.AreEqual(result.Entities.First().Title, drafts.First().CompetitiveEventDraftContent.Title);
+    }
+
+    #endregion GetByProviderId
+
+    #region GetCompetitiveEventDraftByIdMapped
+
+    [Test]
     public async Task GetCompetitiveEventDraftByIdMapped_ReturnsNull_IfDraftDoesNotExist()
     {
         // Arrange

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -496,11 +496,49 @@ public class CompetitiveEventDraftServiceTests
         Assert.AreEqual(1, result.TotalAmount);
     }
 
-    #endregion GetByProviderId
-
-    #region GetCompetitiveEventDraftByIdMapped
-
     [Test]
+    public async Task GetByProviderId_ReturnsSearchResult_WhenFilterContainsSearchText()
+    {
+        // Arrange
+        Guid providerId = Guid.NewGuid();
+        var filter = new CompetitiveEventDraftFilterTitle { SearchText = "test" };
+        var drafts = new List<CompetitiveEventDraft>
+        {
+            new CompetitiveEventDraft
+            {
+                Id = Guid.NewGuid(),
+                DraftStatus = CompetitiveEventDraftStatus.Draft,
+                CompetitiveEventDraftContent = new CompetitiveEventDraftContent { Title = "Test Event" },
+                CoverImageId = "coverImageId"
+            }
+        };
+        var searchResult = new SearchResult<CompetitiveEventDraftViewCardDto>
+        {
+            Entities = new[] { drafts.FirstOrDefault().ToCardDto() },
+            TotalAmount = 1
+        };
+        mockUserService.Setup(service => service.UserHasRights(It.IsAny<IUserRights[]>()))
+            .Returns(Task.CompletedTask);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Count(It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>()))
+            .ReturnsAsync(searchResult.TotalAmount);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Get(filter.From, filter.Size, It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
+            It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
+            .Returns(drafts.AsTestAsyncEnumerableQuery);
+
+        // Act
+        var result = await competitiveEventDraftService.GetByProviderId(providerId, filter);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOf<SearchResult<CompetitiveEventDraftViewCardDto>>(result);
+        Assert.AreEqual(1, result.TotalAmount);
+        Assert.AreEqual(result.Entities.First().Title, drafts.First().CompetitiveEventDraftContent.Title);  
+    }
+        #endregion GetByProviderId
+
+        #region GetCompetitiveEventDraftByIdMapped
+
+        [Test]
     public async Task GetCompetitiveEventDraftByIdMapped_ReturnsNull_IfDraftDoesNotExist()
     {
         // Arrange

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventServiceTests.cs
@@ -335,7 +335,7 @@ public class CompetitiveEventServiceTests
     {
         // Arrange
         var invalidProviderId = Guid.Empty;
-        var filter = new ExcludeIdFilter();
+        var filter = new CompetitiveEventFilterTitle();
 
         // Act & Assert
         var exception = Assert.ThrowsAsync<ArgumentException>(async () =>

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventServiceTests.cs
@@ -384,6 +384,26 @@ public class CompetitiveEventServiceTests
         Assert.IsInstanceOf<IReadOnlyCollection<CompetitiveEventViewCardDto>>(result.Entities);
     }
 
+    [Test]
+    public async Task GetByProviderId_WhenFilterContainsExcludedId_ReturnsValidResult()
+    {
+        // Arrange
+        var filter = new CompetitiveEventFilterTitle
+        {
+            ExcludedId = firstId
+        };
+        var expected = CompetitiveEvents()
+            .Where(x => x.OrganizerOfTheEventId == firstProviderId && x.Id != firstId);
+
+        // Act
+        var result = await service.GetByProviderId(firstProviderId, filter).ConfigureAwait(false);
+
+        // Assert
+        Assert.IsNotNull(result.Entities);
+        Assert.AreEqual(expected.Count(), result.TotalAmount);
+        Assert.IsInstanceOf<IReadOnlyCollection<CompetitiveEventViewCardDto>>(result.Entities);
+    }
+
     #endregion
 
     private void SeedDatabase()

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventServiceTests.cs
@@ -78,6 +78,8 @@ public class CompetitiveEventServiceTests
         SeedDatabase();
     }
 
+    #region GetById
+
     [Test]
     public async Task GetById_WhenIdIsValid_ReturnsEntity()
     {
@@ -110,6 +112,10 @@ public class CompetitiveEventServiceTests
         Assert.IsNull(result, "Expected null for invalid ID.");
     }
 
+    #endregion
+
+    #region Create
+
     [Test]
     [Ignore("Test is ignored because the method being tested uses a transaction, which is not supported by in-memory database.")]
     public async Task Create_WhenEntityIsValid_ReturnsCreatedEntity()
@@ -137,6 +143,10 @@ public class CompetitiveEventServiceTests
         Assert.AreEqual(input.Title, result.Title);
         Assert.That(countBeforeCreating, Is.EqualTo(countAfterCreating - 1));
     }
+
+    #endregion Create
+
+    #region Update
 
     [Test]
     public void Update_WhenDtoIsNull_ThrowsArgumentNullException()
@@ -272,6 +282,10 @@ public class CompetitiveEventServiceTests
             .Any(d => d.Id == firstDescItemId));
     }
 
+    #endregion Update
+
+    #region Delete
+
     [Test]
     public async Task Delete_WhenIdIsValid_DeletesEntity()
     {
@@ -296,6 +310,10 @@ public class CompetitiveEventServiceTests
         Assert.ThrowsAsync<ArgumentOutOfRangeException>(
             async () => await service.Delete(id).ConfigureAwait(false));
     }
+
+    #endregion
+
+    #region GetByProviderId
 
     [Test]
     public async Task GetByProviderId_NotValidProviderId_ReturnsEmpty()
@@ -343,6 +361,30 @@ public class CompetitiveEventServiceTests
 
         Assert.AreEqual("ProviderId cannot be empty. (Parameter 'id')", exception.Message, "Unexpected exception message.");
     }
+
+    [Test]
+    public async Task GetByProviderId_WhenFilterContainsSearchText_ReturnsValidResult()
+    {
+        // Arrange
+        var filter = new CompetitiveEventFilterTitle
+        {
+            SearchText = "test1"
+        };
+        var expected = CompetitiveEvents().Where(x => x.OrganizerOfTheEventId == firstProviderId);
+
+        // Act
+        var result = await service.GetByProviderId(firstProviderId, filter).ConfigureAwait(false);
+
+        // Assert
+        Assert.IsNotNull(result.Entities);
+        Assert.AreEqual(expected.First().Id, result.Entities.First().Id);
+        Assert.AreEqual(expected.First().Title, result.Entities.First().Title);
+        Assert.AreEqual(expected.First().ShortTitle, result.Entities.First().ShortTitle);
+        Assert.AreEqual(expected.Count(), result.TotalAmount);
+        Assert.IsInstanceOf<IReadOnlyCollection<CompetitiveEventViewCardDto>>(result.Entities);
+    }
+
+    #endregion
 
     private void SeedDatabase()
     {

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -829,9 +829,49 @@ public class WorkshopDraftServiceTests
         result.Entities.First().Should().BeEquivalentTo(workshopDraftResponse);
     }
 
-    #endregion
+    [Test]
+    public async Task GetByProviderId_WhenFilterHasExcludedId_ShouldReturnValidResult()
+    {
+        // Arrange
+        var numberOfWorkshops = 5;
+        var excludedId = Guid.NewGuid();
+        var workshops = WorkshopGenerator.Generate(numberOfWorkshops).WithProvider().WithTeachers();
+        workshops.First().Id = excludedId;
+        var workshopV2Dtos = workshops.ToV2Dto();
+        var workshopDrafts = workshopV2Dtos.ToDraft();
+        var workshopDraftResponses = workshopDrafts.Where(x => x.Id != excludedId).ToCardDto();
+        institutionHierarchyRepositoryMoq.Setup(
+            x => x.Get(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<Expression<Func<InstitutionHierarchy, bool>>>(),
+                It.IsAny<Dictionary<Expression<Func<InstitutionHierarchy, object>>, SortDirection>>()))
+            .Returns(new List<InstitutionHierarchy>().AsTestAsyncEnumerableQuery());
+        workshopDraftRepoMoq.Setup(x => x.Count(It.IsAny<Expression<Func<WorkshopDraft, bool>>>()))
+            .ReturnsAsync(numberOfWorkshops).Verifiable(Times.Once);
+        workshopDraftRepoMoq.Setup(x =>
+            x.Get(It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Expression<Func<WorkshopDraft, bool>>>(),
+                    It.IsAny<Dictionary<Expression<Func<WorkshopDraft, object>>, SortDirection>>()))
+            .Returns(workshopDrafts.AsTestAsyncEnumerableQuery).Verifiable(Times.Once);
+        var filter = new WorkshopDraftFilterTitle
+        {
+            ExcludedId = excludedId
+        };
+
+        // Act
+        var result = await service.GetByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false);
+
+        // Assert
+        workshopDraftRepoMoq.VerifyAll();
+        currentUserServiceMoq.VerifyAll();
+        result.Entities.Should().BeEquivalentTo(workshopDraftResponses);
+    }
+        #endregion
 
     #region UpdateWorkshop
+
     [Test]
     public async Task UpdateWorkshop_WhenModeratedFieldsWasNotChanged_ShouldCallWorkshopUpdate()
     {

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -788,6 +788,47 @@ public class WorkshopDraftServiceTests
         currentUserServiceMoq.VerifyAll();
         result.Entities.Should().BeEquivalentTo(workshopDraftResponses);
     }
+
+    [Test]
+    public async Task GetByProviderId_WhenFilterContainsSearchText_ShouldReturnFilteredEntities()
+    {
+        // Arrange
+        var numberOfWorkshops = 5;
+        var searchText = "searchText";
+        var workshops = WorkshopGenerator.Generate(numberOfWorkshops).WithProvider().WithTeachers();
+        workshops.First().Title = $"Some {searchText} title";
+        var workshopV2Dtos = workshops.ToV2Dto();
+        var workshopDrafts = workshopV2Dtos.ToDraft();
+        var workshopDraftResponse = workshopDrafts.First().ToCardDto();
+        institutionHierarchyRepositoryMoq.Setup(
+            x => x.Get(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<Expression<Func<InstitutionHierarchy, bool>>>(),
+                It.IsAny<Dictionary<Expression<Func<InstitutionHierarchy, object>>, SortDirection>>()))
+            .Returns(new List<InstitutionHierarchy>().AsTestAsyncEnumerableQuery());
+        workshopDraftRepoMoq.Setup(x => x.Count(It.IsAny<Expression<Func<WorkshopDraft, bool>>>()))
+            .ReturnsAsync(numberOfWorkshops).Verifiable(Times.Once);
+        workshopDraftRepoMoq.Setup(x =>
+            x.Get(It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<Expression<Func<WorkshopDraft, bool>>>(),
+                    It.IsAny<Dictionary<Expression<Func<WorkshopDraft, object>>, SortDirection>>()))
+            .Returns(workshopDrafts.AsTestAsyncEnumerableQuery).Verifiable(Times.Once);
+        var filter = new WorkshopDraftFilterTitle
+        {
+            SearchText = searchText
+        };
+
+        // Act
+        var result = await service.GetByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false);
+
+        // Assert
+        workshopDraftRepoMoq.VerifyAll();
+        currentUserServiceMoq.VerifyAll();
+        result.Entities.First().Should().BeEquivalentTo(workshopDraftResponse);
+    }
+
     #endregion
 
     #region UpdateWorkshop

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -35,6 +30,11 @@ using OutOfSchool.Services.Models.WorkshopDrafts;
 using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.Tests.Common;
 using OutOfSchool.Tests.Common.TestDataGenerators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -793,10 +793,15 @@ public class WorkshopDraftServiceTests
     public async Task GetByProviderId_WhenFilterContainsSearchText_ShouldReturnFilteredEntities()
     {
         // Arrange
+        var providerId = Guid.NewGuid();
         var numberOfWorkshops = 5;
         var searchText = "searchText";
         var workshops = WorkshopGenerator.Generate(numberOfWorkshops).WithProvider().WithTeachers();
         workshops.First().Title = $"Some {searchText} title";
+        foreach (var workshop in workshops)
+        {
+            workshop.ProviderId = providerId;
+        }
         var workshopV2Dtos = workshops.ToV2Dto();
         var workshopDrafts = workshopV2Dtos.ToDraft();
         var workshopDraftResponse = workshopDrafts.First().ToCardDto();
@@ -807,25 +812,35 @@ public class WorkshopDraftServiceTests
                 It.IsAny<Expression<Func<InstitutionHierarchy, bool>>>(),
                 It.IsAny<Dictionary<Expression<Func<InstitutionHierarchy, object>>, SortDirection>>()))
             .Returns(new List<InstitutionHierarchy>().AsTestAsyncEnumerableQuery());
-        workshopDraftRepoMoq.Setup(x => x.Count(It.IsAny<Expression<Func<WorkshopDraft, bool>>>()))
-            .ReturnsAsync(numberOfWorkshops).Verifiable(Times.Once);
-        workshopDraftRepoMoq.Setup(x =>
-            x.Get(It.IsAny<int>(),
+        Expression<Func<WorkshopDraft, bool>> whereExpr = null;
+        workshopDraftRepoMoq
+                    .Setup(x => x.Count(It.IsAny<Expression<Func<WorkshopDraft, bool>>>()))
+                    .Callback<Expression<Func<WorkshopDraft, bool>>>(p => whereExpr = p)
+                    .ReturnsAsync(() => workshopDrafts.Count(wd => whereExpr.Compile().Invoke(wd)))
+                    .Verifiable(Times.Once);
+        workshopDraftRepoMoq
+                    .Setup(x => x.Get(
+                    It.IsAny<int>(),
                     It.IsAny<int>(),
                     It.IsAny<Expression<Func<WorkshopDraft, bool>>>(),
                     It.IsAny<Dictionary<Expression<Func<WorkshopDraft, object>>, SortDirection>>()))
-            .Returns(workshopDrafts.AsTestAsyncEnumerableQuery).Verifiable(Times.Once);
+                    .Returns((int skip, int take, Expression<Func<WorkshopDraft, bool>> predicate,
+                    Dictionary<Expression<Func<WorkshopDraft, object>>, SortDirection> orderBy)
+                        => workshopDrafts.Where(predicate.Compile()).Skip(skip).Take(take).AsTestAsyncEnumerableQuery())
+                    .Verifiable(Times.Once);
         var filter = new WorkshopDraftFilterTitle
         {
             SearchText = searchText
         };
 
         // Act
-        var result = await service.GetByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false);
+        var result = await service.GetByProviderId(providerId, filter).ConfigureAwait(false);
 
         // Assert
         workshopDraftRepoMoq.VerifyAll();
         currentUserServiceMoq.VerifyAll();
+        result.TotalAmount.Should().Be(1);
+        result.Entities.Should().HaveCount(1);
         result.Entities.First().Should().BeEquivalentTo(workshopDraftResponse);
     }
 
@@ -833,10 +848,15 @@ public class WorkshopDraftServiceTests
     public async Task GetByProviderId_WhenFilterHasExcludedId_ShouldReturnValidResult()
     {
         // Arrange
+        var providerId = Guid.NewGuid();
         var numberOfWorkshops = 5;
         var excludedId = Guid.NewGuid();
         var workshops = WorkshopGenerator.Generate(numberOfWorkshops).WithProvider().WithTeachers();
         workshops.First().Id = excludedId;
+        foreach (var workshop in workshops)
+        {
+            workshop.ProviderId = providerId;
+        }
         var workshopV2Dtos = workshops.ToV2Dto();
         var workshopDrafts = workshopV2Dtos.ToDraft();
         var workshopDraftResponses = workshopDrafts.Where(x => x.Id != excludedId).ToCardDto();
@@ -847,28 +867,38 @@ public class WorkshopDraftServiceTests
                 It.IsAny<Expression<Func<InstitutionHierarchy, bool>>>(),
                 It.IsAny<Dictionary<Expression<Func<InstitutionHierarchy, object>>, SortDirection>>()))
             .Returns(new List<InstitutionHierarchy>().AsTestAsyncEnumerableQuery());
-        workshopDraftRepoMoq.Setup(x => x.Count(It.IsAny<Expression<Func<WorkshopDraft, bool>>>()))
-            .ReturnsAsync(numberOfWorkshops).Verifiable(Times.Once);
-        workshopDraftRepoMoq.Setup(x =>
-            x.Get(It.IsAny<int>(),
+        Expression<Func<WorkshopDraft, bool>> whereExpr = null;
+        workshopDraftRepoMoq
+                    .Setup(x => x.Count(It.IsAny<Expression<Func<WorkshopDraft, bool>>>()))
+                    .Callback<Expression<Func<WorkshopDraft, bool>>>(p => whereExpr = p)
+                    .ReturnsAsync(() => workshopDrafts.Count(wd => whereExpr.Compile().Invoke(wd)))
+                    .Verifiable(Times.Once);
+        workshopDraftRepoMoq
+                    .Setup(x => x.Get(
+                    It.IsAny<int>(),
                     It.IsAny<int>(),
                     It.IsAny<Expression<Func<WorkshopDraft, bool>>>(),
                     It.IsAny<Dictionary<Expression<Func<WorkshopDraft, object>>, SortDirection>>()))
-            .Returns(workshopDrafts.AsTestAsyncEnumerableQuery).Verifiable(Times.Once);
+                    .Returns((int skip, int take, Expression<Func<WorkshopDraft, bool>> predicate,
+                    Dictionary < Expression<Func<WorkshopDraft, object>>, SortDirection > orderBy)
+                        => workshopDrafts.Where(predicate.Compile()).Skip(skip).Take(take).AsTestAsyncEnumerableQuery())
+                    .Verifiable(Times.Once);
         var filter = new WorkshopDraftFilterTitle
         {
             ExcludedId = excludedId
         };
 
         // Act
-        var result = await service.GetByProviderId(Guid.NewGuid(), filter).ConfigureAwait(false);
+        var result = await service.GetByProviderId(providerId, filter).ConfigureAwait(false);
 
         // Assert
         workshopDraftRepoMoq.VerifyAll();
         currentUserServiceMoq.VerifyAll();
+        result.TotalAmount.Should().Be(workshopDraftResponses.Count);
+        result.Entities.Should().HaveCount(workshopDraftResponses.Count);
         result.Entities.Should().BeEquivalentTo(workshopDraftResponses);
     }
-        #endregion
+    #endregion
 
     #region UpdateWorkshop
 

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CompetitiveEventController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V1/CompetitiveEventController.cs
@@ -157,15 +157,6 @@ public class CompetitiveEventController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpGet("/api/v{version:apiVersion}/provider/{id}/competitiveevents")]
-    public async Task<IActionResult> GetCompetitiveEventViewCardByProviderId(Guid id, [FromQuery] ExcludeIdFilter filter)
-    {
-        if (id == Guid.Empty)
-        {
-            return BadRequest("Provider id is empty.");
-        }
-       
-        SearchResult<CompetitiveEventViewCardDto> result = await service.GetByProviderId(id, filter).ConfigureAwait(false);
-        return this.SearchResultToOkOrNoContent(result);
-
-    }
+    public async Task<IActionResult> GetCompetitiveEventViewCardByProviderId(Guid id, [FromQuery] CompetitiveEventFilterTitle filter) =>
+        await service.GetByProviderId(id, filter).ProtectAndMap(this.SearchResultToOkOrNoContent);
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
@@ -70,12 +70,8 @@ public class CompetitiveEventController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SearchResult<CompetitiveEventViewCardDto>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> GetByProviderId(Guid id, [FromQuery] ExcludeIdFilter filter)
-    {
-        var competitiveEventsCards = await competitiveEventService.GetByProviderId(id, filter).ConfigureAwait(false);
-
-        return this.SearchResultToOkOrNoContent(competitiveEventsCards);
-    }
+    public async Task<IActionResult> GetByProviderId(Guid id, [FromQuery] CompetitiveEventFilterTitle filter) =>
+        await competitiveEventService.GetByProviderId(id, filter).ProtectAndMap(this.SearchResultToOkOrNoContent);
 
     /// <summary>
     /// Get CompetitiveEvents cards by list of Ids.

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventDraftController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventDraftController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 using OutOfSchool.BusinessLogic.Models;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.V2;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
 using OutOfSchool.BusinessLogic.Services.CompetitiveEventDrafts;
@@ -271,7 +272,7 @@ public class CompetitiveEventDraftController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpGet("/api/v{version:apiVersion}/provider/{providerId}/competitions-drafts")]
-    public async Task<IActionResult> GetByProviderId(Guid providerId, [FromQuery] ExcludeIdFilter filter) =>
+    public async Task<IActionResult> GetByProviderId(Guid providerId, [FromQuery] CompetitiveEventFilterTitle filter) =>
         await competitiveEventDraftService.GetByProviderId(providerId, filter).ProtectAndMap(this.SearchResultToOkOrNoContent);
 
     /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventDraftController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventDraftController.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 using OutOfSchool.BusinessLogic.Models;
-using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.V2;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
 using OutOfSchool.BusinessLogic.Services.CompetitiveEventDrafts;
@@ -272,7 +271,7 @@ public class CompetitiveEventDraftController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpGet("/api/v{version:apiVersion}/provider/{providerId}/competitions-drafts")]
-    public async Task<IActionResult> GetByProviderId(Guid providerId, [FromQuery] CompetitiveEventFilterTitle filter) =>
+    public async Task<IActionResult> GetByProviderId(Guid providerId, [FromQuery] CompetitiveEventDraftFilterTitle filter) =>
         await competitiveEventDraftService.GetByProviderId(providerId, filter).ProtectAndMap(this.SearchResultToOkOrNoContent);
 
     /// <summary>

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 using OutOfSchool.BusinessLogic.Models;
-using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.WorkshopDraft;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.BusinessLogic.Services.ProviderServices;
@@ -226,7 +225,7 @@ public class WorkshopDraftController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpGet("provider/{id}/drafts")]
-    public async Task<IActionResult> GetByProviderId(Guid id, [FromQuery] CompetitiveEventFilterTitle filter) =>
+    public async Task<IActionResult> GetByProviderId(Guid id, [FromQuery] WorkshopDraftFilterTitle filter) =>
         await workshopDraftService.GetByProviderId(id, filter).ProtectAndMap(this.SearchResultToOkOrNoContent);
 
     private async Task<IActionResult> ValidateProvider(Guid providerId)

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 using OutOfSchool.BusinessLogic.Models;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.WorkshopDraft;
 using OutOfSchool.BusinessLogic.Models.Workshops;
 using OutOfSchool.BusinessLogic.Services.ProviderServices;
@@ -225,7 +226,7 @@ public class WorkshopDraftController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpGet("provider/{id}/drafts")]
-    public async Task<IActionResult> GetByProviderId(Guid id, [FromQuery] ExcludeIdFilter filter) =>
+    public async Task<IActionResult> GetByProviderId(Guid id, [FromQuery] CompetitiveEventFilterTitle filter) =>
         await workshopDraftService.GetByProviderId(id, filter).ProtectAndMap(this.SearchResultToOkOrNoContent);
 
     private async Task<IActionResult> ValidateProvider(Guid providerId)


### PR DESCRIPTION
Related issue: #1941

- Extended filter functionality with title filtering for Competitive Events, their drafts and Workshop Drafts
- Added related tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added title search to provider listings for Competitive Events, Competitive Event Drafts, and Workshop Drafts. Use the SearchText query parameter to filter results by case-insensitive title match.

- Refactor
  - Unified provider filtering to combine exclusion and title search without changing pagination or response shape.
  - Workshop Draft results now ordered by last modified date, then creation date.

- Tests
  - Updated and expanded tests to cover the new title-search behavior across services and controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->