### PR TITLE
Fixed the Update flow for the CompetitiveEvent

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDescriptionItemDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDescriptionItemDto.cs
@@ -58,7 +58,7 @@ public static class CompetitiveEventDescriptionItemDtoExtensions
             Id = model.Id,
             SectionName = model.SectionName,
             Description = model.Description,
-            CompetitiveEventId = model.CompetitiveEventId ?? default
+            CompetitiveEventId = model.CompetitiveEventId ?? Guid.Empty
         };
 
     public static List<CompetitiveEventDescriptionItemDto> ToDto(this IEnumerable<CompetitiveEventDescriptionItem> list)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDescriptionItemDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDescriptionItemDto.cs
@@ -46,18 +46,19 @@ public static class CompetitiveEventDescriptionItemDtoExtensions
             Id = dto.Id,
             SectionName = dto.SectionName,
             Description = dto.Description,
+            CompetitiveEventId = dto.CompetitiveEventId
         };
 
     public static List<CompetitiveEventDescriptionItem> ToModel(this IEnumerable<CompetitiveEventDescriptionItemDto> list)
         => list.MapToList(ToModel);
 
-    public static CompetitiveEventDescriptionItemDto ToDto(this CompetitiveEventDescriptionItem dto)
+    public static CompetitiveEventDescriptionItemDto ToDto(this CompetitiveEventDescriptionItem model)
         => new()
         {
-            Id = dto.Id,
-            SectionName = dto.SectionName,
-            Description = dto.Description,
-            CompetitiveEventId = dto.CompetitiveEventId ?? default
+            Id = model.Id,
+            SectionName = model.SectionName,
+            Description = model.Description,
+            CompetitiveEventId = model.CompetitiveEventId ?? default
         };
 
     public static List<CompetitiveEventDescriptionItemDto> ToDto(this IEnumerable<CompetitiveEventDescriptionItem> list)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
@@ -179,4 +179,71 @@ public static class CompetitiveEventV2DtoExtensions
         SubDirectionIds = competitiveEventV2Dto.SubDirectionIds ?? [],
         CompetitiveEventDescriptionItems = competitiveEventV2Dto.CompetitiveEventDescriptionItems?.ToModel(),
     };
+
+    public static CompetitiveEventV2CreateRequestDto ToV2CreateRequestDto(this CompetitiveEventV2Dto competitiveEventV2Dto)
+    => new()
+    {
+        AreThereBenefits = competitiveEventV2Dto.AreThereBenefits ?? default,
+        Benefits = competitiveEventV2Dto.Benefits,
+        CompetitiveSelection = competitiveEventV2Dto.CompetitiveSelection ?? default,
+        Contacts = competitiveEventV2Dto.Contacts ?? new List<ContactsDto>(),
+        DescriptionOfTheEnrollmentProcedure = competitiveEventV2Dto.DescriptionOfTheEnrollmentProcedure,
+        MaximumAge = competitiveEventV2Dto.MaximumAge ?? default,
+        MinimumAge = competitiveEventV2Dto.MinimumAge,
+        NumberOfSeats = competitiveEventV2Dto.NumberOfSeats,
+        OrganizerOfTheEventId = competitiveEventV2Dto.OrganizerOfTheEventId,
+        ParentId = competitiveEventV2Dto.ParentId,
+        PlannedFormatOfClasses = competitiveEventV2Dto.PlannedFormatOfClasses ?? default,
+        Price = competitiveEventV2Dto.Price ?? default,
+        RegistrationEndTime = competitiveEventV2Dto.RegistrationEndTime ?? default,
+        RegistrationStartTime = competitiveEventV2Dto.RegistrationStartTime ?? default,
+        ScheduledEndTime = competitiveEventV2Dto.ScheduledEndTime,
+        ScheduledStartTime = competitiveEventV2Dto.ScheduledStartTime,
+        ShortTitle = competitiveEventV2Dto.ShortTitle,
+        Title = competitiveEventV2Dto.Title,
+        TermsOfParticipation = competitiveEventV2Dto.TermsOfParticipation,
+        VenueName = competitiveEventV2Dto.VenueName,
+        SubDirectionIds = competitiveEventV2Dto.SubDirectionIds ?? [],
+        CompetitiveEventDescriptionItems = competitiveEventV2Dto.CompetitiveEventDescriptionItems,
+        CoverageId = competitiveEventV2Dto.CoverageId,
+        CompetitiveEventAccountingTypeId = competitiveEventV2Dto.CompetitiveEventAccountingTypeId,
+        CoverImageId = competitiveEventV2Dto.CoverImageId,
+        Id = competitiveEventV2Dto.Id,
+        ImageIds = competitiveEventV2Dto.ImageIds,
+    };
+
+    /// <summary>
+    /// Copies values from a CompetitiveEventV2CreateRequestDto into an existing CompetitiveEvent domain model, updating the model in-place.
+    /// </summary>
+    /// <param name="dto">Source DTO containing new values; nullable properties on the DTO will not overwrite existing model values.</param>
+    /// <param name="model">The existing domain model to update.</param>
+    /// <returns>The same CompetitiveEvent instance after applying updates.</returns>
+    public static OutOfSchool.Services.Models.CompetitiveEvents.CompetitiveEvent SetToModel(this CompetitiveEventV2Dto dto, OutOfSchool.Services.Models.CompetitiveEvents.CompetitiveEvent model)
+    {
+        model.Title = dto.Title;
+        model.ShortTitle = dto.ShortTitle;
+        model.State = dto.State;
+        model.RegistrationStartTime = dto.RegistrationStartTime ?? model.RegistrationStartTime;
+        model.RegistrationEndTime = dto.RegistrationEndTime ?? model.RegistrationEndTime;
+        model.ParentId = dto.ParentId;
+        model.CoverageId = dto.CoverageId;
+        model.ScheduledStartTime = dto.ScheduledStartTime;
+        model.ScheduledEndTime = dto.ScheduledEndTime;
+        model.NumberOfSeats = dto.NumberOfSeats;
+        model.CompetitiveEventAccountingTypeId = dto.CompetitiveEventAccountingTypeId;
+        model.DescriptionOfTheEnrollmentProcedure = dto.DescriptionOfTheEnrollmentProcedure;
+        model.OrganizerOfTheEventId = dto.OrganizerOfTheEventId;
+        model.PlannedFormatOfClasses = dto.PlannedFormatOfClasses ?? model.PlannedFormatOfClasses;
+        model.VenueName = dto.VenueName;
+        model.TermsOfParticipation = dto.TermsOfParticipation;
+        model.AreThereBenefits = dto.AreThereBenefits ?? model.AreThereBenefits;
+        model.Benefits = dto.Benefits;
+        model.MinimumAge = dto.MinimumAge;
+        model.MaximumAge = dto.MaximumAge ?? model.MaximumAge;
+        model.Price = dto.Price ?? model.Price;
+        model.CompetitiveSelection = dto.CompetitiveSelection ?? model.CompetitiveSelection;
+        model.Contacts = dto.Contacts?.ToModel() ?? model.Contacts;
+
+        return model;
+    }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
@@ -181,36 +181,40 @@ public static class CompetitiveEventV2DtoExtensions
     };
 
     public static CompetitiveEventV2CreateRequestDto ToV2CreateRequestDto(this CompetitiveEventV2Dto competitiveEventV2Dto)
