### PR TITLE
update position dto time fields

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Position/PositionDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Position/PositionDto.cs
@@ -33,9 +33,9 @@ public class PositionDto // for get method
 
     public Guid ContactId { get; set; }
 
-    public DateTime CreatedAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
 
-    public DateTime? UpdatedAt { get; set; }
+    public DateTimeOffset? UpdatedAt { get; set; }
 
     public DateOnly ActiveFrom { get; set; }
 
@@ -66,8 +66,10 @@ public static class PositionDtoExtensions
             ClassifierType = model.ClassifierType,
             ProviderId = model.ProviderId,
             ContactId = model.ContactId,
-            CreatedAt = model.CreatedAt,
-            UpdatedAt = model.UpdatedAt,
+            CreatedAt = new DateTimeOffset(DateTime.SpecifyKind(model.CreatedAt, DateTimeKind.Utc)),
+            UpdatedAt = model.UpdatedAt.HasValue
+                ? new DateTimeOffset(DateTime.SpecifyKind(model.UpdatedAt.Value, DateTimeKind.Utc))
+                : null,
             ActiveFrom = model.ActiveFrom,
             ActiveTo = model.ActiveTo,
             PositionType = model.PositionType,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PositionControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/PositionControllerTests.cs
@@ -294,7 +294,7 @@ public class PositionControllerTests
             IsForRuralAreas = positionCreateDto.IsForRuralAreas,
             ProviderId = providerId,
             ContactId = Guid.NewGuid(),
-            CreatedAt = DateTime.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = null,
             IsDeleted = false
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized position timestamps to use offset-aware UTC values for greater consistency across time zones.
  - API responses for CreatedAt and UpdatedAt now include timezone information (ISO 8601 with offset/UTC).

- Tests
  - Updated tests to reflect the new offset-aware timestamp format, ensuring accurate validation of date-time fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->