### PR TITLE
Fix issues with StudyPeriodDate validation, PayRate defaults, and Keywords duplicates

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -252,6 +252,14 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
                     yield return new ValidationResult($"Keyword \"{keyword}\" must be no longer than 60 characters.", new[] { nameof(Keywords) });
                 }
             }
+
+            var cleanedKeyWordsList = keywordsList.Select(k => k.Trim());
+            HashSet<string> keywordsSet = new(StringComparer.OrdinalIgnoreCase);
+            
+            if (!cleanedKeyWordsList.All(keywordsSet.Add))
+            {
+                yield return new ValidationResult("Keywords list contains duplicates.", new[] { nameof(Keywords) });
+            }
         }
 
         if (AvailableSeats != uint.MaxValue && (AvailableSeats < 1 || AvailableSeats > 100000))

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -241,19 +241,24 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
                 yield return new ValidationResult("Keywords list should contain no more than 5 words", new[] { nameof(Keywords) });
             }
 
-            foreach (var keyword in keywordsList)
+            if (keywordsList.Any(string.IsNullOrWhiteSpace))
             {
-                if (string.IsNullOrWhiteSpace(keyword))
-                {
-                    yield return new ValidationResult($"Keyword cannot be empty or whitespace.", new[] { nameof(Keywords) });
-                }
-                else if (keyword.Length > 60)
-                {
-                    yield return new ValidationResult($"Keyword \"{keyword}\" must be no longer than 60 characters.", new[] { nameof(Keywords) });
-                }
+                yield return new ValidationResult(
+                    "Keyword cannot be empty or whitespace.",
+                    new[] { nameof(Keywords) });
             }
 
-            var cleanedKeyWordsList = keywordsList.Select(k => k.Trim());
+            if (keywordsList.Any(k => !string.IsNullOrWhiteSpace(k) && k.Length > 60))
+            {
+                yield return new ValidationResult(
+                    "Keyword must be no longer than 60 characters.",
+                    new[] { nameof(Keywords) });
+            }
+
+            var cleanedKeyWordsList = keywordsList
+                .Where(k => !string.IsNullOrWhiteSpace(k))
+                .Select(k => k.Trim());
+            
             HashSet<string> keywordsSet = new(StringComparer.OrdinalIgnoreCase);
             
             if (!cleanedKeyWordsList.All(keywordsSet.Add))

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -48,7 +48,7 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
     public decimal? Price { get; set; } = default;
 
     [EnumDataType(typeof(PayRateType), ErrorMessage = Constants.EnumErrorMessage)]
-    public PayRateType? PayRate { get; set; } = PayRateType.Class;
+    public PayRateType? PayRate { get; set; } = PayRateType.None;
 
     [Required(ErrorMessage = "Form of learning is required")]
     [EnumDataType(typeof(FormOfLearning), ErrorMessage = Constants.EnumErrorMessage)]
@@ -226,6 +226,10 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
                     yield return new ValidationResult("Price must be less than or equal to 100000.00.", new[] { nameof(Price) });
                 }
             }
+        }
+        else 
+        { 
+            PayRate = PayRateType.None;
         }
 
         if (!Keywords.IsNullOrEmpty())

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/JsonTools/JsonModelBinder.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/JsonTools/JsonModelBinder.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using OutOfSchool.BusinessLogic.Models.Workshops;
+using System.Text.Json;
 
 namespace OutOfSchool.BusinessLogic.Util.JsonTools;
 
@@ -12,16 +14,24 @@ public class JsonModelBinder : IModelBinder
         }
 
         var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+
         if (valueProviderResult != ValueProviderResult.None)
         {
             bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
-
             var valueAsString = valueProviderResult.FirstValue;
-            var result = JsonSerializerHelper.Deserialize(valueAsString, bindingContext.ModelType);
-            if (result != null)
+
+            try
             {
-                bindingContext.Result = ModelBindingResult.Success(result);
-                return Task.CompletedTask;
+                var result = JsonSerializerHelper.Deserialize(valueAsString, bindingContext.ModelType);
+                
+                if (result != null)
+                {
+                    bindingContext.Result = ModelBindingResult.Success(result);
+                }
+            }
+            catch (JsonException jsonException)
+            {
+                bindingContext.ModelState.TryAddModelError(bindingContext.ModelName, jsonException, bindingContext.ModelMetadata);
             }
         }
         return Task.CompletedTask;


### PR DESCRIPTION
Problems solved
- API returned 500 when invalid JSON (wrong date format) was passed.
- PayRate could still be sent and stored when "isPaid": false or not provided during workshop draft creation
- Workshop was created even when duplicate keyword values were provided.

Solutions applied
- Added try/catch in JsonModelBinder → now returns proper 400 Bad Request with validation error.
- Set default value of PayRate to None and updated validation logic: when isPaid is not set or equals false, PayRate is forced to None.
- Added validation to prevent workshop creation with duplicate keywords

Related issues
- Closes #1958 (Invalid date format in StudyPeriodDates)
- Closes #1962 (PayRate validation)
- Closes #1975 (Keywords duplicates)
- Partially covers #1970 (scenarios 1–5 are resolved by fix in #1958))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON requests now report deserialization errors to model state instead of silently succeeding on malformed input.
  * Keywords are trimmed and checked for case-insensitive duplicates; duplicate entries are blocked and per-keyword validation retained.
  * When a workshop is marked unpaid, the pay rate is automatically set to None; default pay rate updated to None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->