-    => new()
     {
-        AreThereBenefits = competitiveEventV2Dto.AreThereBenefits ?? default,
-        Benefits = competitiveEventV2Dto.Benefits,
-        CompetitiveSelection = competitiveEventV2Dto.CompetitiveSelection ?? default,
-        Contacts = competitiveEventV2Dto.Contacts ?? new List<ContactsDto>(),
-        DescriptionOfTheEnrollmentProcedure = competitiveEventV2Dto.DescriptionOfTheEnrollmentProcedure,
-        MaximumAge = competitiveEventV2Dto.MaximumAge ?? default,
-        MinimumAge = competitiveEventV2Dto.MinimumAge,
-        NumberOfSeats = competitiveEventV2Dto.NumberOfSeats,
-        OrganizerOfTheEventId = competitiveEventV2Dto.OrganizerOfTheEventId,
-        ParentId = competitiveEventV2Dto.ParentId,
-        PlannedFormatOfClasses = competitiveEventV2Dto.PlannedFormatOfClasses ?? default,
-        Price = competitiveEventV2Dto.Price ?? default,
-        RegistrationEndTime = competitiveEventV2Dto.RegistrationEndTime ?? default,
-        RegistrationStartTime = competitiveEventV2Dto.RegistrationStartTime ?? default,
-        ScheduledEndTime = competitiveEventV2Dto.ScheduledEndTime,
-        ScheduledStartTime = competitiveEventV2Dto.ScheduledStartTime,
-        ShortTitle = competitiveEventV2Dto.ShortTitle,
-        Title = competitiveEventV2Dto.Title,
-        TermsOfParticipation = competitiveEventV2Dto.TermsOfParticipation,
-        VenueName = competitiveEventV2Dto.VenueName,
-        SubDirectionIds = competitiveEventV2Dto.SubDirectionIds ?? [],
-        CompetitiveEventDescriptionItems = competitiveEventV2Dto.CompetitiveEventDescriptionItems,
-        CoverageId = competitiveEventV2Dto.CoverageId,
-        CompetitiveEventAccountingTypeId = competitiveEventV2Dto.CompetitiveEventAccountingTypeId,
-        CoverImageId = competitiveEventV2Dto.CoverImageId,
-        Id = competitiveEventV2Dto.Id,
-        ImageIds = competitiveEventV2Dto.ImageIds,
-    };
+        ArgumentNullException.ThrowIfNull(competitiveEventV2Dto);
+
+        return new()
+        {
+            AreThereBenefits = competitiveEventV2Dto.AreThereBenefits ?? default,
+            Benefits = competitiveEventV2Dto.Benefits,
+            CompetitiveSelection = competitiveEventV2Dto.CompetitiveSelection ?? default,
+            Contacts = competitiveEventV2Dto.Contacts ?? new List<ContactsDto>(),
+            DescriptionOfTheEnrollmentProcedure = competitiveEventV2Dto.DescriptionOfTheEnrollmentProcedure,
+            MaximumAge = competitiveEventV2Dto.MaximumAge ?? default,
+            MinimumAge = competitiveEventV2Dto.MinimumAge,
+            NumberOfSeats = competitiveEventV2Dto.NumberOfSeats,
+            OrganizerOfTheEventId = competitiveEventV2Dto.OrganizerOfTheEventId,
+            ParentId = competitiveEventV2Dto.ParentId,
+            PlannedFormatOfClasses = competitiveEventV2Dto.PlannedFormatOfClasses ?? default,
+            Price = competitiveEventV2Dto.Price ?? default,
+            RegistrationEndTime = competitiveEventV2Dto.RegistrationEndTime ?? default,
+            RegistrationStartTime = competitiveEventV2Dto.RegistrationStartTime ?? default,
+            ScheduledEndTime = competitiveEventV2Dto.ScheduledEndTime,
+            ScheduledStartTime = competitiveEventV2Dto.ScheduledStartTime,
+            ShortTitle = competitiveEventV2Dto.ShortTitle,
+            Title = competitiveEventV2Dto.Title,
+            TermsOfParticipation = competitiveEventV2Dto.TermsOfParticipation,
+            VenueName = competitiveEventV2Dto.VenueName,
+            SubDirectionIds = competitiveEventV2Dto.SubDirectionIds ?? [],
+            CompetitiveEventDescriptionItems = competitiveEventV2Dto.CompetitiveEventDescriptionItems,
+            CoverageId = competitiveEventV2Dto.CoverageId,
+            CompetitiveEventAccountingTypeId = competitiveEventV2Dto.CompetitiveEventAccountingTypeId,
+            CoverImageId = competitiveEventV2Dto.CoverImageId,
+            Id = competitiveEventV2Dto.Id,
+            ImageIds = competitiveEventV2Dto.ImageIds,
+        };
+    }
 
     /// <summary>
     /// Copies values from a CompetitiveEventV2CreateRequestDto into an existing CompetitiveEvent domain model, updating the model in-place.

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
@@ -182,8 +182,8 @@ public static class WorkshopV2DtoExtensions
         model.WorkshopType = dto.WorkshopType;
         model.DefaultTeacherId = dto.DefaultTeacherId;
         model.ParentWorkshopId = dto.ParentWorkshopId;
-        model.CoverImageId = dto.CoverImageId;
         model.IsChampionPath = dto.IsChampionPath;
+
         return model;
     }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -79,7 +79,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         {
             createdCompetitiveEventDraft.Images ??= [];
             createdCompetitiveEventDraft.Images.AddRange(
-                competitiveEventV2Dto.ImageIds.Select(id => new Image<CompetitiveEventDraft> { ExternalStorageId = id }));
+                (competitiveEventV2Dto.ImageIds ?? []).Select(id => new Image<CompetitiveEventDraft> { ExternalStorageId = id }));
         }
 
         await competitiveEventDraftRepository.SaveChangesAsync().ConfigureAwait(false);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -7,6 +7,7 @@ using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.V2;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEventDraft;
 using OutOfSchool.BusinessLogic.Models.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
+using OutOfSchool.Common.Enums.CompetitiveEvent;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Enums.CompetitiveEventStatus;
 using OutOfSchool.Services.Models.CompetitiveEventDrafts;
@@ -30,7 +31,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
 {
 
     // <inheritdoc/>
-    public async Task<CompetitiveEventDraftResultDto> Create(CompetitiveEventV2Dto competitiveEventV2Dto)
+    public async Task<CompetitiveEventDraftResultDto> Create(CompetitiveEventV2Dto competitiveEventV2Dto, bool fromCompetitiveEvent = false)
     {
         if (competitiveEventV2Dto == null)
         {
@@ -58,6 +59,10 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             }
             else
             {
+                if (existingCompetitiveEvent.State == CompetitiveEventStates.Archived)
+                {
+                    throw new InvalidOperationException("This CompetitiveEvent is archived. It can not be updated.");
+                }
                 await currentUserService.UserHasRights(new ProviderRights(existingCompetitiveEvent.OrganizerOfTheEventId),
                     new EmployeeRights(existingCompetitiveEvent.OrganizerOfTheEventId)).ConfigureAwait(false);
             }
@@ -69,6 +74,13 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
 
         var uploadImagesResult = await UploadImages(createdCompetitiveEventDraft, competitiveEventV2Dto)
             .ConfigureAwait(false);
+
+        if (fromCompetitiveEvent)
+        {
+            createdCompetitiveEventDraft.Images ??= [];
+            createdCompetitiveEventDraft.Images.AddRange(
+                competitiveEventV2Dto.ImageIds.Select(id => new Image<CompetitiveEventDraft> { ExternalStorageId = id }));
+        }
 
         await competitiveEventDraftRepository.SaveChangesAsync().ConfigureAwait(false);
 
@@ -311,7 +323,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         }
         else
         {
-            await competitiveEventService.UpdateV2(competitiveEventDraft.ToV2CreateRequestDto(), true);
+            await competitiveEventService.UpdateV2(competitiveEventDraft.ToDto(), true);
         }
 
         await competitiveEventDraftRepository.Delete(competitiveEventDraft);
@@ -364,12 +376,13 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         if (AreModeratedFieldsChanged(competitiveEventV2Dto, existingCompetitiveEvent))
         {
             logger.LogDebug("Moderated fields was changed. CompetitiveEvent draft creation initiated. CompetitiveEvent Id = {Id}.", competitiveEventV2Dto.Id);
-            return (await Create(competitiveEventV2Dto)).CompetitiveEventDraft.CompetitiveEventDetails;
+            return (await Create(competitiveEventV2Dto, true)).CompetitiveEventDraft.CompetitiveEventDetails;
         }
 
         logger.LogDebug("Moderated fields was not changed. CompetitiveEvent update initiated. CompetitiveEvent Id = {Id}.", competitiveEventV2Dto.Id);
 
-        var result = await competitiveEventService.UpdateV2(competitiveEventV2Dto.ToDraft().ToV2CreateRequestDto()).ConfigureAwait(false);
+        var result = await competitiveEventService.UpdateV2(competitiveEventV2Dto).ConfigureAwait(false);
+
         return result.CompetitiveEventV2;
     }
 
@@ -403,10 +416,13 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
 
         var stringFieldsToCompare = new List<Func<CompetitiveEventDto, string>>
         {
-            w => w.ShortTitle,
-            w => w.Title,
-            w => w.DescriptionOfTheEnrollmentProcedure,
-            w => string.Join(" | ", w.Contacts.Select(c => c.ToString()))
+            ce => ce.ShortTitle,
+            ce => ce.Title,
+            ce => ce.DescriptionOfTheEnrollmentProcedure,
+            ce => ce.TermsOfParticipation,
+            ce => ce.Benefits,
+            ce => ce.VenueName,
+            ce => string.Join(" | ", ce.Contacts.Select(c => c.ToString()))
         };
 
         return stringFieldsToCompare.Any(field =>

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -362,6 +362,11 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             throw new InvalidOperationException($"There is no CompetitiveEvent with such Id. CompetitiveEvent can`t be updated.");
         }
 
+        if (existingCompetitiveEvent.State == CompetitiveEventStates.Archived)
+        {
+            throw new InvalidOperationException("This CompetitiveEvent is archived. It can not be updated.");
+        }
+
         var draft = await competitiveEventDraftRepository.Get(whereExpression: ced => ced.CompetitiveEventId == competitiveEventV2Dto.Id)
             .AsNoTracking()
             .FirstOrDefaultAsync();
@@ -422,14 +427,15 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             ce => ce.TermsOfParticipation,
             ce => ce.Benefits,
             ce => ce.VenueName,
