### PR TITLE
Fixed the CompetitiveEvent Update workflow

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -106,8 +106,8 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         return new CompetitiveEventDraftResultDto
         {
             CompetitiveEventDraft = await MapCompetitiveEventDraftWithDetails(draftImageUpdateResult.Value.createdCompetitiveEventDraft),
-            UploadingCoverImagesCompetitiveEventResult = draftImageUpdateResult.Value.uploadImagesResult.UploadingCoverImageResult,
-            UploadingImagesResults = draftImageUpdateResult.Value.uploadImagesResult.UploadingImagesResults.MultipleKeyValueOperationResult
+            UploadingCoverImagesCompetitiveEventResult = draftImageUpdateResult.Value.uploadImagesResult?.UploadingCoverImageResult,
+            UploadingImagesResults = draftImageUpdateResult.Value.uploadImagesResult?.UploadingImagesResults?.MultipleKeyValueOperationResult
         };
     }
 
@@ -128,11 +128,20 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             return Result<CompetitiveEventDraftResultDto>.Failed(new OperationError()
             {
                 Code = "400",
+                Description = "ID in route can't be empty."
+            });
+        }
+
+        if (competitiveEventDraftUpdateDto.Id == Guid.Empty)
+        {
+            return Result<CompetitiveEventDraftResultDto>.Failed(new OperationError()
+            {
+                Code = "400",
                 Description = "Dto's id can't be empty."
             });
         }
 
-        if (competitiveEventDraftUpdateDto.Id != Guid.Empty && competitiveEventDraftUpdateDto.Id != id)
+        if (competitiveEventDraftUpdateDto.Id != id)
         {
             return Result<CompetitiveEventDraftResultDto>.Failed(new OperationError()
             {
@@ -328,7 +337,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         logger.LogDebug("Approving CompetitiveEventDraft started. CompetitiveEventDraft Id = {Id}.", id);
 
         var competitiveEventDraft = await GetDraftById(id) ?? throw new ArgumentException($"There is no CompetitiveEvent draft with such Id.");
-        
+
         if (competitiveEventDraft.DraftStatus != CompetitiveEventDraftStatus.PendingModeration && competitiveEventDraft.DraftStatus != CompetitiveEventDraftStatus.EditedByModerator)
         {
             throw new ArgumentException("This Competitive event draft can`t be approved.");
@@ -874,22 +883,19 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             new EmployeeRights(competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.OrganizerOfTheEventId))
             .ConfigureAwait(false);
 
-        if (competitiveEventDraftUpdateDto.Id != Guid.Empty)
-        {
-            var existingCompetitiveEvent = await competitiveEventService.GetById(competitiveEventDraftUpdateDto.Id)
-                .ConfigureAwait(false);
+        var existingCompetitiveEvent = await competitiveEventService.GetById(competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Id)
+         .ConfigureAwait(false);
 
-            if (existingCompetitiveEvent == null)
-            {
-                competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Id = Guid.Empty;
-            }
-            else
-            {
-                await currentUserService.UserHasRights(
-                    new ProviderRights(existingCompetitiveEvent.OrganizerOfTheEventId),
-                    new EmployeeRights(existingCompetitiveEvent.OrganizerOfTheEventId))
-                    .ConfigureAwait(false);
-            }
+        if (existingCompetitiveEvent == null)
+        {
+            competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Id = Guid.Empty;
+        }
+        else
+        {
+            await currentUserService.UserHasRights(
+                new ProviderRights(existingCompetitiveEvent.OrganizerOfTheEventId),
+                new EmployeeRights(existingCompetitiveEvent.OrganizerOfTheEventId))
+                .ConfigureAwait(false);
         }
 
         if (competitiveEventDraft.DraftStatus == CompetitiveEventDraftStatus.PendingModeration)

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -373,7 +373,27 @@ public class CompetitiveEventDraftServiceTests
         // Assert
         Assert.That(result.Succeeded, Is.False);
         Assert.That(result.OperationResult.Errors.FirstOrDefault().Code, Is.EqualTo("400"));
-        Assert.That(result.OperationResult.Errors.FirstOrDefault().Description, Does.Contain("Dto's id can't be empty"));
+        Assert.That(result.OperationResult.Errors.FirstOrDefault().Description, Does.Contain("ID in route can't be empty."));
+    }
+
+    [Test]
+    public async Task Update_ReturnsFailedResult_IfIdIsNotEmptyButDtoIdIsEmpty()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        var dto = new CompetitiveEventDraftUpdateDto()
+        {
+            Id = Guid.Empty,
+            CompetitiveEventV2Dto = new CompetitiveEventV2Dto()
+        };
+
+        // Act
+        var result = await competitiveEventDraftService.Update(id, dto);
+
+        // Assert
+        Assert.That(result.Succeeded, Is.False);
+        Assert.That(result.OperationResult.Errors.FirstOrDefault().Code, Is.EqualTo("400"));
+        Assert.That(result.OperationResult.Errors.FirstOrDefault().Description, Does.Contain("Dto's id can't be empty."));
     }
 
     [Test]


### PR DESCRIPTION
Fixed the CompetitiveEvent Update workflow:
- fixed 500 Internal Server Error for case when new images for properties CoverImage and ImageFiles are not downloaded;
- fixed the Update workflow for  the CompetitiveEvent draft.

For this:
1) Fixed the Create() method of the CompetitiveEventDraftService class - added null check to the uploadImagesResult property for the returned CompetitiveEventDraftResultDto value.
2) Fixed Update() and UpdateDraftWithImagesAsync() methods of the CompetitiveEventDraftService class.
3) Added the corresponding test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors when image upload results are absent, improving draft updates with images.
  * Returns a 400 error when the route ID is empty for clearer API behavior.
  * More reliable rights validation when linking to an existing event during draft updates.

* **Improvements**
  * Clearer, more consistent error messages for empty or mismatched IDs between route and payload.
  * Safer handling of optional upload results to avoid null-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->