### PR TITLE
Added the [ModelBinder(...)] attribute to the ImageIds property of the CompetitiveEventDto class.

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDto.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
+using OutOfSchool.BusinessLogic.Util.JsonTools;
 
 namespace OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 
@@ -11,6 +13,7 @@ public class CompetitiveEventDto : CompetitiveEventBaseDto
 
     [MaxLength(256)]
     public string CoverImageId { get; set; } = string.Empty;
+    [ModelBinder(BinderType = typeof(JsonModelBinder))]
     public IList<string> ImageIds { get; set; }
     public CompetitiveEventCoverageDto Coverage { get; set; }
     public IList<DirectionSubDirectionIdsDto> DirectionSubDirectionIds { get; set; } = [];


### PR DESCRIPTION
Added the [ModelBinder(BinderType = typeof(JsonModelBinder))] attribute to the ImageIds property of the CompetitiveEventDto class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where image IDs for competitive events were not parsed correctly in requests. The API now reliably accepts image ID lists provided in JSON payloads, ensuring images are associated with events as expected. This improves compatibility across clients and reduces validation errors during event creation or updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->