-            ce => string.Join(" | ", ce.Contacts.Select(c => c.ToString()))
+            ce => string.Join(" | ", (ce.Contacts ?? []).Select(c => c?.ToString()))
         };
 
         return stringFieldsToCompare.Any(field =>
         {
             var newValue = field(competitiveEventV2Dto);
             var oldValue = field(existingCompetitiveEvent);
-            return newValue != oldValue;
+
+            return !string.Equals(newValue, oldValue, StringComparison.Ordinal);
         });
     }
 
@@ -915,6 +921,16 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         await currentUserService.UserHasRights(new ModeratorRights(), new TechAdminRights()).ConfigureAwait(false);
 
         var competitiveEventDraft = await GetDraftById(draftId);
+
+        if (competitiveEventDraft == null)
+        {
+            logger.LogWarning("CompetitiveEventDraft with Id = {Id} not found.", draftId);
+            return Result<CompetitiveEventDraft>.Failed(new OperationError
+            {
+                Code = "404",
+                Description = "Competitive event draft not found."
+            });
+        }
 
         if (competitiveEventDraft.DraftStatus != CompetitiveEventDraftStatus.PendingModeration &&
             competitiveEventDraft.DraftStatus != CompetitiveEventDraftStatus.EditedByModerator)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/ICompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/ICompetitiveEventDraftService.cs
@@ -14,6 +14,9 @@ public interface ICompetitiveEventDraftService
     /// - Uploading associated images (competitive event images, cover image) in the external storage.
     /// </summary>
     /// <param name="competitiveEventV2Dto">
+    /// </param>
+    /// <param name="fromCompetitiveEvent">Flag to signal if the new draft is created from existing competitiveEvent.</param>
+    /// <returns>
     /// Data transfer object containing information required to create the draft, 
     /// including competitive event details, and optional images.
     /// </param>
@@ -21,7 +24,7 @@ public interface ICompetitiveEventDraftService
     /// A <see cref="CompetitiveEventDraftResultDto"/> containing the details of the created draft, 
     /// including any results or status from image processing operations.
     /// </returns>
