### PR TITLE
fix(workshop approve): add return type of Guid of created workshop when approve workshopDraft

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/IWorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/IWorkshopDraftService.cs
@@ -62,7 +62,7 @@ public interface IWorkshopDraftService
     /// Approve draft after moderating.
     /// </summary>
     /// <param name="id">Key in the table.</param>
-    /// <returns>A <see cref="Task<Guid> "/> representing the result of the asynchronous operation wihh id of created Workshop.</returns>
+    /// A <see cref="Task{Guid}"/> representing the result of the asynchronous operation with the id of the created or updated Workshop.
     Task<Guid> Approve(Guid id);
 
     /// <summary>

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/IWorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/IWorkshopDraftService.cs
@@ -62,8 +62,8 @@ public interface IWorkshopDraftService
     /// Approve draft after moderating.
     /// </summary>
     /// <param name="id">Key in the table.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-    Task Approve(Guid id);
+    /// <returns>A <see cref="Task<Guid> "/> representing the result of the asynchronous operation wihh id of created Workshop.</returns>
+    Task<Guid> Approve(Guid id);
 
     /// <summary>
     /// Reject draft after moderating.

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -327,10 +327,11 @@ public class WorkshopDraftService(
     }
 
     // <inheritdoc/>
-    public async Task Approve(Guid id)
+    public async Task<Guid> Approve(Guid id)
     {
         //TODO: Check if we can add RunInTransaction later
 
+        Guid createdWorkshopId;
         logger.LogDebug("Approving WorkshopDraft started. WorkshopDraft Id = {Id}.", id);
 
         var workshopDraft = await GetByIdWithProviderAndWorkshop(id);
@@ -345,16 +346,20 @@ public class WorkshopDraftService(
             {
                 await SyncSectionWithRegistryAsync(workshopDraft);
             }
-            await workshopServicesCombinerV2.Create(workshopDraft.ToV2CreateRequestDto());
+            var result = await workshopServicesCombinerV2.Create(workshopDraft.ToV2CreateRequestDto());
+            createdWorkshopId = result.Workshop.Id;
         }
         else
         {
             await workshopServicesCombinerV2.Update(workshopDraft.ToDto(), true);
+            createdWorkshopId = workshopDraft.WorkshopId.Value;
         }
 
         await workshopDraftRepository.Delete(workshopDraft);
 
         logger.LogDebug("Draft was successfully approved and deleted. Draft Id = {DraftId}.", id);
+        
+        return createdWorkshopId;
     }
 
     // <inheritdoc/>

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopDraftControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/WorkshopDraftControllerTests.cs
@@ -213,18 +213,24 @@ public class WorkshopDraftControllerTests
 
     #region Approve
     [Test]
-    public async Task Approve_WhenModelIsValid_ShouldReturnOk()
+    public async Task Approve_WhenModelIsValid_ShouldReturnValidGuid()
     {
-        // Arrange  
-        workshopDraftServiceMoq.Setup(x => x.Approve(workshopV2Dto.Id))
-            .Returns(Task.CompletedTask).Verifiable(Times.Once);
+        // Arrange
+        Guid expectedId = Guid.NewGuid();
+        workshopDraftServiceMoq
+            .Setup(x => x.Approve(workshopV2Dto.Id))
+            .ReturnsAsync(expectedId)
+            .Verifiable();
 
         // Act
-        var result = await controller.Approve(workshopV2Dto.Id).ConfigureAwait(false) as OkResult;
+        var result = await controller.Approve(workshopV2Dto.Id).ConfigureAwait(false) as ObjectResult;
 
-        // Assert        
+        // Assert
         workshopDraftServiceMoq.VerifyAll();
-        Assert.AreEqual(Ok, result.StatusCode);
+        Assert.NotNull(result);
+        Assert.AreEqual(StatusCodes.Status200OK, result.StatusCode);
+
+        Assert.NotNull(result.Value);
     }
     #endregion 
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -664,7 +664,12 @@ public class WorkshopDraftServiceTests
             .ReturnsAsync(workshopDraft).Verifiable(Times.Once);
         workshopDraftRepoMoq.Setup(x => x.Delete(It.IsAny<WorkshopDraft>()))
             .Returns(Task.CompletedTask).Verifiable(Times.Once);
