### PR TITLE
make rnokpp optional due to request by MODT

### DIFF
--- a/OutOfSchool/OutOfSchool.AuthCommon/Controllers/AuthController.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Controllers/AuthController.cs
@@ -653,14 +653,23 @@ public class AuthController : Controller
         Individual individual,
         User user)
     {
-        return
-        [
+        var claims = new List<Claim>
+        {
             new(OpenIddictConstants.Claims.Role, user.Role),
             new(OpenIddictConstants.Claims.GivenName, individual.FirstName),
             new(OpenIddictConstants.Claims.FamilyName, individual.LastName),
-            new(OpenIddictConstants.Claims.Email, user.Email),
-            new(Constants.ClaimTypes.Rnokpp, individual.Rnokpp)
-        ];
+        };
+        if (user.Email != null)
+        {
+            claims.Add(new(OpenIddictConstants.Claims.Email, user.Email));
+        }
+
+        // TODO: revise when back to required Rnokpp
+        if (individual.Rnokpp != null)
+        {
+            claims.Add(new(Constants.ClaimTypes.Rnokpp, individual.Rnokpp));
+        }
+        return claims;
     }
 
     private record PositionProjection(string ProviderTitle, Guid ProviderId, string ProviderEdrpou, PositionType PositionType);

--- a/OutOfSchool/OutOfSchool.AuthCommon/Controllers/ExternalAuthController.cs
+++ b/OutOfSchool/OutOfSchool.AuthCommon/Controllers/ExternalAuthController.cs
@@ -377,8 +377,9 @@ public class ExternalAuthController : Controller
     /// <returns><see cref="Individual"/> entity.</returns>
     private async Task<Individual?> GetIndividualAsync(UserInfoResponse userInfo, User user)
     {
+        // TODO: modify when back to required Rnokpp
         var individual = await dbContext.Individuals
-            .FirstOrDefaultAsync(i => !i.IsDeleted && i.Rnokpp == userInfo.DrfoCode);
+            .FirstOrDefaultAsync(i => !i.IsDeleted && i.Rnokpp != null && i.Rnokpp == userInfo.DrfoCode);
 
         if (individual == null)
         {
@@ -445,11 +446,18 @@ public class ExternalAuthController : Controller
             new(OpenIddictConstants.Claims.GivenName, individual.FirstName),
             new(OpenIddictConstants.Claims.FamilyName, individual.LastName),
             new(OpenIddictConstants.Claims.Email, userInfo.Email),
-            new(Constants.ClaimTypes.Rnokpp, individual.Rnokpp),
+            // TODO: return when back to required Rnokpp
+            // new(Constants.ClaimTypes.Rnokpp, individual.Rnokpp),
             new(Constants.ClaimTypes.Edrpou, userInfo.EdrpouCode),
             new(Constants.ClaimTypes.ProviderId, providerId.ToString()),
             new(Constants.ClaimTypes.IsDeputy, isDeputy.ToString(), ClaimValueTypes.Boolean),
         };
+
+        // TODO: return when back to required Rnokpp
+        if (individual.Rnokpp != null)
+        {
+            claims.Add(new(Constants.ClaimTypes.Rnokpp, individual.Rnokpp));
+        }
 
         if (externalProviderId.HasValue)
         {
@@ -478,6 +486,7 @@ public class ExternalAuthController : Controller
             new(OpenIddictConstants.Claims.GivenName, individual.FirstName),
             new(OpenIddictConstants.Claims.FamilyName, individual.LastName),
             new(OpenIddictConstants.Claims.Email, userInfo.Email),
+            // TODO: technical staff should not have null rnokpp
             new(Constants.ClaimTypes.Rnokpp, individual.Rnokpp),
             new(Constants.ClaimTypes.IndividualId, individual.Id.ToString()),
         };
@@ -499,6 +508,7 @@ public class ExternalAuthController : Controller
             IsPersistent = false,
         };
 
+        // TODO: unable to sign in without rnokpp
         var user = await userManager.FindByNameAsync(claims
             .First(c => c.Type == Constants.ClaimTypes.Rnokpp).Value);
         await signInManager.SignInWithClaimsAsync(user, properties, claims.Where(c => c.Type != OpenIddictConstants.Claims.Role));

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Services/ProfileService.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Services/ProfileService.cs
@@ -101,7 +101,11 @@ public class ProfileService : IProfileService
                 var isDeputy = positions.Any(p => p.PositionType == PositionType.DeputyDirector);
                 var edrpou = positions.First().Edrpou;
 