-    Task<CompetitiveEventDraftResultDto> Create(CompetitiveEventV2Dto competitiveEventV2Dto);
+    Task<CompetitiveEventDraftResultDto> Create(CompetitiveEventV2Dto competitiveEventV2Dto, bool fromCompetitiveEvent = false);
 
     /// <summary>
     /// Update existing competitive event draft.

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventService.cs
@@ -457,9 +457,9 @@ public class CompetitiveEventService(
     /// <returns>A result DTO containing the updated competitive event and results of the image updates</returns>
     /// <exception cref="ArgumentNullException">Thrown if the DTO is null.</exception>
     /// <exception cref="DbUpdateConcurrencyException">Thrown if the competitive event with the given Id does not exist</exception>
-    public async Task<CompetitiveEventResultDto> UpdateV2(CompetitiveEventV2CreateRequestDto dto, bool fromDraft = false)
+    public async Task<CompetitiveEventResultDto> UpdateV2(CompetitiveEventV2Dto dto, bool fromDraft = false)
     {
-        var competitiveEvent = await CheckAndPrepareCompetitiveEventForUpdating(dto);
+        var competitiveEvent = await CheckAndPrepareCompetitiveEventForUpdating(dto.ToV2CreateRequestDto());
 
         async Task<(CompetitiveEvent updatedCompetitiveEvent, MultipleImageChangingResult multipleImageChangingResult,
            ImageChangingResult changingCoverImageResult)> UpdateCompetitiveEventWithDependencies()
@@ -490,6 +490,12 @@ public class CompetitiveEventService(
 
             var changingCoverImageResult = await competitiveImagesService
                 .ChangeCoverImageAsync(competitiveEvent, dto.CoverImageId, dto.CoverImage).ConfigureAwait(false);
+
+            // Fill CoverImageId for the updated competitiveEvent
+            if (!string.IsNullOrEmpty(dto.CoverImageId))
+            {
+                competitiveEvent.CoverImageId = dto.CoverImageId;
+            }
 
             await UpdateCompetitiveEvent().ConfigureAwait(false);
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventService.cs
@@ -459,6 +459,7 @@ public class CompetitiveEventService(
     /// <exception cref="DbUpdateConcurrencyException">Thrown if the competitive event with the given Id does not exist</exception>
     public async Task<CompetitiveEventResultDto> UpdateV2(CompetitiveEventV2Dto dto, bool fromDraft = false)
     {
+        ArgumentNullException.ThrowIfNull(dto);
         var competitiveEvent = await CheckAndPrepareCompetitiveEventForUpdating(dto.ToV2CreateRequestDto());
 
         async Task<(CompetitiveEvent updatedCompetitiveEvent, MultipleImageChangingResult multipleImageChangingResult,

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -548,6 +548,12 @@ public class WorkshopService(
             var changingCoverImageResult = await workshopImagesService
                 .ChangeCoverImageAsync(currentWorkshop, dto.CoverImageId, dto.CoverImage).ConfigureAwait(false);
 
+            // Fill CoverImageId for the updated competitiveEvent
+            if (!string.IsNullOrEmpty(dto.CoverImageId))
+            {
+                currentWorkshop.CoverImageId = dto.CoverImageId;
+            }
+
             await UpdateWorkshop().ConfigureAwait(false);
 
             return (currentWorkshop, multipleImageChangingResult, changingCoverImageResult);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Database/WorkshopService.cs
@@ -548,7 +548,7 @@ public class WorkshopService(
             var changingCoverImageResult = await workshopImagesService
                 .ChangeCoverImageAsync(currentWorkshop, dto.CoverImageId, dto.CoverImage).ConfigureAwait(false);
 
-            // Fill CoverImageId for the updated competitiveEvent
+            // Fill CoverImageId for the updated workshop.
             if (!string.IsNullOrEmpty(dto.CoverImageId))
             {
                 currentWorkshop.CoverImageId = dto.CoverImageId;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/ICompetitiveEventServiceV2.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/ICompetitiveEventServiceV2.cs
@@ -17,7 +17,7 @@ public interface ICompetitiveEventServiceV2 : ICompetitiveEventService
     /// /// <param name="dto">The DTO containing updated data for the competitive event</param>
     /// <param name="fromDraft">Flag to signal if the updated value is taken from draft.</param>
     /// <returns>A result DTO containing the updated competitive event and results of the image updates</returns>
-    Task<CompetitiveEventResultDto> UpdateV2(CompetitiveEventV2CreateRequestDto dto, bool fromDraft = false);
+    Task<CompetitiveEventResultDto> UpdateV2(CompetitiveEventV2Dto dto, bool fromDraft = false);
 
     /// <summary>
     /// Deletes a competitive event and removes any associated images and cover image if present

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -1297,7 +1297,8 @@ public class WorkshopDraftService(
             w => w.EnrollmentProcedureDescription,
             w => w.PreferentialTermsOfParticipation,
             w => w.ShortTitle,
-            w => w.Title
+            w => w.Title,
+            w => string.Join(" | ", (w.Contacts ?? []).Select(c => c?.ToString()))
         };
 
         return stringFieldsToCompare.Any(field =>
@@ -1305,7 +1306,7 @@ public class WorkshopDraftService(
             var newValue = field(workshopV2Dto);
             var oldValue = field(existingWorkshop);
 
-            return newValue != oldValue;
+            return !string.Equals(newValue, oldValue, StringComparison.Ordinal);
         });
     }
     private async Task SetLanguageNameOrThrow(WorkshopV2Dto dto)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -133,7 +133,7 @@ public class WorkshopDraftService(
         {
             createdDraftWithAssociatedTeachers.Images ??= [];
             createdDraftWithAssociatedTeachers.Images.AddRange(
-                workshopV2Dto.ImageIds.Select(id => new Image<WorkshopDraft> { ExternalStorageId = id }));
+                (workshopV2Dto.ImageIds ?? []).Select(id => new Image<WorkshopDraft> { ExternalStorageId = id }));
         }
 
         await workshopDraftRepository.SaveChangesAsync()
@@ -358,7 +358,7 @@ public class WorkshopDraftService(
         await workshopDraftRepository.Delete(workshopDraft);
 
         logger.LogDebug("Draft was successfully approved and deleted. Draft Id = {DraftId}.", id);
-        
+
         return createdWorkshopId;
     }
 
@@ -1423,13 +1423,13 @@ public class WorkshopDraftService(
         var likeMethod = typeof(DbFunctionsExtensions).GetMethods()
             .Single(m => m.Name == nameof(DbFunctionsExtensions.Like)
                 && m.GetParameters().Length == 3);
-        
+
         var jsonUnquoteMethod = typeof(MySqlJsonDbFunctionsExtensions).GetMethods()
             .Single(m => m.Name == nameof(MySqlJsonDbFunctionsExtensions.JsonUnquote)
                 && m.GetParameters().Length == 2);
 
         Expression JsonUnquote(Expression e)
-            => Expression.Call(null, jsonUnquoteMethod, efFunctions, e);    
+            => Expression.Call(null, jsonUnquoteMethod, efFunctions, e);
 
         Expression AddWeighted(Expression cond, int w)
             => Expression.Condition(cond, Expression.Constant(w), Expression.Constant(0));

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventDraftControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventDraftControllerTests.cs
@@ -51,7 +51,7 @@ public class CompetitiveEventDraftControllerTests
             Id = Guid.NewGuid(),
             OrganizerOfTheEventId = Guid.NewGuid()
         };
-        competitiveEventDraftServiceMock.Setup(s => s.Create(dto))
+        competitiveEventDraftServiceMock.Setup(s => s.Create(dto, false))
             .ReturnsAsync(new CompetitiveEventDraftResultDto
             {
                 CompetitiveEventDraft = new CompetitiveEventDraftResponseDto
@@ -81,7 +81,7 @@ public class CompetitiveEventDraftControllerTests
         // Arrange
         var dto = new CompetitiveEventV2Dto();
         providerServiceMock.Setup(s => s.IsBlocked(It.IsAny<Guid>())).ReturnsAsync(false);
-        competitiveEventDraftServiceMock.Setup(s => s.Create(dto))
+        competitiveEventDraftServiceMock.Setup(s => s.Create(dto, false))
             .ReturnsAsync((CompetitiveEventDraftResultDto)null);
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventsV2ControllerTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Controllers/CompetitiveEventsV2ControllerTests.cs
@@ -9,6 +9,7 @@ using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.V2;
 using OutOfSchool.BusinessLogic.Services;
+using OutOfSchool.BusinessLogic.Services.CompetitiveEventDrafts;
 using OutOfSchool.WebApi.Controllers.V2;
 
 namespace OutOfSchool.WebApi.Tests.Controllers;
@@ -18,6 +19,7 @@ public class CompetitiveEventsV2ControllerTests
     private Mock<IUserService> userServiceMock;
     private Mock<ILogger<CompetitiveEventController>> loggerMock;
     private CompetitiveEventController controller;
+    private Mock<ICompetitiveEventDraftService> competitiveEventDraftServiceMock;
 
     [SetUp]
     public void Setup()
@@ -25,11 +27,13 @@ public class CompetitiveEventsV2ControllerTests
         competitiveEventServiceMock = new Mock<ICompetitiveEventServiceV2>();
         userServiceMock = new Mock<IUserService>();
         loggerMock = new Mock<ILogger<CompetitiveEventController>>();
+        competitiveEventDraftServiceMock = new Mock<ICompetitiveEventDraftService>();
 
         controller = new CompetitiveEventController(
             competitiveEventServiceMock.Object,
             userServiceMock.Object,
-            loggerMock.Object);
+            loggerMock.Object,
+            competitiveEventDraftServiceMock.Object);
     }
 
     #region GetById
@@ -162,35 +166,36 @@ public class CompetitiveEventsV2ControllerTests
     [Test]
     public async Task Update_ReturnsOk_WhenSuccessful()
     {
-        var dto = new CompetitiveEventV2CreateRequestDto();
+        // Arrange
+        var dto = new CompetitiveEventV2Dto();
         var expectedId = Guid.NewGuid();
-        var resultDto = new CompetitiveEventResultDto
-        {
-            CompetitiveEventV2 = new CompetitiveEventV2Dto { Id = expectedId }
-        };
+        var resultDto = new CompetitiveEventV2Dto { Id = expectedId };
+        competitiveEventDraftServiceMock.Setup(s => s.UpdateCompetitiveEvent(dto)).ReturnsAsync(resultDto);
 
-        competitiveEventServiceMock.Setup(s => s.UpdateV2(dto, false)).ReturnsAsync(resultDto);
-
+        // Act
         var result = await controller.Update(dto);
 
+        // Assert
         Assert.IsInstanceOf<OkObjectResult>(result);
         var okResult = result as OkObjectResult;
         Assert.That(okResult.StatusCode, Is.EqualTo(200));
-        var responseDto = okResult.Value as CompetitiveEventResponseDto;
+        var responseDto = okResult.Value as CompetitiveEventV2Dto;
         Assert.That(responseDto, Is.Not.Null);
-        Assert.That(responseDto.CompetitiveEventV2.Id, Is.EqualTo(expectedId));
+        Assert.That(responseDto.Id, Is.EqualTo(expectedId));
     }
 
     [Test]
     public async Task Update_ReturnsBadRequest_WhenResultIsNull()
     {
-        var dto = new CompetitiveEventV2CreateRequestDto();
+        // Arrange
+        var dto = new CompetitiveEventV2Dto();
+        var resultDto = (CompetitiveEventV2Dto)null;
+        competitiveEventDraftServiceMock.Setup(s => s.UpdateCompetitiveEvent(dto)).ReturnsAsync(resultDto);
 
-        competitiveEventServiceMock.Setup(s => s.UpdateV2(dto, false))
-            .ReturnsAsync(new CompetitiveEventResultDto { CompetitiveEventV2 = null });
-
+        // Act
         var result = await controller.Update(dto);
 
+        // Assert
         Assert.IsInstanceOf<BadRequestResult>(result);
         var badRequest = result as BadRequestResult;
         Assert.That(badRequest.StatusCode, Is.EqualTo(400));
@@ -199,13 +204,15 @@ public class CompetitiveEventsV2ControllerTests
     [Test]
     public async Task Update_ReturnsBadRequest_WhenServiceThrowsInvalidOperation()
     {
-        var dto = new CompetitiveEventV2CreateRequestDto();
-
-        competitiveEventServiceMock.Setup(s => s.UpdateV2(dto, false))
+        // Arrange
+        var dto = new CompetitiveEventV2Dto();
+        competitiveEventDraftServiceMock.Setup(s => s.UpdateCompetitiveEvent(dto))
             .ThrowsAsync(new InvalidOperationException("Service error"));
 
+        // Act
         var result = await controller.Update(dto);
 
+        // Assert
         Assert.IsInstanceOf<BadRequestObjectResult>(result);
         var badRequest = result as BadRequestObjectResult;
         Assert.That(badRequest.StatusCode, Is.EqualTo(400));

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -931,7 +931,6 @@ public class CompetitiveEventDraftServiceTests
         mockCodeficatorRepository.Setup(repo => repo.Get(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Expression<Func<CATOTTG, bool>>>(),
             It.IsAny<Dictionary<Expression<Func<CATOTTG, object>>, SortDirection>>()))
             .Returns(catottgs.AsTestAsyncEnumerableQuery);
-
         mockSubDirectionRepository.Setup(repo => repo.GetByFilter(
             It.IsAny<Expression<Func<SubDirection, bool>>>(),
             It.IsAny<string>(),
@@ -948,9 +947,6 @@ public class CompetitiveEventDraftServiceTests
         Assert.That(result.DirectionSubDirectionIds
               .Select(x => (x.DirectionId, x.SubDirectionId)), Is.EqualTo(directionSubDirectionIds.Select(x => (x.DirectionId, x.SubDirectionId))));
     }
-
-
-
 
     [Test]
     public async Task UpdateCompetitiveEvent_CallUpdateV2_IfModeratedFieldsDoesNotChanged()

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -12,6 +12,7 @@ using OutOfSchool.BusinessLogic.Services;
 using OutOfSchool.BusinessLogic.Services.CompetitiveEventDrafts;
 using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
+using OutOfSchool.Common.Enums.CompetitiveEvent;
 using OutOfSchool.Common.Models;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Enums.CompetitiveEventStatus;
@@ -146,6 +147,100 @@ public class CompetitiveEventDraftServiceTests
         Assert.That(result.CompetitiveEventDraft.CompetitiveEventDetails.DirectionSubDirectionIds, Has.Count.EqualTo(1));
         Assert.That(result.CompetitiveEventDraft.CompetitiveEventDetails.DirectionSubDirectionIds
               .Select(x => (x.DirectionId, x.SubDirectionId)), Is.EqualTo(directionSubDirectionIds.Select(x => (x.DirectionId, x.SubDirectionId))));
+    }
+
+    [Test]
+    public async Task Create_ReturnsDraftResultDto_WhenDtoIsValidAndCompetitiveEventExisted()
+    {
+        // Arrange
+        var dto = new CompetitiveEventV2Dto()
+        {
+            Id = Guid.NewGuid(),
+            Contacts =
+            [
+                new ContactsDto
+                {
+                    IsDefault = true,
+                    Address = ContactsAddressDtoGenerator.Generate()
+                }
+            ]
+        };
+        var draft = dto.ToDraft();
+        var catottgs = new List<CATOTTG>
+        {
+            new() { Id = 1, Name = "Test Codeficator" }
+        };
+
+        var directionSubDirectionIds = new List<DirectionSubDirectionIdsDto>
+        {
+            new() { DirectionId = 14, SubDirectionId = 54  }
+        };
+
+        var subDirections = new List<SubDirection>
+        {
+            new() { Id = 54, DirectionId = 14, Description = "description1", IsDeleted = false, Title = "title1"  },
+            new() { Id = 9, DirectionId = 10, Description = "description2", IsDeleted = true, Title = "title2"  }
+        };
+
+        var existedCompetitiveEventDto = new CompetitiveEventDto() { State = CompetitiveEventStates.Published };
+
+        mockCompetitiveEventService.Setup(service => service.GetById(dto.Id))
+            .ReturnsAsync(existedCompetitiveEventDto);
+        mockUserService.Setup(service => service.UserHasRights(It.IsAny<IUserRights[]>()))
+            .Returns(Task.CompletedTask);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.RunInTransaction(It.IsAny<Func<Task<CompetitiveEventDraft>>>()))
+            .ReturnsAsync(draft);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Create(draft))
+            .ReturnsAsync(draft);
+        mockImageService.Setup(service => service.AddManyImagesAsync(draft, dto.ImageFiles))
+            .ReturnsAsync(new MultipleImageUploadingResult());
+        mockImageService.Setup(service => service.AddCoverImageAsync(draft, dto.CoverImage))
+            .ReturnsAsync(Result<string>.Success("some text"));
+        mockCodeficatorRepository.Setup(repo => repo.Get(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Expression<Func<CATOTTG, bool>>>(),
+            It.IsAny<Dictionary<Expression<Func<CATOTTG, object>>, SortDirection>>()))
+            .Returns(catottgs.AsTestAsyncEnumerableQuery);
+
+        mockSubDirectionRepository.Setup(repo => repo.GetByFilter(
+            It.IsAny<Expression<Func<SubDirection, bool>>>(),
+            It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<SubDirection>, IQueryable<SubDirection>>>()))
+            .ReturnsAsync(subDirections.Where(sd => !sd.IsDeleted));
+
+        // Act
+        var result = await competitiveEventDraftService.Create(dto, true);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOf<CompetitiveEventDraftResultDto>(result);
+        Assert.That(result.CompetitiveEventDraft.CompetitiveEventDetails.DirectionSubDirectionIds, Has.Count.EqualTo(1));
+        Assert.That(result.CompetitiveEventDraft.CompetitiveEventDetails.DirectionSubDirectionIds
+              .Select(x => (x.DirectionId, x.SubDirectionId)), Is.EqualTo(directionSubDirectionIds.Select(x => (x.DirectionId, x.SubDirectionId))));
+    }
+
+    [Test]
+    public void Create_ThrowsInvalidOperationException_WhenCompetitiveEventStateIsArchived()
+    {
+        // Arrange
+        var dto = new CompetitiveEventV2Dto()
+        {
+            Id = Guid.NewGuid(),
+            Contacts =
+            [
+                new ContactsDto
+                {
+                    IsDefault = true,
+                    Address = ContactsAddressDtoGenerator.Generate()
+                }
+            ]
+        };
+        var existedCompetitiveEventDto = new CompetitiveEventDto() { State = CompetitiveEventStates.Archived };
+        mockCompetitiveEventService.Setup(service => service.GetById(dto.Id))
+            .ReturnsAsync(existedCompetitiveEventDto);
+        mockUserService.Setup(service => service.UserHasRights(It.IsAny<IUserRights[]>()))
+            .Returns(Task.CompletedTask);
+
+        // Act & Assert
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await competitiveEventDraftService.Create(dto));
     }
 
     #endregion

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -775,25 +775,29 @@ public class CompetitiveEventDraftServiceTests
     {
         // Arrange
         Guid draftId = Guid.NewGuid();
-        CompetitiveEventDraft draft = new() 
-        { 
-            DraftStatus = CompetitiveEventDraftStatus.PendingModeration, 
+        CompetitiveEventDraft draft = new()
+        {
+            DraftStatus = CompetitiveEventDraftStatus.PendingModeration,
             CompetitiveEventId = null
         };
 
         mockCompetitiveEventDraftRepository.Setup(repo => repo.GetById(draftId))
             .ReturnsAsync(draft);
-        mockCompetitiveEventService.Setup(s => s.CreateV2(draft.ToV2CreateRequestDto()))
-            .ReturnsAsync(It.IsAny<CompetitiveEventResultDto>()).Verifiable(Times.Once);
+        mockCompetitiveEventService.Setup(s => s.CreateV2(It.IsAny<CompetitiveEventV2CreateRequestDto>()))
+           .ReturnsAsync(new CompetitiveEventResultDto());
         mockCompetitiveEventDraftRepository.Setup(repo => repo.Delete(draft))
-            .Returns(Task.CompletedTask).Verifiable(Times.Once);
+            .Returns(Task.CompletedTask);
 
-        // Act & Assert
+        // Act
         await competitiveEventDraftService.Approve(draftId);
+
+        // Assert
+        mockCompetitiveEventService.Verify(s => s.CreateV2(It.IsAny<CompetitiveEventV2CreateRequestDto>()), Times.Once);
+        mockCompetitiveEventDraftRepository.Verify(repo => repo.Delete(draft), Times.Once);
     }
 
     [Test]
-    public async Task Approve_CallUpdateV2_IfCompetitiveEventIdIsNottNull()
+    public async Task Approve_CallUpdateV2_IfCompetitiveEventIdIsNotNull()
     {
         // Arrange
         Guid draftId = Guid.NewGuid();
@@ -802,13 +806,174 @@ public class CompetitiveEventDraftServiceTests
 
         mockCompetitiveEventDraftRepository.Setup(repo => repo.GetById(draftId))
             .ReturnsAsync(draft);
-        mockCompetitiveEventService.Setup(s => s.UpdateV2(It.IsAny<CompetitiveEventV2Dto>(), true))
-            .ReturnsAsync(It.IsAny<CompetitiveEventResultDto>()).Verifiable(Times.Once);
+        mockCompetitiveEventService.Setup(s => s.UpdateV2(draft.ToDto(), true))
+            .ReturnsAsync(new CompetitiveEventResultDto());
         mockCompetitiveEventDraftRepository.Setup(repo => repo.Delete(draft))
-            .Returns(Task.CompletedTask).Verifiable(Times.Once);
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await competitiveEventDraftService.Approve(draftId);
+
+        // Assert
+        mockCompetitiveEventService.Verify(s => s.UpdateV2(It.IsAny<CompetitiveEventV2Dto>(), true), Times.Once);
+        mockCompetitiveEventDraftRepository.Verify(repo => repo.Delete(draft), Times.Once);
+    }
+
+    #endregion
+
+    #region UpdateCompetitiveEvent
+
+
+    [Test]
+    public void UpdateCompetitiveEvent_ReturnsInvalidOperationException_IfCompetitiveEventDoesNotExist()
+    {
+        // Arrange
+        CompetitiveEventV2Dto v2dto = CompetitiveEventV2DtoGenerator.Generate();
+        CompetitiveEventDto dto = null;
+
+        mockCompetitiveEventService.Setup(repo => repo.GetById(v2dto.Id))
+            .ReturnsAsync(dto);
 
         // Act & Assert
-        await competitiveEventDraftService.Approve(draftId);
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await competitiveEventDraftService.UpdateCompetitiveEvent(v2dto));
+    }
+
+    [Test]
+    public void UpdateCompetitiveEvent_ReturnsInvalidOperationException_IfCompetitiveEventStateIsAchieved()
+    {
+        // Arrange
+        CompetitiveEventV2Dto v2dto = CompetitiveEventV2DtoGenerator.Generate();
+        v2dto.State = CompetitiveEventStates.Archived;
+        CompetitiveEventDto dto = v2dto;
+
+        mockCompetitiveEventService.Setup(repo => repo.GetById(v2dto.Id))
+            .ReturnsAsync(dto);
+
+        // Act & Assert
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await competitiveEventDraftService.UpdateCompetitiveEvent(v2dto));
+    }
+
+    [Test]
+    public void UpdateCompetitiveEvent_ReturnsInvalidOperationException_IfDraftExists()
+    {
+        // Arrange
+        CompetitiveEventV2Dto v2dto = CompetitiveEventV2DtoGenerator.Generate();
+        CompetitiveEventDto dto = v2dto;
+        Guid excludedId = Guid.NewGuid();
+        var filter = new CompetitiveEventDraftFilterTitle { ExcludedId = excludedId };
+        var drafts = new List<CompetitiveEventDraft>
+        {
+            new CompetitiveEventDraft
+            {
+                Id = excludedId,
+                DraftStatus = CompetitiveEventDraftStatus.Draft,
+                CompetitiveEventDraftContent = new CompetitiveEventDraftContent { Title = "Test Event" },
+                CoverImageId = "coverImageId"
+            },
+            new CompetitiveEventDraft
+            {
+                Id = Guid.NewGuid(),
+                DraftStatus = CompetitiveEventDraftStatus.Draft,
+                CompetitiveEventDraftContent = new CompetitiveEventDraftContent { Title = "Another Test Event" },
+                CoverImageId = "coverImageId2"
+            }
+        };
+
+        mockCompetitiveEventService.Setup(repo => repo.GetById(v2dto.Id))
+            .ReturnsAsync(dto);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Get(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
+            It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
+            .Returns(drafts.AsTestAsyncEnumerableQuery);
+
+        // Act & Assert
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await competitiveEventDraftService.UpdateCompetitiveEvent(v2dto));
+    }
+
+    [Test]
+    public async Task UpdateCompetitiveEvent_CallCreate_IfModeratedFieldsChanged()
+    {
+        // Arrange
+        CompetitiveEventV2Dto v2dto = CompetitiveEventV2DtoGenerator.Generate();
+        CompetitiveEventDraft draft = v2dto.ToDraft();
+        CompetitiveEventDto dto = draft.ToDto();
+        dto.Title = "new Title";
+        var drafts = new List<CompetitiveEventDraft>();
+        var catottgs = new List<CATOTTG>
+        {
+            new() { Id = 1, Name = "Test Codeficator" }
+        };
+        var directionSubDirectionIds = new List<DirectionSubDirectionIdsDto>
+        {
+            new() { DirectionId = 14, SubDirectionId = 54  }
+        };
+        var subDirections = new List<SubDirection>
+        {
+            new() { Id = 54, DirectionId = 14, Description = "description1", IsDeleted = false, Title = "title1"  },
+            new() { Id = 9, DirectionId = 10, Description = "description2", IsDeleted = true, Title = "title2"  }
+        };
+
+        mockCompetitiveEventService.Setup(repo => repo.GetById(v2dto.Id))
+            .ReturnsAsync(dto);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Get(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
+            It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
+            .Returns(drafts.AsTestAsyncEnumerableQuery);
+
+        mockUserService.Setup(service => service.UserHasRights(It.IsAny<IUserRights[]>()))
+            .Returns(Task.CompletedTask);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.RunInTransaction(It.IsAny<Func<Task<CompetitiveEventDraft>>>()))
+            .ReturnsAsync(draft);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Create(draft))
+            .ReturnsAsync(draft);
+        mockImageService.Setup(service => service.AddManyImagesAsync(draft, v2dto.ImageFiles))
+            .ReturnsAsync(new MultipleImageUploadingResult());
+        mockImageService.Setup(service => service.AddCoverImageAsync(draft, v2dto.CoverImage))
+            .ReturnsAsync(Result<string>.Success("some text"));
+        mockCodeficatorRepository.Setup(repo => repo.Get(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Expression<Func<CATOTTG, bool>>>(),
+            It.IsAny<Dictionary<Expression<Func<CATOTTG, object>>, SortDirection>>()))
+            .Returns(catottgs.AsTestAsyncEnumerableQuery);
+
+        mockSubDirectionRepository.Setup(repo => repo.GetByFilter(
+            It.IsAny<Expression<Func<SubDirection, bool>>>(),
+            It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<SubDirection>, IQueryable<SubDirection>>>()))
+            .ReturnsAsync(subDirections.Where(sd => !sd.IsDeleted));
+
+        // Act 
+        var result = await competitiveEventDraftService.UpdateCompetitiveEvent(v2dto);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOf<CompetitiveEventV2Dto>(result);
+        Assert.That(result.DirectionSubDirectionIds, Has.Count.EqualTo(1));
+        Assert.That(result.DirectionSubDirectionIds
+              .Select(x => (x.DirectionId, x.SubDirectionId)), Is.EqualTo(directionSubDirectionIds.Select(x => (x.DirectionId, x.SubDirectionId))));
+    }
+
+
+
+
+    [Test]
+    public async Task UpdateCompetitiveEvent_CallUpdateV2_IfModeratedFieldsDoesNotChanged()
+    {
+        // Arrange
+        CompetitiveEventV2Dto v2dto = CompetitiveEventV2DtoGenerator.Generate();
+        CompetitiveEventDraft draft = v2dto.ToDraft();
+        CompetitiveEventDto dto = draft.ToDto();
+        var drafts = new List<CompetitiveEventDraft>();
+
+        mockCompetitiveEventService.Setup(repo => repo.GetById(v2dto.Id))
+            .ReturnsAsync(dto);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Get(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
+            It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
+            .Returns(drafts.AsTestAsyncEnumerableQuery);
+        mockCompetitiveEventService.Setup(s => s.UpdateV2(v2dto, false))
+            .ReturnsAsync(new CompetitiveEventResultDto() { CompetitiveEventV2 = draft.ToDto() });
+
+        // Act 
+        var result = await competitiveEventDraftService.UpdateCompetitiveEvent(v2dto);
+
+        // Assert
+        mockCompetitiveEventService.Verify(s => s.UpdateV2(It.IsAny<CompetitiveEventV2Dto>(), false), Times.Once);
     }
 
     #endregion

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -631,7 +631,7 @@ public class CompetitiveEventDraftServiceTests
             It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
             It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
             .Returns((int from, int size, Expression<Func<CompetitiveEventDraft, bool>> predicate,
-            Dictionary < Expression<Func<CompetitiveEventDraft, object>>, SortDirection > sort)
+            Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection> sort)
                 => drafts.AsQueryable().Where(predicate).AsTestAsyncEnumerableQuery());
 
         // Act
@@ -686,7 +686,7 @@ public class CompetitiveEventDraftServiceTests
             It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
             It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
             .Returns((int from, int size, Expression<Func<CompetitiveEventDraft, bool>> predicate,
-            Dictionary <Expression<Func<CompetitiveEventDraft, object>>, SortDirection> sort)
+            Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection> sort)
                 => drafts.AsQueryable().Where(predicate).AsTestAsyncEnumerableQuery());
 
         // Act
@@ -751,6 +751,64 @@ public class CompetitiveEventDraftServiceTests
         Assert.IsNotNull(result);
         Assert.IsInstanceOf<CompetitiveEventDraftResponseDto>(result);
         Assert.AreEqual(draft.Id, result.CompetitiveEventDraftId);
+    }
+
+    #endregion
+
+    #region Approve
+
+    [Test]
+    public void Approve_ReturnsArgumentException_IfDraftStatusIsNotPendingModerationOrEditedByModerator()
+    {
+        // Arrange
+        Guid draftId = Guid.NewGuid();
+        CompetitiveEventDraft draft = new() { DraftStatus = CompetitiveEventDraftStatus.Draft };
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.GetById(draftId))
+            .ReturnsAsync(draft);
+
+        // Act & Assert
+        Assert.ThrowsAsync<ArgumentException>(async () => await competitiveEventDraftService.Approve(draftId));
+    }
+
+    [Test]
+    public async Task Approve_CallCreateV2_IfCompetitiveEventIdIsNull()
+    {
+        // Arrange
+        Guid draftId = Guid.NewGuid();
+        CompetitiveEventDraft draft = new() 
+        { 
+            DraftStatus = CompetitiveEventDraftStatus.PendingModeration, 
+            CompetitiveEventId = null
+        };
+
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.GetById(draftId))
+            .ReturnsAsync(draft);
+        mockCompetitiveEventService.Setup(s => s.CreateV2(draft.ToV2CreateRequestDto()))
+            .ReturnsAsync(It.IsAny<CompetitiveEventResultDto>()).Verifiable(Times.Once);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Delete(draft))
+            .Returns(Task.CompletedTask).Verifiable(Times.Once);
+
+        // Act & Assert
+        await competitiveEventDraftService.Approve(draftId);
+    }
+
+    [Test]
+    public async Task Approve_CallUpdateV2_IfCompetitiveEventIdIsNottNull()
+    {
+        // Arrange
+        Guid draftId = Guid.NewGuid();
+        CompetitiveEventDraft draft = CompetitiveEventDraftGenerator.Generate();
+        draft.DraftStatus = CompetitiveEventDraftStatus.PendingModeration;
+
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.GetById(draftId))
+            .ReturnsAsync(draft);
+        mockCompetitiveEventService.Setup(s => s.UpdateV2(It.IsAny<CompetitiveEventV2Dto>(), true))
+            .ReturnsAsync(It.IsAny<CompetitiveEventResultDto>()).Verifiable(Times.Once);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Delete(draft))
+            .Returns(Task.CompletedTask).Verifiable(Times.Once);
+
+        // Act & Assert
+        await competitiveEventDraftService.Approve(draftId);
     }
 
     #endregion

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventsV2ServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventsV2ServiceTests.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -11,6 +13,7 @@ using NUnit.Framework;
 using OutOfSchool.BusinessLogic;
 using OutOfSchool.BusinessLogic.Common;
 using OutOfSchool.BusinessLogic.Models;
