### PR TITLE
refactor(todos): extract MariaDB version validation into IConfiguration extension

### DIFF
--- a/OutOfSchool/OutOfSchool.AdminInitializer/Program.cs
+++ b/OutOfSchool/OutOfSchool.AdminInitializer/Program.cs
@@ -18,13 +18,7 @@ var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((context, services) =>
     {
         var config = context.Configuration;
-        // TODO: Move version check into an extension to reuse code across apps
-        var mariaDbServerVersion = config["MariaDbServerVersion"];
-        var serverVersion = new MariaDbServerVersion(new Version(mariaDbServerVersion));
-        if (serverVersion.Version.Major < Constants.MariaDbServerMinimalMajorVersion)
-        {
-            throw new InvalidOperationException("MariaDb Server version should be 11 or higher.");
-        }
+        var serverVersion = config.GetAndValidateMariaDbVersion();
 
         var connectionString = config.GetMySqlConnectionString<InitializerConnectionOptions>(
             "DefaultConnection",

--- a/OutOfSchool/OutOfSchool.AdminInitializer/Program.cs
+++ b/OutOfSchool/OutOfSchool.AdminInitializer/Program.cs
@@ -18,7 +18,8 @@ var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((context, services) =>
     {
         var config = context.Configuration;
-        var serverVersion = config.GetAndValidateMariaDbVersion();
+        var mariaDbVersion = config.GetAndValidateMariaDbVersion();
+        var serverVersion = new MariaDbServerVersion(mariaDbVersion);
 
         var connectionString = config.GetMySqlConnectionString<InitializerConnectionOptions>(
             "DefaultConnection",

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Startup.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Startup.cs
@@ -35,7 +35,8 @@ public static class Startup
 
         var migrationsAssembly = typeof(Startup).GetTypeInfo().Assembly.GetName().Name;
 
-        var serverVersion = config.GetAndValidateMariaDbVersion();
+        var mariaDbVersion = config.GetAndValidateMariaDbVersion();
+        var serverVersion = new MariaDbServerVersion(mariaDbVersion);
 
         var quartzConfig = config.GetSection(QuartzConfig.Name).Get<QuartzConfig>();
         services.AddDefaultQuartz(

--- a/OutOfSchool/OutOfSchool.AuthorizationServer/Startup.cs
+++ b/OutOfSchool/OutOfSchool.AuthorizationServer/Startup.cs
@@ -35,13 +35,7 @@ public static class Startup
 
         var migrationsAssembly = typeof(Startup).GetTypeInfo().Assembly.GetName().Name;
 
-        // TODO: Move version check into an extension to reuse code across apps
-        var mariaDbServerVersion = config["MariaDbServerVersion"];
-        var serverVersion = new MariaDbServerVersion(new Version(mariaDbServerVersion));
-        if (serverVersion.Version.Major < Constants.MariaDbServerMinimalMajorVersion)
-        {
-            throw new InvalidOperationException("MariaDb Server version should be 11 or higher.");
-        }
+        var serverVersion = config.GetAndValidateMariaDbVersion();
 
         var quartzConfig = config.GetSection(QuartzConfig.Name).Get<QuartzConfig>();
         services.AddDefaultQuartz(

--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -2,6 +2,7 @@
 
 public static class Constants
 {
+    public const string MariaDbServerVersion = "MariaDbServerVersion";
     /// <summary>
     /// Maximum length of unified URL.
     /// </summary>

--- a/OutOfSchool/OutOfSchool.Common/Extensions/Startup/MariaDbConfigurationExtensions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Extensions/Startup/MariaDbConfigurationExtensions.cs
@@ -1,5 +1,5 @@
 using System;
-using Microsoft.EntityFrameworkCore;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 
 namespace OutOfSchool.Common.Extensions.Startup;
@@ -10,26 +10,36 @@ public static class MariaDbConfigurationExtensions
     /// Retrieves and validates the MariaDB server version from IConfiguration.
     /// </summary>
     /// <param name="configuration">The application configuration.</param>
-    /// <returns>A MariaDbServerVersion object to be used in UseMySql.</returns>
+    /// <returns>A System.Version representing the MariaDB server version.</returns>
     /// <exception cref="InvalidOperationException">
-    /// Thrown if the version is not configured or is lower than the minimum allowed.
+    /// Thrown if the version is not configured, cannot be parsed, or is lower than the minimum allowed.
     /// </exception>
-    public static MariaDbServerVersion GetAndValidateMariaDbVersion(this IConfiguration configuration)
+    public static Version GetAndValidateMariaDbVersion(this IConfiguration configuration)
     {
-        var mariaDbServerVersion = configuration[Constants.MariaDbServerVersion];
-        if (string.IsNullOrWhiteSpace(mariaDbServerVersion))
+        var raw = configuration[Constants.MariaDbServerVersion];
+        if (string.IsNullOrWhiteSpace(raw))
         {
             throw new InvalidOperationException("MariaDbServerVersion is not configured.");
         }
 
-        var serverVersion = new MariaDbServerVersion(new Version(mariaDbServerVersion));
-
-        if (serverVersion.Version.Major < Constants.MariaDbServerMinimalMajorVersion)
+        // Extract the leading numeric part (e.g., "10.11.7" from "10.11.7-MariaDB-1:...")
+        var numeric = new string(raw.Trim().TakeWhile(c => char.IsDigit(c) || c == '.').ToArray());
+        if (!Version.TryParse(numeric, out var parsed))
         {
             throw new InvalidOperationException(
-                $"MariaDb Server version should be {Constants.MariaDbServerMinimalMajorVersion} or higher.");
+                $"Invalid MariaDbServerVersion value '{raw}'. Expected formats like '10.11' or '11.4.2'.");
         }
 
-        return serverVersion;
+        // Allow MariaDB 10.11+ and 11+
+        var isSupported =
+            parsed.Major > 10 ||
+            (parsed.Major == 10 && parsed.Minor >= 11);
+
+        if (!isSupported)
+        {
+            throw new InvalidOperationException("MariaDb Server version should be 10.11 or higher.");
+        }
+
+        return parsed;
     }
 }

--- a/OutOfSchool/OutOfSchool.Common/Extensions/Startup/MariaDbConfigurationExtensions.cs
+++ b/OutOfSchool/OutOfSchool.Common/Extensions/Startup/MariaDbConfigurationExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+namespace OutOfSchool.Common.Extensions.Startup;
+
+public static class MariaDbConfigurationExtensions
+{
+    /// <summary>
+    /// Retrieves and validates the MariaDB server version from IConfiguration.
+    /// </summary>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>A MariaDbServerVersion object to be used in UseMySql.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the version is not configured or is lower than the minimum allowed.
+    /// </exception>
+    public static MariaDbServerVersion GetAndValidateMariaDbVersion(this IConfiguration configuration)
+    {
+        var mariaDbServerVersion = configuration[Constants.MariaDbServerVersion];
+        if (string.IsNullOrWhiteSpace(mariaDbServerVersion))
+        {
+            throw new InvalidOperationException("MariaDbServerVersion is not configured.");
+        }
+
+        var serverVersion = new MariaDbServerVersion(new Version(mariaDbServerVersion));
+
+        if (serverVersion.Version.Major < Constants.MariaDbServerMinimalMajorVersion)
+        {
+            throw new InvalidOperationException(
+                $"MariaDb Server version should be {Constants.MariaDbServerMinimalMajorVersion} or higher.");
+        }
+
+        return serverVersion;
+    }
+}

--- a/OutOfSchool/OutOfSchool.Common/OutOfSchool.Common.csproj
+++ b/OutOfSchool/OutOfSchool.Common/OutOfSchool.Common.csproj
@@ -11,16 +11,11 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.SmartEnum" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" /> 
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Pomelo.EntityFrameworkCore.MySql">
-      <HintPath>..\..\..\..\.nuget\packages\pomelo.entityframeworkcore.mysql\8.0.0\lib\net8.0\Pomelo.EntityFrameworkCore.MySql.dll</HintPath>
-    </Reference>
   </ItemGroup>
 </Project>

--- a/OutOfSchool/OutOfSchool.Common/OutOfSchool.Common.csproj
+++ b/OutOfSchool/OutOfSchool.Common/OutOfSchool.Common.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.SmartEnum" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" /> 
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/OutOfSchool/OutOfSchool.Common/OutOfSchool.Common.csproj
+++ b/OutOfSchool/OutOfSchool.Common/OutOfSchool.Common.csproj
@@ -17,4 +17,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Pomelo.EntityFrameworkCore.MySql">
+      <HintPath>..\..\..\..\.nuget\packages\pomelo.entityframeworkcore.mysql\8.0.0\lib\net8.0\Pomelo.EntityFrameworkCore.MySql.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/OutOfSchool/OutOfSchool.Migrations/Program.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Program.cs
@@ -4,20 +4,14 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OutOfSchool.AuthCommon;
-using OutOfSchool.Common;
+using OutOfSchool.Common.Extensions.Startup;
 using OutOfSchool.Services;
 
 var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((context, services) =>
     {
         var config = context.Configuration;
-        // TODO: Move version check into an extension to reuse code across apps
-        var mariaDbServerVersion = config["MariaDbServerVersion"];
-        var serverVersion = new MariaDbServerVersion(new Version(mariaDbServerVersion));
-        if (serverVersion.Version.Major < Constants.MariaDbServerMinimalMajorVersion)
-        {
-            throw new InvalidOperationException("MariaDb Server version should be 11 or higher.");
-        }
+        var serverVersion = config.GetAndValidateMariaDbVersion();
 
         var connectionString = config.GetConnectionString("DefaultConnection");
 

--- a/OutOfSchool/OutOfSchool.Migrations/Program.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Program.cs
@@ -11,7 +11,8 @@ var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((context, services) =>
     {
         var config = context.Configuration;
-        var serverVersion = config.GetAndValidateMariaDbVersion();
+        var mariaDbVersion = config.GetAndValidateMariaDbVersion();
+        var serverVersion = new MariaDbServerVersion(mariaDbVersion);
 
         var connectionString = config.GetConnectionString("DefaultConnection");
 

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -290,7 +290,8 @@ public static class Startup
         services.Configure<ImageOptions<WorkshopDraft>>(configuration.GetSection($"Images:{nameof(Workshop)}:Specs"));
         services.Configure<ImageOptions<CompetitiveEventDraft>>(configuration.GetSection($"Images:{nameof(CompetitiveEvent)}:Specs"));
         
-        var serverVersion = configuration.GetAndValidateMariaDbVersion();
+        var mariaDbVersion = configuration.GetAndValidateMariaDbVersion();
+        var serverVersion = new MariaDbServerVersion(mariaDbVersion);
 
         // registartion of thumbnail generation 
         builder.Services.Configure<ThumbnailGenerationOptions>(builder.Configuration.GetSection("ThumbnailGeneration:Thumbnails"));

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -289,16 +289,10 @@ public static class Startup
         services.Configure<ImageOptions<TeacherDraft>>(configuration.GetSection($"Images:{nameof(Teacher)}:Specs"));
         services.Configure<ImageOptions<WorkshopDraft>>(configuration.GetSection($"Images:{nameof(Workshop)}:Specs"));
         services.Configure<ImageOptions<CompetitiveEventDraft>>(configuration.GetSection($"Images:{nameof(CompetitiveEvent)}:Specs"));
+        
+        var serverVersion = configuration.GetAndValidateMariaDbVersion();
 
-        // TODO: Move version check into an extension to reuse code across apps
-        var mariaDbServerVersion = configuration["MariaDbServerVersion"];
-        var serverVersion = new MariaDbServerVersion(new Version(mariaDbServerVersion));
-        if (serverVersion.Version.Major < Constants.MariaDbServerMinimalMajorVersion)
-        {
-            throw new InvalidOperationException("MariaDb Server version should be 11 or higher.");
-        }
-
-        //registartion of thumbnail generation 
+        // registartion of thumbnail generation 
         builder.Services.Configure<ThumbnailGenerationOptions>(builder.Configuration.GetSection("ThumbnailGeneration:Thumbnails"));
         builder.Services.AddTransient<IThumbnailProcessingService, ThumbnailProcessingService>();
 


### PR DESCRIPTION
This PR introduces a new extension method GetAndValidateMariaDbVersion in the OutOfSchool.Common.Extensions.Startup namespace.
**The purpose is to centralize MariaDB server version validation logic, which was previously duplicated across multiple projects**

**Changes included**:

Added MariaDbConfigurationExtensions class with GetAndValidateMariaDbVersion method.

Introduced ConfigKeys.MariaDbServerVersion constant to avoid magic strings.

Updated WebApi and other projects to use the new extension as an example.

Why:

Eliminates code duplication across projects.

Provides a single source of truth for MariaDB version validation.

Improves maintainability and consistency.

Removes 4 Todos from our technical debt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized MariaDB version detection and validation via a configuration extension, simplifying setup across services and removing duplicate logic.
* **Bug Fixes**
  * More robust parsing and validation of the configured MariaDB version with clearer startup errors when using unsupported versions (requires 10.11+ or 11.x).
* **Chores**
  * Standardized configuration key for the MariaDB server version to ensure consistent configuration across applications.
  * Minor comment and formatting cleanups with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->