-        workshopServiceCombinerV2Moq.Setup(x => x.Create(It.IsAny<WorkshopV2CreateRequestDto>()))
+        workshopServiceCombinerV2Moq
+            .Setup(x => x.Create(It.IsAny<WorkshopV2CreateRequestDto>()))
+            .ReturnsAsync(new WorkshopResultDto
+            {
+                Workshop = new WorkshopV2Dto { Id = Guid.NewGuid() }
+            })
             .Verifiable(Times.Once);
 
         // Act
@@ -733,8 +738,10 @@ public class WorkshopDraftServiceTests
 
         workshopServiceCombinerV2Moq
             .Setup(x => x.Create(It.IsAny<WorkshopV2CreateRequestDto>()))
-            .Returns(Task.FromResult(new WorkshopResultDto()));
-
+            .ReturnsAsync(new WorkshopResultDto
+            {
+                Workshop = new WorkshopV2Dto { Id = Guid.NewGuid() }
+            });
         // Act
         await service.Approve(workshopDraft.Id);
 
@@ -871,7 +878,10 @@ public class WorkshopDraftServiceTests
 
         workshopServiceCombinerV2Moq
             .Setup(x => x.Create(It.IsAny<WorkshopV2CreateRequestDto>()))
-            .Returns(Task.FromResult(new WorkshopResultDto()))
+            .ReturnsAsync(new WorkshopResultDto
+            {
+                Workshop = new WorkshopV2Dto { Id = Guid.NewGuid() }
+            })
             .Verifiable();
 
         // Act
@@ -921,8 +931,11 @@ public class WorkshopDraftServiceTests
 
         workshopServiceCombinerV2Moq
             .Setup(x => x.Create(It.IsAny<WorkshopV2CreateRequestDto>()))
-            .Returns(Task.FromResult(new WorkshopResultDto()))
-            .Verifiable(Times.Once);
+            .ReturnsAsync(new WorkshopResultDto
+            {
+                Workshop = new WorkshopV2Dto { Id = Guid.NewGuid() }
+            })
+            .Verifiable();
 
         // Act
         await service.Approve(workshopDraft.Id);

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
@@ -206,8 +206,7 @@ public class WorkshopDraftController : ControllerBase
         try
         {
             var createdWorkshopId = await workshopDraftService.Approve(id);
-            return StatusCode(StatusCodes.Status200OK,new 
-                { Message = $"WorkshopDraft approved successfully. Id of created / updated workshop:{createdWorkshopId}"});
+            return StatusCode(StatusCodes.Status200OK,new { WorkshopId = createdWorkshopId});
         }
         catch (EntityDeletedConflictException ex)
         {

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/WorkshopDraftController.cs
@@ -205,8 +205,9 @@ public class WorkshopDraftController : ControllerBase
     {
         try
         {
-            await workshopDraftService.Approve(id);
-            return Ok();
+            var createdWorkshopId = await workshopDraftService.Approve(id);
+            return StatusCode(StatusCodes.Status200OK,new 
+                { Message = $"WorkshopDraft approved successfully. Id of created / updated workshop:{createdWorkshopId}"});
         }
         catch (EntityDeletedConflictException ex)
         {


### PR DESCRIPTION
Quick fix of return type of the approve workshop draft method to align with QC team.
Now you can see a valid response with id of created workshop while you testing our API
<img width="1465" height="149" alt="image" src="https://github.com/user-attachments/assets/7bc90075-2537-4d1c-b0cf-068e12ce7358" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approving a workshop draft now returns the workshop ID in the 200 OK JSON response (payload includes WorkshopId).

* **Tests**
  * Updated automated tests to expect and validate the returned workshop ID after approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->