+using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.V2;
 using OutOfSchool.BusinessLogic.Models.Images;
 using OutOfSchool.BusinessLogic.Services;
@@ -21,6 +24,7 @@ using OutOfSchool.Services.Models.CompetitiveEvents;
 using OutOfSchool.Services.Models.Images;
 using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.Services.Repository.Base.Api;
+using OutOfSchool.Tests.Common.TestDataGenerators;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -34,6 +38,7 @@ public class CompetitiveEventsV2ServiceTests
     private Mock<IContactsService<CompetitiveEvent, IHasContactsDto<CompetitiveEvent>>> contactsServiceMock;
     private Mock<IImageDependentEntityImagesInteractionService<CompetitiveEvent>> imageServiceMock;
     private Mock<IEntityRepository<long, SubDirection>> mockSubDirectionRepository;
+
 
     private CompetitiveEventService service;
 
@@ -59,6 +64,8 @@ public class CompetitiveEventsV2ServiceTests
             contactsServiceMock.Object,
             imageServiceMock.Object);
     }
+
+    #region CreateV2
 
     [Test]
     public async Task CreateV2_ReturnsMappedDto_WhenSuccessful()
@@ -146,6 +153,21 @@ public class CompetitiveEventsV2ServiceTests
         Mock.VerifyAll();
     }
 