-                claims[Constants.ClaimTypes.Rnokpp] = individual.Rnokpp;
+                // TODO: revise when back to required Rnokpp
+                if (individual.Rnokpp != null)
+                {
+                    claims[Constants.ClaimTypes.Rnokpp] = individual.Rnokpp;
+                }
                 claims[Constants.ClaimTypes.Edrpou] = edrpou;
                 claims[Constants.ClaimTypes.ProviderId] = providerId.ToString();
                 claims[Constants.ClaimTypes.IsDeputy] = isDeputy.ToString();

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Individual.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Individual.cs
@@ -20,8 +20,9 @@ public class Individual : BusinessEntity
     [MaxLength(60)]
     public string LastName { get; set; }
 
-    [Required(ErrorMessage = "Rnokpp is required")]
-    public string Rnokpp { get; set; }
+    // TODO: Making rnokpp nullable was requested by MODT. This will affect authorization flow, so this needs to be fixed asap when they know what to do
+    // [Required(ErrorMessage = "Rnokpp is required")]
+    public string? Rnokpp { get; set; }
 
     // TODO: will be retrieved from aikom
     [Required(ErrorMessage = "ExternalRegistryId is required")]

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Individual.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Individual.cs
@@ -25,8 +25,9 @@ public class Individual : BusinessEntity
     public string? Rnokpp { get; set; }
 
     // TODO: will be retrieved from aikom
-    [Required(ErrorMessage = "ExternalRegistryId is required")]
-    public Guid ExternalRegistryId { get; set; } = default;
+    // TODO: make required when AIKOM is working
+    // [Required(ErrorMessage = "ExternalRegistryId is required")]
+    public Guid? ExternalRegistryId { get; set; } = null;
 
     public Gender Gender { get; set; }
 

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250904115243_MakeRnokppOptionalDuringTransition.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250904115243_MakeRnokppOptionalDuringTransition.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
@@ -11,9 +12,11 @@ using OutOfSchool.Services;
 namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250904115243_MakeRnokppOptionalDuringTransition")]
+    partial class MakeRnokppOptionalDuringTransition
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250904115243_MakeRnokppOptionalDuringTransition.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250904115243_MakeRnokppOptionalDuringTransition.cs
@@ -1,0 +1,46 @@
+﻿#nullable disable
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+{
+    /// <inheritdoc />
+    public partial class MakeRnokppOptionalDuringTransition : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Rnokpp",
+                table: "Individuals",
+                type: "varchar(255)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(255)")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Individuals",
+                keyColumn: "Rnokpp",
+                keyValue: null,
+                column: "Rnokpp",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Rnokpp",
+                table: "Individuals",
+                type: "varchar(255)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(255)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250904121247_MakeExternalRegistryIdOptionalDuringTransition.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250904121247_MakeExternalRegistryIdOptionalDuringTransition.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
@@ -11,9 +12,11 @@ using OutOfSchool.Services;
 namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250904121247_MakeExternalRegistryIdOptionalDuringTransition")]
+    partial class MakeExternalRegistryIdOptionalDuringTransition
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250904121247_MakeExternalRegistryIdOptionalDuringTransition.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250904121247_MakeExternalRegistryIdOptionalDuringTransition.cs
@@ -1,0 +1,36 @@
+﻿#nullable disable
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+{
+    /// <inheritdoc />
+    public partial class MakeExternalRegistryIdOptionalDuringTransition : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ExternalRegistryId",
+                table: "Individuals",
+                type: "binary(16)",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "binary(16)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ExternalRegistryId",
+                table: "Individuals",
+                type: "binary(16)",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "binary(16)",
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Allow signing in and using the app when RNOKPP or email is not provided where permitted.

- Bug Fixes
  - Prevent creation of empty/null identifier claims to avoid authentication errors.
  - Improved reliability of external provider sign-in when RNOKPP is missing.
  - Ensure profile claims load only when corresponding data exists.

- Chores
  - Relaxed data validation to permit profiles without RNOKPP in allowed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->