### PR TITLE
increase ws title length

### DIFF
--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -140,7 +140,7 @@ public static class Constants
     /// <summary>
     /// Maximum length of workshop title.
     /// </summary>
-    public const int MaxWorkshopTitleLength = 60;
+    public const int MaxWorkshopTitleLength = 120;
 
     /// <summary>
     /// Minimum length of workshop short title.

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250912071432_IncreaseWorkshopTitleLength.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250912071432_IncreaseWorkshopTitleLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
@@ -11,9 +12,11 @@ using OutOfSchool.Services;
 namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250912071432_IncreaseWorkshopTitleLength")]
+    partial class IncreaseWorkshopTitleLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250912071432_IncreaseWorkshopTitleLength.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20250912071432_IncreaseWorkshopTitleLength.cs
@@ -1,0 +1,42 @@
+﻿#nullable disable
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+{
+    /// <inheritdoc />
+    public partial class IncreaseWorkshopTitleLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Workshops",
+                type: "varchar(120)",
+                maxLength: 120,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Workshops",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(120)",
+                oldMaxLength: 120)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowed workshop title length from 60 to 120 characters.
  * Users can now enter more descriptive workshop titles without truncation.
  * Validation and input fields across the app have been updated to support the extended length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->