+    #endregion
+
+    #region UpdateV2
+
+    [Test]
+    public void UpdateV2_WhenDtoIsNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        CompetitiveEventV2Dto dto = null;
+
+        // Act and Assert
+        Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await service.UpdateV2(dto).ConfigureAwait(false));
+    }
+
     [Test]
     public void UpdateV2_ThrowsConcurrencyException_WhenEntityDoesNotExist()
     {
@@ -160,6 +182,65 @@ public class CompetitiveEventsV2ServiceTests
         Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () => await service.UpdateV2(dto));
     }
 
+    [Test]
+    public void UpdateV2_ThrowsInvalidOperationException_WhenSubDirectionIdsAreEmpty()
+    {
+        // Arrange
+        var dto = CompetitiveEventV2DtoGenerator.Generate();
+        var competitiveEvent = dto.SetToModel(new CompetitiveEvent());
+        competitiveEvent.Id = dto.Id;
+
+        repoMock.Setup(r => r.GetByIdWithDetails(dto.Id, It.IsAny<string>(), It.IsAny<Func<IQueryable<CompetitiveEvent>, IQueryable<CompetitiveEvent>>>()))
+            .ReturnsAsync(competitiveEvent);
+        repoMock.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<(CompetitiveEvent, MultipleImageChangingResult, ImageChangingResult)>>>()))
+            .Returns<Func<Task<(CompetitiveEvent, MultipleImageChangingResult, ImageChangingResult)>>>(f => f());
+
+        // Act, Assert
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await service.UpdateV2(dto));
+    }
+
+    [Test]
+    public async Task UpdateV2_ReturnResult_WhenEntityExists()
+    {
+        // Arrange
+        var dto = CompetitiveEventV2DtoGenerator.Generate();
+        var competitiveEvent = dto.SetToModel(new CompetitiveEvent());
+        competitiveEvent.Id = dto.Id;
+        competitiveEvent.CompetitiveEventDescriptionItems = dto.CompetitiveEventDescriptionItems.ToModel();
+        var subDirections = new List<SubDirection>
+        {
+            new() { Id = 54, DirectionId = 14, Description = "description1", IsDeleted = false, Title = "title1"  },
+            new() { Id = 9, DirectionId = 10, Description = "description2", IsDeleted = true, Title = "title2"  }
+        };
+
+        repoMock.Setup(r => r.GetByIdWithDetails(dto.Id, It.IsAny<string>(), It.IsAny<Func<IQueryable<CompetitiveEvent>, IQueryable<CompetitiveEvent>>>()))
+            .ReturnsAsync(competitiveEvent).Verifiable(Times.Once); ;
+        repoMock.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<(CompetitiveEvent, MultipleImageChangingResult, ImageChangingResult)>>>()))
+            .Returns<Func<Task<(CompetitiveEvent, MultipleImageChangingResult, ImageChangingResult)>>>(f => f()).Verifiable(Times.Once);;
+        mockSubDirectionRepository.Setup(repo => repo.GetByFilter(
+            It.IsAny<Expression<Func<SubDirection, bool>>>(),
+            It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<SubDirection>, IQueryable<SubDirection>>>()))
+            .ReturnsAsync(subDirections.Where(sd => !sd.IsDeleted)).Verifiable(Times.Once); ;
+        imageServiceMock.Setup(service => service.ChangeImagesAsync(competitiveEvent, It.IsAny<List<string>>(), It.IsAny<List<IFormFile>>()))
+            .ReturnsAsync(new MultipleImageChangingResult()).Verifiable(Times.Once); ;
+        imageServiceMock.Setup(service => service.ChangeCoverImageAsync(competitiveEvent, It.IsAny<string>(), It.IsAny<IFormFile>()))
+            .ReturnsAsync(new ImageChangingResult()).Verifiable(Times.Once); ;
+        repoMock.Setup(w => w.SaveChangesAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<int>()).Verifiable(Times.Once);
+
+        // Act
+        var result = await service.UpdateV2(dto);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(competitiveEvent.Id, result.CompetitiveEventV2.Id);
+        Mock.VerifyAll();
+    }
+
+    #endregion
+
+    #region DeleteV2
     [Test]
     public async Task DeleteV2_CallsRemoveImagesAndDeletesEntity_WhenImagesExist()
     {
@@ -212,4 +293,6 @@ public class CompetitiveEventsV2ServiceTests
         imageServiceMock.Verify(s => s.RemoveCoverImageAsync(It.IsAny<CompetitiveEvent>()), Times.Never);
         repoMock.Verify(r => r.Delete(entity), Times.Once);
     }
