### PR TITLE
fix(workshop title and shortTitle): trim unexpected chars in ShortTitle and Title 

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateUpdateDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateUpdateDto.cs
@@ -19,8 +19,8 @@ public static class WorkshopCreateUpdateDtoExtensions
     public static Workshop SetToModel(this WorkshopCreateUpdateDto dto, Workshop model)
     {
         model.Id = dto.Id;
-        model.Title = dto.Title.Trim(TrimChars);
-        model.ShortTitle = dto.ShortTitle.Trim(TrimChars);
+        model.Title = dto.Title?.Trim(TrimChars);
+        model.ShortTitle = dto.ShortTitle?.Trim(TrimChars);
         model.MinAge = dto.MinAge ?? default;
         model.MaxAge = dto.MaxAge ?? default;
         model.DateTimeRanges = dto.DateTimeRanges?.ToModel()

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateUpdateDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateUpdateDto.cs
@@ -15,11 +15,12 @@ public class WorkshopCreateUpdateDto : WorkshopBaseDto
 
 public static class WorkshopCreateUpdateDtoExtensions
 {
+    private static readonly char[] TrimChars = { ' ', ',', '.',';',':' };
     public static Workshop SetToModel(this WorkshopCreateUpdateDto dto, Workshop model)
     {
         model.Id = dto.Id;
-        model.Title = dto.Title;
-        model.ShortTitle = dto.ShortTitle;
+        model.Title = dto.Title.Trim(TrimChars);
+        model.ShortTitle = dto.ShortTitle.Trim(TrimChars);
         model.MinAge = dto.MinAge ?? default;
         model.MaxAge = dto.MaxAge ?? default;
         model.DateTimeRanges = dto.DateTimeRanges?.ToModel()

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
@@ -146,8 +146,8 @@ public static class WorkshopV2DtoExtensions
     public static Workshop SetToModel(this WorkshopV2Dto dto, Workshop model)
     {
         model.Id = dto.Id;
-        model.Title = dto.Title.Trim(TrimChars);
-        model.ShortTitle = dto.ShortTitle.Trim(TrimChars);
+        model.Title = dto.Title?.Trim(TrimChars);
+        model.ShortTitle = dto.ShortTitle?.Trim(TrimChars);
         model.MinAge = dto.MinAge ?? default;
         model.MaxAge = dto.MaxAge ?? default;
         model.DateTimeRanges = dto.DateTimeRanges?.SetToModel(model.DateTimeRanges);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
@@ -18,6 +18,7 @@ public class WorkshopV2Dto : WorkshopDto, IHasCoverImage, IHasImages
 
 public static class WorkshopV2DtoExtensions
 {
+    private static readonly char[] TrimChars = { ' ', ',', '.',';',':' };
     public static WorkshopDraftContent ToDraftContent(this WorkshopV2Dto dto)
         => new()
         {
@@ -31,7 +32,7 @@ public static class WorkshopV2DtoExtensions
             ActiveFrom = dto.ActiveFrom,
             ActiveTo = dto.ActiveTo,
             TagIds = (dto.Tags ?? []).Select(x => x.Id).Concat(dto.TagIds ?? []).ToList(),
-            Title = dto.Title,
+            Title = dto.Title.Trim(TrimChars),
             IsPaid = dto.IsPaid,
             StudyPeriodStartDate = dto.StudyPeriodDates.StartDate.ToStudyPeriodDate(),
             StudyPeriodEndDate = dto.StudyPeriodDates.EndDate.ToStudyPeriodDate(),
@@ -39,7 +40,7 @@ public static class WorkshopV2DtoExtensions
             OwnershipType = dto.ProviderOwnership,
             AvailableSeats = dto.AvailableSeats ?? default,
             IncludedStudyGroupsIds = dto.IncludedStudyGroups?.Select(x => x.Id).ToList() ?? [],
-            ShortTitle = dto.ShortTitle,
+            ShortTitle = dto.ShortTitle.Trim(TrimChars),
             CompetitiveSelectionDescription = dto.CompetitiveSelectionDescription,
             FormOfLearning = dto.FormOfLearning,
             WorkshopStatus = dto.Status,
@@ -145,8 +146,8 @@ public static class WorkshopV2DtoExtensions
     public static Workshop SetToModel(this WorkshopV2Dto dto, Workshop model)
     {
         model.Id = dto.Id;
-        model.Title = dto.Title;
-        model.ShortTitle = dto.ShortTitle;
+        model.Title = dto.Title.Trim(TrimChars);
+        model.ShortTitle = dto.ShortTitle.Trim(TrimChars);
         model.MinAge = dto.MinAge ?? default;
         model.MaxAge = dto.MaxAge ?? default;
         model.DateTimeRanges = dto.DateTimeRanges?.SetToModel(model.DateTimeRanges);


### PR DESCRIPTION
## **Summary**

This PR fixes an issue where the WorkshopDraft Title and ShortTitle field was saved with leading or trailing spaces when creating (POST) or updating (PUT) via API. This caused “dirty” data in the database (e.g., " Short " instead of "Short").

## Changes

Applied .Trim() for ShortTitle and Title in DTO → Model and Draft mapping.

Ensured consistency across WorkshopV2DtoExtensions and WorkshopCreateUpdateDtoExtensions.

## **Closes**

Closes #1972

Closes #1959

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workshop titles and short titles are now automatically trimmed to remove leading/trailing spaces and common punctuation when creating or updating entries.
  - Draft content generation also trims titles and short titles to ensure consistent formatting.
  - No changes to public workflows or APIs; this improves readability and searchability of workshop listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->