### PR TITLE
fix(di registration): added fake DI registration if  min sport integration disabled

### DIFF
--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Extensions/SportsRegistryClientExtensions.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Extensions/SportsRegistryClientExtensions.cs
@@ -26,14 +26,17 @@ public static class SportsRegistryClientExtensions
         }
         services.Configure<SportsRegistryApiClientConfig>(configuration.GetSection(SportsRegistryApiClientConfig.Name));
 
-        if (!sportConfiguration.Enable)
+        if (sportConfiguration.Enable)
         {
-            // Registry integration is turned off; skip service registrations.
-            return sportConfiguration;
+            services.TryAddTransient<ICommunicationService, CommunicationService>();
+            services.TryAddTransient<ISportsRegistryApiService, SportsRegistryApiService>();
+            services.TryAddTransient<ISportsRegistryProviderService, SportsRegistryProviderService>();
         }
-        services.TryAddTransient<ICommunicationService, CommunicationService>();
-        services.TryAddTransient<ISportsRegistryApiService, SportsRegistryApiService>();
-        services.TryAddTransient<ISportsRegistryProviderService, SportsRegistryProviderService>();
+        else
+        {
+            services.TryAddSingleton<ISportsRegistryProviderService, DisabledSportsRegistryProviderService>();
+        }
+        
         return sportConfiguration;
     }
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/DisabledSportsRegistryProviderService.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/DisabledSportsRegistryProviderService.cs
@@ -1,0 +1,20 @@
+using System.Net;
+using OutOfSchool.Common.Models;
+using OutOfSchool.SportsRegistryApiClient.Interfaces;
+using OutOfSchool.SportsRegistryApiClient.Models.Requests;
+using OutOfSchool.SportsRegistryApiClient.Models.Responses;
+
+sealed class DisabledSportsRegistryProviderService : ISportsRegistryProviderService
+{
+    static ErrorResponse Disabled(string op) => new()
+    {
+        HttpStatusCode = HttpStatusCode.ServiceUnavailable,
+        Message = $"Sports Registry integration is disabled. Operation: {op}"
+    };
+
+    public Task<Either<ErrorResponse, SectionCreateResponse>> RegisterSectionAsync(SportsSectionPostRequest r)
+        => Task.FromResult<Either<ErrorResponse, SectionCreateResponse>>(Disabled("CreateSection"));
+
+    public Task<Either<ErrorResponse, SectionCreateResponse>> UpdateSectionAsync(SportsSectionPostRequest r)
+        => Task.FromResult<Either<ErrorResponse, SectionCreateResponse>>(Disabled("UpdateSection"));
+}

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/DisabledSportsRegistryProviderService.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/DisabledSportsRegistryProviderService.cs
@@ -4,6 +4,7 @@ using OutOfSchool.SportsRegistryApiClient.Interfaces;
 using OutOfSchool.SportsRegistryApiClient.Models.Requests;
 using OutOfSchool.SportsRegistryApiClient.Models.Responses;
 
+namespace OutOfSchool.SportsRegistryApiClient.Services;
 sealed class DisabledSportsRegistryProviderService : ISportsRegistryProviderService
 {
     static ErrorResponse Disabled(string op) => new()


### PR DESCRIPTION
Fix  situation when flag Enable is false in configuration for **SportsRegistryApiClient**. Added fake implementation of DI registration if flag is non active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a graceful "disabled" provider for the Sports Registry integration that returns clear "Service Unavailable (integration disabled)" responses for section creation and updates.
* **Bug Fixes**
  * Always registers a provider service (real when enabled, disabled fallback when off) to prevent errors when the integration is turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->