+
+    #endregion
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventsV2ServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventsV2ServiceTests.cs
@@ -149,7 +149,7 @@ public class CompetitiveEventsV2ServiceTests
     [Test]
     public void UpdateV2_ThrowsConcurrencyException_WhenEntityDoesNotExist()
     {
-        var dto = new CompetitiveEventV2CreateRequestDto { Id = Guid.NewGuid() };
+        var dto = new CompetitiveEventV2Dto { Id = Guid.NewGuid() };
 
         repoMock.Setup(r => r.GetByIdWithDetails(dto.Id, It.IsAny<string>(), It.IsAny<Func<IQueryable<CompetitiveEvent>, IQueryable<CompetitiveEvent>>>()))
             .ReturnsAsync((CompetitiveEvent)null);

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
@@ -4,6 +4,7 @@ using OutOfSchool.BusinessLogic.Common;
 using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.V2;
+using OutOfSchool.BusinessLogic.Services.CompetitiveEventDrafts;
 using OutOfSchool.Services.Models.CompetitiveEvents;
 using OutOfSchool.WebApi.Enums;
 using OutOfSchool.WebApi.Util.ControllersResultsHelpers;
@@ -21,15 +22,18 @@ public class CompetitiveEventController : ControllerBase
     private readonly ILogger<CompetitiveEventController> logger;
     private readonly ICompetitiveEventServiceV2 competitiveEventService;
     private readonly IUserService userService;
+    private readonly ICompetitiveEventDraftService competitiveEventDraftService;
 
     public CompetitiveEventController(
         ICompetitiveEventServiceV2 competitiveEventService,
         IUserService userService,
-        ILogger<CompetitiveEventController> logger)
+        ILogger<CompetitiveEventController> logger,
+        ICompetitiveEventDraftService competitiveEventDraftService)
     {
         this.competitiveEventService = competitiveEventService ?? throw new ArgumentNullException(nameof(competitiveEventService));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         this.userService = userService ?? throw new ArgumentNullException(nameof(userService));
+        this.competitiveEventDraftService = competitiveEventDraftService ?? throw new ArgumentNullException(nameof(competitiveEventDraftService));
     }
 
     /// <summary>
@@ -95,7 +99,6 @@ public class CompetitiveEventController : ControllerBase
         }
         return this.Ok(competitiveEvents);
     }
-
 
     /// <summary>
     /// Add new competitive image with image to the database.
@@ -175,25 +178,25 @@ public class CompetitiveEventController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPut]
     [Consumes("multipart/form-data")]
-    public async Task<IActionResult> Update([FromForm] CompetitiveEventV2CreateRequestDto dto)
+    public async Task<IActionResult> Update([FromForm] CompetitiveEventV2Dto dto)
     {
         try
         {
-            var updatingResult = await competitiveEventService.UpdateV2(dto).ConfigureAwait(false);
+            //TODO:???
+            dto.CoverImageId = dto.CoverImage is null ? dto.CoverImageId : null;
 
-            if (updatingResult.CompetitiveEventV2 is null)
+            var result = await competitiveEventDraftService.UpdateCompetitiveEvent(dto).ConfigureAwait(false);
+
+            if (result is null)
             {
                 return BadRequest();
             }
 
-            return Ok(CreateUpdateResponse(updatingResult));
+            return Ok(result);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException e)
         {
-            var errorMessage = $"Unable to update a new competitive event: {ex.Message}";
-            logger.LogError(ex, errorMessage);
-
-            return BadRequest(errorMessage);
+            return BadRequest(e.Message);
         }
     }
 
