### PR TITLE
fix(workshopDrafts): return 400 with validation message when LanguageOfEducationId not found

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -1313,9 +1313,10 @@ public class WorkshopDraftService(
         var language = await languageService.GetById(dto.LanguageOfEducationId).ConfigureAwait(false);
         if (language is null)
         {
-            var errorMessage = $"Language with ID = {dto.LanguageOfEducationId} was not found.";
+            var errorMessage  = $"Validation error. Language with ID = {dto.LanguageOfEducationId} was not found.";
             logger.LogWarning(errorMessage);
-            throw new InvalidOperationException(errorMessage);
+            throw new ArgumentException(errorMessage);
+
         }
         dto.LanguageOfEducationName = language.Name;
     }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -197,7 +197,7 @@ public class WorkshopDraftServiceTests
         result.WorkshopDraft.WorkshopDetails.WorkshopType.Should().Be(WorkshopType.Workshop);
     }
     [Test]
-    public void Create_WithInvalidLanguageId_ShouldThrowInvalidOperationException()
+    public void Create_WithInvalidLanguageId_ShouldThrowArgumentException()
     {
         // Arrange
         var workshop = WorkshopGenerator.Generate().WithProvider().WithTeachers();
@@ -208,7 +208,7 @@ public class WorkshopDraftServiceTests
             .ReturnsAsync((LanguageDto)null);
 
         // Act & Assert
-        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await service.Create(workshopV2Dto));
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () => await service.Create(workshopV2Dto));
         ex.Message.Should().Contain($"Language with ID = {workshopV2Dto.LanguageOfEducationId}");
     }
 
@@ -447,7 +447,7 @@ public class WorkshopDraftServiceTests
             .ReturnsAsync(workshopV2Dto);
 
         // Act & Assert
-        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await service.Update(updateDto));
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () => await service.Update(updateDto));
         ex.Message.Should().Contain($"Language with ID = {workshopV2Dto.LanguageOfEducationId}");
     }
 

--- a/OutOfSchool/OutOfSchool.WebApi/Extensions/ExceptionMiddlewareExtension.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Extensions/ExceptionMiddlewareExtension.cs
@@ -39,9 +39,8 @@ public class ExceptionMiddlewareExtension
         catch (ArgumentException ex)
         {
             logger.LogError($"Exception information: {ex}");
-
-            var messageForUser = "Validation error. Please check your input data and try again. If you are sure of input data please contact support.";
-
+            var baseMessageForUser = "Validation error. Please check your input data and try again. If you are sure of input data please contact support.";
+            var messageForUser = string.IsNullOrWhiteSpace(ex.Message) ? baseMessageForUser : ex.Message;
             await HandleExceptionAsync(context, messageForUser, StatusCodes.Status400BadRequest).ConfigureAwait(false);
         }
         catch (UnauthorizedAccessException ex)


### PR DESCRIPTION
**Description**

Currently, when a non-existent LanguageOfEducationId is passed, the service throws InvalidOperationException which is mapped to 500 Internal Server Error.
This makes the API return an unexpected server error instead of a proper validation error.

**Changes in this PR**:

- Updated SetLanguageNameOrThrow to throw ArgumentException with a clear message when the language does not exist.

- Adjusted ExceptionMiddlewareExtension to return the exception’s message in 400 Bad Request response instead of a generic validation error text.

Now testers will see a user-friendly message like:
`{
  "Message": "Language with ID = 3 does not exist."
}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors now produce clearer, user-friendly messages and consistent 400 responses.
  * When a specific validation message is available, it is shown to the client; otherwise a standard validation message is used.
  * Client-visible behavior for successful requests remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->