@@ -233,16 +236,6 @@ public class CompetitiveEventController : ControllerBase
 
             return BadRequest(errorMessage);
         }
-    }
-
-    private CompetitiveEventResponseDto CreateUpdateResponse(CompetitiveEventResultDto updatingResult)
-    {
-        return new CompetitiveEventResponseDto
-        {
-            CompetitiveEventV2 = updatingResult.CompetitiveEventV2,
-            UploadingCoverImageResult = updatingResult.UploadingCoverImageResult?.CreateSingleUploadingResult(),
-            UploadingImagesResults = updatingResult.UploadingImagesResults?.CreateMultipleUploadingResult(),
-        };
     }
 
     private async Task<bool> IsCurrentUserBlocked()

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
@@ -93,7 +93,7 @@ public class CompetitiveEventController : ControllerBase
     {
         var competitiveEvents = await competitiveEventService.GetByIds(ids).ConfigureAwait(false);
 
-        if (competitiveEvents.Any())
+        if (!competitiveEvents.Any())
         {
             return NotFound();
         }
@@ -182,7 +182,7 @@ public class CompetitiveEventController : ControllerBase
     {
         try
         {
-            //TODO:???
+            // Prefer one source for the cover image update
             dto.CoverImageId = dto.CoverImage is null ? dto.CoverImageId : null;
 
             var result = await competitiveEventDraftService.UpdateCompetitiveEvent(dto).ConfigureAwait(false);
@@ -196,6 +196,7 @@ public class CompetitiveEventController : ControllerBase
         }
         catch (InvalidOperationException e)
         {
+            logger.LogError("Unable to update competitive event: {Message}", e.Message);
             return BadRequest(e.Message);
         }
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
@@ -182,9 +182,6 @@ public class CompetitiveEventController : ControllerBase
     {
         try
         {
-            // Prefer one source for the cover image update
-            dto.CoverImageId = dto.CoverImage is null ? dto.CoverImageId : null;
-
             var result = await competitiveEventDraftService.UpdateCompetitiveEvent(dto).ConfigureAwait(false);
 
             if (result is null)

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
@@ -95,7 +95,7 @@ public class CompetitiveEventController : ControllerBase
 
         if (!competitiveEvents.Any())
         {
-            return NotFound();
+            return NoContent();
         }
         return this.Ok(competitiveEvents);
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/CompetitiveEventController.cs
@@ -191,10 +191,11 @@ public class CompetitiveEventController : ControllerBase
 
             return Ok(result);
         }
-        catch (InvalidOperationException e)
+        catch (InvalidOperationException ex)
         {
-            logger.LogError("Unable to update competitive event: {Message}", e.Message);
-            return BadRequest(e.Message);
+            logger.LogError(ex, "Unable to update competitive event: {Message}", ex.Message);
+
+            return BadRequest(ex.Message);
         }
     }
 

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftContentGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftContentGenerator.cs
@@ -1,0 +1,36 @@
+﻿using Bogus;
+using OutOfSchool.Services.Models.CompetitiveEventDrafts;
+using OutOfSchool.Services.Models.CompetitiveEvents;
+using OutOfSchool.Services.Models.ContactInfo;
+using System.Collections.Generic;
+
+namespace OutOfSchool.Tests.Common.TestDataGenerators;
+public static class CompetitiveEventDraftContentGenerator
+{
+    private static readonly Faker<CompetitiveEventDraftContent> Faker = new Faker<CompetitiveEventDraftContent>()
+        .RuleFor(x => x.Title, f => f.Lorem.Sentence(5))
+        .RuleFor(x => x.ShortTitle, f => f.Lorem.Sentence(3))
+        .RuleFor(x => x.RegistrationStartTime, f => f.Date.PastOffset(1))
+        .RuleFor(x => x.RegistrationEndTime, f => f.Date.FutureOffset(1))
+        .RuleFor(x => x.ParentId, f => f.Random.Guid())
+        .RuleFor(x => x.CompetitiveEventDescriptionItems, f => new List<CompetitiveEventDescriptionItem>
+        {
+            new() {
+                Id = f.Random.Guid(),
+                Description = f.Lorem.Paragraph(1),
+                CompetitiveEventId = f.Random.Guid(),
+                SectionName = f.Lorem.Word(),
+            }
+        })
+        .RuleFor(x => x.ScheduledStartTime, f => f.Date.FutureOffset(1))
+        .RuleFor(x => x.ScheduledEndTime, f => f.Date.FutureOffset(2))
+        .RuleFor(x => x.NumberOfSeats, f => f.Random.UInt(1, 100))
+        .RuleFor(x => x.OrganizerOfTheEventId, f => f.Random.Guid())
+        .RuleFor(x => x.MinimumAge, f => f.Random.Int(5, 18))
+        .RuleFor(x => x.Contacts, f => new List<Contacts> { })
+        .RuleFor(x => x.SubDirectionIds, f => new List<long> { f.Random.Long(1, 100) });
+
+    public static CompetitiveEventDraftContent Generate() => Faker.Generate();
+
+    public static List<CompetitiveEventDraftContent> Generate(int count) => Faker.Generate(count);
+}

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftGenerator.cs
@@ -1,0 +1,20 @@
+﻿using Bogus;
+using OutOfSchool.Services.Enums.CompetitiveEventStatus;
+using OutOfSchool.Services.Models.CompetitiveEventDrafts;
+using System.Collections.Generic;
+
+namespace OutOfSchool.Tests.Common.TestDataGenerators;
+public static class CompetitiveEventDraftGenerator
+{
+    private static readonly Faker<CompetitiveEventDraft> Faker = new Faker<CompetitiveEventDraft>()
+        .RuleFor(x => x.Id, f => f.Random.Guid())
+        .RuleFor(x => x.DraftStatus, CompetitiveEventDraftStatus.Draft)
+        .RuleFor(x => x.CATOTTGId, f => f.Random.Long(1, 100000))
+        .RuleFor(x => x.CoverageId, f => f.Random.Int(1, 5))
+        .RuleFor(x => x.CompetitiveEventAccountingTypeId, f => f.Random.Int(1, 10))
+        .RuleFor(x => x.CoverImageId, f => f.Lorem.Word())
+        .RuleFor(x => x.CompetitiveEventDraftContent, CompetitiveEventDraftContentGenerator.Generate());
+    public static CompetitiveEventDraft Generate() => Faker.Generate();
+
+    public static List<CompetitiveEventDraft> Generate(int count) => Faker.Generate(count);
+}

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftGenerator.cs
@@ -8,6 +8,7 @@ public static class CompetitiveEventDraftGenerator
 {
     private static readonly Faker<CompetitiveEventDraft> Faker = new Faker<CompetitiveEventDraft>()
         .RuleFor(x => x.Id, f => f.Random.Guid())
+        .RuleFor(x => x.CompetitiveEventId, f => f.Random.Guid())
         .RuleFor(x => x.DraftStatus, CompetitiveEventDraftStatus.Draft)
         .RuleFor(x => x.CATOTTGId, f => f.Random.Long(1, 100000))
         .RuleFor(x => x.CoverageId, f => f.Random.Int(1, 5))


### PR DESCRIPTION
1) Improved the CompetitiveEventController class:
- injected ICompetitiveEventDraftService dependency in the CompetitiveEventController class;
- fixed Update() action. 

2) Changed the signature of the Create() method of the ICompetitiveEventDraftService interface and CompetitiveEventDraftService class - the fromCompetitiveEvent parameter with type bool has been added. 

3) Fixed methods of CompetitiveEventDraftService class - Create(), Approve(), UpdateCompetitiveEvent() and AreModeratedFieldsChanged(). 

4) Changed the signature of the UpdateV2() method of the ICompetitiveEventServiceV2 interface and CompetitiveEventService class - the type of the dto parameter has been changed from CompetitiveEventV2CreateRequestDto to CompetitiveEventV2Dto.

5) Added 2 methods (ToV2CreateRequestDto() and SetToModel()) for mapping CompetitiveEventV2Dto to CompetitiveEventV2CreateRequestDto and CompetitiveEvent appropriately. 

6) Changed the CompetitiveEventDescriptionItemDto class:
- fixed the mapping extension method - ToModel();
- added the ToDto() method for mapping from CompetitiveEventDescriptionItem to CompetitiveEventDescriptionItemDto class. 

7) Fixed tests for classes - CompetitiveEventDraftController, CompetitiveEventsV2Controller and CompetitiveEventsV2Service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update now routes through the draft service, accepts V2 payloads, and returns the updated V2 event.
  * Draft creation can be flagged as originating from an existing event so drafts retain associated images.
  * Controller now integrates the draft service and Update action accepts V2 DTOs.

* **Bug Fixes**
  * Updates to archived events are rejected with a clear error.
  * Cover image changes now synchronize reliably.
  * Safe handling of empty/null image lists during draft creation.

* **Tests**
  * Added comprehensive tests for draft creation, archive-blocking, approve/update flows, and update branching.
* **Tests (support)**
  * New test data generators for competitive event drafts and content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->