### PR TITLE
Change the CompetitiveEvent and Workshops moderation conditions

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Config/Elasticsearch/ElasticsearchCompetitiveEventConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Config/Elasticsearch/ElasticsearchCompetitiveEventConfiguration.cs
@@ -40,7 +40,7 @@ public class ElasticsearchCompetitiveEventConfiguration : IElasticsearchEntityTy
                    .Keyword(n => n.OrganizerOfTheEventId)
                    .Keyword(n => n.PlannedFormatOfClasses)
                    .Text(n => n.VenueName)
-                   .Text(n => n.TermsOfParticipation)
+                   .Text(n => n.CompetitiveSelectionDescription)
                    .Text(n => n.PreferentialTermsOfParticipation)
                    .Boolean(n => n.AreThereBenefits)
                    .Text(n => n.Benefits)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventBaseDto.cs
@@ -76,10 +76,10 @@ public class CompetitiveEventBaseDto : IValidatableObject, IHasContactsDto<OutOf
     public string VenueName { get; set; }
 
     [MinLength(3)]
-    [MaxLength(Constants.MaxTermsOfParticipationLength)]
-    [RequiredIf(nameof(CompetitiveSelection), true, ErrorMessage = "Terms of participation is required")]
+    [MaxLength(Constants.MaxCompetitiveSelectionDescriptionLength)]
+    [RequiredIf(nameof(CompetitiveSelection), true, ErrorMessage = "Competitive selection description is required")]
     [MustContain(RequiredCharacterType.AnyLetter)]
-    public string TermsOfParticipation { get; set; }
+    public string CompetitiveSelectionDescription { get; set; }
 
     public bool? AreThereBenefits { get; set; }
 
@@ -174,7 +174,7 @@ public static class CompetitiveEventBaseDtoExtensions
         OrganizerOfTheEventId = dto.OrganizerOfTheEventId,
         PlannedFormatOfClasses = dto.PlannedFormatOfClasses ?? default,
         VenueName = dto.VenueName,
-        TermsOfParticipation = dto.TermsOfParticipation,
+        CompetitiveSelectionDescription = dto.CompetitiveSelectionDescription,
         AreThereBenefits = dto.AreThereBenefits ?? false,
         Benefits = dto.Benefits,
         MinimumAge = dto.MinimumAge,
@@ -212,7 +212,7 @@ public static class CompetitiveEventBaseDtoExtensions
         model.OrganizerOfTheEventId = dto.OrganizerOfTheEventId;
         model.PlannedFormatOfClasses = dto.PlannedFormatOfClasses ?? model.PlannedFormatOfClasses;
         model.VenueName = dto.VenueName;
-        model.TermsOfParticipation = dto.TermsOfParticipation;
+        model.CompetitiveSelectionDescription = dto.CompetitiveSelectionDescription;
         model.AreThereBenefits = dto.AreThereBenefits ?? model.AreThereBenefits;
         model.Benefits = dto.Benefits;
         model.MinimumAge = dto.MinimumAge;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDto.cs
@@ -57,7 +57,7 @@ public static class CompetitiveEventDtoExtensions
             OrganizerOfTheEventId = model.OrganizerOfTheEventId,
             PlannedFormatOfClasses = model.PlannedFormatOfClasses,
             VenueName = model.VenueName,
-            TermsOfParticipation = model.TermsOfParticipation,
+            CompetitiveSelectionDescription = model.CompetitiveSelectionDescription,
             AreThereBenefits = model.AreThereBenefits,
             Benefits = model.Benefits,
             MinimumAge = model.MinimumAge,

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventDescriptionDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventDescriptionDto.cs
@@ -35,10 +35,10 @@ public class CompetitiveEventDescriptionDto : CompetitiveEventAboutDto
     public bool? CompetitiveSelection { get; set; }
 
     [MinLength(3)]
-    [MaxLength(Constants.MaxTermsOfParticipationLength)]
-    [RequiredIf(nameof(CompetitiveSelection), true, ErrorMessage = "Terms of participation is required")]
+    [MaxLength(Constants.MaxCompetitiveSelectionDescriptionLength)]
+    [RequiredIf(nameof(CompetitiveSelection), true, ErrorMessage = "Competitive selection description is required")]
     [MustContain(RequiredCharacterType.AnyLetter)]
-    public string TermsOfParticipation { get; set; }
+    public string CompetitiveSelectionDescription { get; set; }
 
     [MinLength(3)]
     [MaxLength(Constants.MaxVenueNameLength)]

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
@@ -67,7 +67,7 @@ public static class CompetitiveEventV2DtoExtensions
         OrganizerOfTheEventId = model.OrganizerOfTheEventId,
         PlannedFormatOfClasses = model.PlannedFormatOfClasses,
         VenueName = model.VenueName,
-        TermsOfParticipation = model.TermsOfParticipation,
+        CompetitiveSelectionDescription = model.CompetitiveSelectionDescription,
         AreThereBenefits = model.AreThereBenefits,
         Benefits = model.Benefits,
         MinimumAge = model.MinimumAge,
@@ -123,7 +123,7 @@ public static class CompetitiveEventV2DtoExtensions
             OrganizerOfTheEventId = draft.CompetitiveEventDraftContent.OrganizerOfTheEventId,
             PlannedFormatOfClasses = draft.CompetitiveEventDraftContent?.PlannedFormatOfClasses,
             VenueName = draft.CompetitiveEventDraftContent?.VenueName,
-            TermsOfParticipation = draft.CompetitiveEventDraftContent?.TermsOfParticipation,
+            CompetitiveSelectionDescription = draft.CompetitiveEventDraftContent?.CompetitiveSelectionDescription,
             AreThereBenefits = draft.CompetitiveEventDraftContent?.AreThereBenefits,
             Benefits = draft.CompetitiveEventDraftContent?.Benefits,
             MinimumAge = draft.CompetitiveEventDraftContent?.MinimumAge ?? 0,
@@ -171,7 +171,7 @@ public static class CompetitiveEventV2DtoExtensions
     /// </summary>
     /// <param name="competitiveEventV2Dto">Source DTO to convert; its nullable fields are mapped with sensible defaults.</param>
     /// <returns>
-    /// A new CompetitiveEventDraftContent populated from the DTO. Nullable booleans and numeric fields are replaced with their default values when null;
+    /// A new CompetitiveEventDraftContent populated from the DTO. Nullable boolean and numeric fields are replaced with their default values when null;
     /// <see cref="Contacts"/> is an empty list if DTO contacts are null; <see cref="SubDirectionIds"/> is an empty list if null; 
     /// <see cref="CompetitiveEventDescriptionItems"/> is mapped using the DTO's ToModel() when present.
     /// </returns>
@@ -196,7 +196,7 @@ public static class CompetitiveEventV2DtoExtensions
         ScheduledStartTime = competitiveEventV2Dto.ScheduledStartTime,
         ShortTitle = competitiveEventV2Dto.ShortTitle,
         Title = competitiveEventV2Dto.Title,
-        TermsOfParticipation = competitiveEventV2Dto.TermsOfParticipation,
+        CompetitiveSelectionDescription = competitiveEventV2Dto.CompetitiveSelectionDescription,
         VenueName = competitiveEventV2Dto.VenueName,
         SubDirectionIds = competitiveEventV2Dto.SubDirectionIds ?? [],
         CompetitiveEventDescriptionItems = competitiveEventV2Dto.CompetitiveEventDescriptionItems?.ToModel(),
@@ -225,7 +225,7 @@ public static class CompetitiveEventV2DtoExtensions
         model.OrganizerOfTheEventId = dto.OrganizerOfTheEventId;
         model.PlannedFormatOfClasses = dto.PlannedFormatOfClasses ?? model.PlannedFormatOfClasses;
         model.VenueName = dto.VenueName;
-        model.TermsOfParticipation = dto.TermsOfParticipation;
+        model.CompetitiveSelectionDescription = dto.CompetitiveSelectionDescription;
         model.AreThereBenefits = dto.AreThereBenefits ?? model.AreThereBenefits;
         model.Benefits = dto.Benefits;
         model.MinimumAge = dto.MinimumAge;
@@ -262,7 +262,7 @@ public static class CompetitiveEventV2DtoExtensions
         OrganizerOfTheEventId = dto.OrganizerOfTheEventId,
         PlannedFormatOfClasses = dto.PlannedFormatOfClasses ?? default,
         VenueName = dto.VenueName,
-        TermsOfParticipation = dto.TermsOfParticipation,
+        CompetitiveSelectionDescription = dto.CompetitiveSelectionDescription,
         AreThereBenefits = dto.AreThereBenefits ?? false,
         Benefits = dto.Benefits,
         MinimumAge = dto.MinimumAge,

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/ModeratorCompetitiveEventDraftEditDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/ModeratorCompetitiveEventDraftEditDto.cs
@@ -22,7 +22,7 @@ public class ModeratorCompetitiveEventDraftEditDto
 
     public string VenueName { get; set; }
 
-    public string TermsOfParticipation { get; set; }
+    public string CompetitiveSelectionDescription { get; set; }
 
     public string PreferentialTermsOfParticipation { get; set; }
 
@@ -53,7 +53,7 @@ public static class ModeratorCompetitiveEventDraftEditDtoExtensions
         model.CompetitiveEventDraftContent.ShortTitle = dto.ShortTitle;
         model.CompetitiveEventDraftContent.DescriptionOfTheEnrollmentProcedure = dto.DescriptionOfTheEnrollmentProcedure;
         model.CompetitiveEventDraftContent.VenueName = dto.VenueName;
-        model.CompetitiveEventDraftContent.TermsOfParticipation = dto.TermsOfParticipation;
+        model.CompetitiveEventDraftContent.CompetitiveSelectionDescription = dto.CompetitiveSelectionDescription;
         model.CompetitiveEventDraftContent.Benefits = dto.Benefits;       
         model.CompetitiveEventDraftContent.CompetitiveEventDescriptionItems = dto.CompetitiveEventDescriptionItems.ToDraft();
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/ModeratorCompetitiveEventDraftEditDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEventDraft/ModeratorCompetitiveEventDraftEditDto.cs
@@ -22,6 +22,7 @@ public class ModeratorCompetitiveEventDraftEditDto
 
     public string VenueName { get; set; }
 
+    [MaxLength(Constants.MaxCompetitiveSelectionDescriptionLength)]
     public string CompetitiveSelectionDescription { get; set; }
 
     public string PreferentialTermsOfParticipation { get; set; }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Exported/CompetitiveEvents/CompetitiveEventInfoDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Exported/CompetitiveEvents/CompetitiveEventInfoDto.cs
@@ -58,8 +58,8 @@ public class CompetitiveEventInfoDto : CompetitiveEventInfoBaseDto, IExternalRat
     [MaxLength(Constants.MaxVenueNameLength)]
     public string VenueName { get; set; } = string.Empty;
 
-    [MaxLength(Constants.MaxTermsOfParticipationLength)]
-    public string TermsOfParticipation { get; set; } = string.Empty;
+    [MaxLength(Constants.MaxCompetitiveSelectionDescriptionLength)]
+    public string CompetitiveSelectionDescription { get; set; } = string.Empty;
 
     public bool AreThereBenefits { get; set; }
 
@@ -76,9 +76,6 @@ public class CompetitiveEventInfoDto : CompetitiveEventInfoBaseDto, IExternalRat
     public int Price { get; set; } = 0;
 
     public bool CompetitiveSelection { get; set; }
-
-    [MaxLength(2000)]
-    public string CompetitiveSelectionDescription { get; set; }
 
     public string CoverImageId { get; set; } = string.Empty;
 
@@ -130,7 +127,7 @@ public static class CompetitiveEventInfoDtoExtensions
             DescriptionOfTheEnrollmentProcedure = model.DescriptionOfTheEnrollmentProcedure,
             PlannedFormatOfClasses = model.PlannedFormatOfClasses,
             VenueName = model.VenueName,
-            TermsOfParticipation = model.TermsOfParticipation,
+            CompetitiveSelectionDescription = model.CompetitiveSelectionDescription,
             AreThereBenefits = model.AreThereBenefits,
             Benefits = model.Benefits,
             MinimumAge = model.MinimumAge,

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -419,7 +419,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
 
     /// <summary>
     /// Determines whether any moderated fields differ between an incoming V2 DTO and an existing competitive event.
-    /// Except case when a new value equals null or an empty string.
+    /// Returns false when the new value is null or an empty string.
     /// </summary>
     /// <param name="competitiveEventV2Dto">The incoming competitive event data to compare.</param>
     /// <param name="existingCompetitiveEvent">The existing competitive event to compare against.</param>
@@ -430,9 +430,8 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
     /// The comparison considers:
     /// - Presence of new images (CoverImage or ImageFiles) on the V2 DTO.
     /// - Competitive event description items compared by concatenating SectionName and Description in sequence (order-sensitive).
-    /// - The following string fields: ShortTitle, Title, DescriptionOfTheEnrollmentProcedure, and Contacts (contacts are compared by joining each contact's ToString() with " | ").
-    /// If any of the above parameters are different and the new values are not null or an empty string, the method returns true; otherwise false.
-    /// </remarks>
+    /// - The following string fields: ShortTitle, Title, DescriptionOfTheEnrollmentProcedure, CompetitiveSelectionDescription, Benefits, VenueName, and Contacts (contacts are compared by joining each contact's ToString() with " | ").
+    /// If any of the above fields are different and the new value is not null or an empty string, the method returns true; otherwise false.    /// </remarks>
     private static bool ShouldBeModerate(CompetitiveEventV2Dto competitiveEventV2Dto, CompetitiveEventDto existingCompetitiveEvent)
     {
         if (competitiveEventV2Dto.CoverImage != null || competitiveEventV2Dto.ImageFiles != null)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -404,7 +404,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             throw new InvalidOperationException("CompetitiveEvent draft for this CompetitiveEvent exists. CompetitiveEvent can`t be updated.");
         }
 
-        if (AreModeratedFieldsChanged(competitiveEventV2Dto, existingCompetitiveEvent))
+        if (ShouldBeModerate(competitiveEventV2Dto, existingCompetitiveEvent))
         {
             logger.LogDebug("Moderated fields was changed. CompetitiveEvent draft creation initiated. CompetitiveEvent Id = {Id}.", competitiveEventV2Dto.Id);
             return (await Create(competitiveEventV2Dto, true)).CompetitiveEventDraft.CompetitiveEventDetails;
@@ -419,7 +419,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
 
     /// <summary>
     /// Determines whether any moderated fields differ between an incoming V2 DTO and an existing competitive event.
-    /// Except case when a new value equals null or an empty string..
+    /// Except case when a new value equals null or an empty string.
     /// </summary>
     /// <param name="competitiveEventV2Dto">The incoming competitive event data to compare.</param>
     /// <param name="existingCompetitiveEvent">The existing competitive event to compare against.</param>
@@ -433,7 +433,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
     /// - The following string fields: ShortTitle, Title, DescriptionOfTheEnrollmentProcedure, and Contacts (contacts are compared by joining each contact's ToString() with " | ").
     /// If any of the above parameters are different and the new values are not null or an empty string, the method returns true; otherwise false.
     /// </remarks>
-    private static bool AreModeratedFieldsChanged(CompetitiveEventV2Dto competitiveEventV2Dto, CompetitiveEventDto existingCompetitiveEvent)
+    private static bool ShouldBeModerate(CompetitiveEventV2Dto competitiveEventV2Dto, CompetitiveEventDto existingCompetitiveEvent)
     {
         if (competitiveEventV2Dto.CoverImage != null || competitiveEventV2Dto.ImageFiles != null)
         {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -419,18 +419,19 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
 
     /// <summary>
     /// Determines whether any moderated fields differ between an incoming V2 DTO and an existing competitive event.
+    /// Except case when a new value equals null or an empty string..
     /// </summary>
     /// <param name="competitiveEventV2Dto">The incoming competitive event data to compare.</param>
     /// <param name="existingCompetitiveEvent">The existing competitive event to compare against.</param>
     /// <returns>
-    /// True if any moderated field has changed and therefore requires moderation; otherwise false.
+    /// True if any moderated field has changed and the new value is not null or an empty string and therefore requires moderation; false otherwise.
     /// </returns>
     /// <remarks>
     /// The comparison considers:
     /// - Presence of new images (CoverImage or ImageFiles) on the V2 DTO.
     /// - Competitive event description items compared by concatenating SectionName and Description in sequence (order-sensitive).
     /// - The following string fields: ShortTitle, Title, DescriptionOfTheEnrollmentProcedure, and Contacts (contacts are compared by joining each contact's ToString() with " | ").
-    /// If any of the above differ, the method returns true.
+    /// If any of the above parameters are different and the new values are not null or an empty string, the method returns true; otherwise false.
     /// </remarks>
     private static bool AreModeratedFieldsChanged(CompetitiveEventV2Dto competitiveEventV2Dto, CompetitiveEventDto existingCompetitiveEvent)
     {
@@ -450,7 +451,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             ce => ce.ShortTitle,
             ce => ce.Title,
             ce => ce.DescriptionOfTheEnrollmentProcedure,
-            ce => ce.TermsOfParticipation,
+            ce => ce.CompetitiveSelectionDescription,
             ce => ce.Benefits,
             ce => ce.VenueName,
             ce => string.Join(" | ", (ce.Contacts ?? []).Select(c => c?.ToString()))
@@ -461,7 +462,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             var newValue = field(competitiveEventV2Dto);
             var oldValue = field(existingCompetitiveEvent);
 
-            return !string.Equals(newValue, oldValue, StringComparison.Ordinal);
+            return !string.Equals(newValue, oldValue, StringComparison.Ordinal) && !string.IsNullOrEmpty(newValue);
         });
     }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Elasticsearch/CompetitiveEventSynchronizationService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Elasticsearch/CompetitiveEventSynchronizationService.cs
@@ -55,7 +55,7 @@ public static class CompetitiveEventESExtensions
             OrganizerOfTheEventId = dto.OrganizerOfTheEventId,
             PlannedFormatOfClasses = dto.PlannedFormatOfClasses,
             VenueName = dto.VenueName,
-            TermsOfParticipation = dto.TermsOfParticipation,
+            CompetitiveSelectionDescription = dto.CompetitiveSelectionDescription,
             AreThereBenefits = dto.AreThereBenefits,
             Benefits = dto.Benefits,
             MinimumAge = dto.MinimumAge,

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -549,7 +549,7 @@ public class WorkshopDraftService(
             throw new InvalidOperationException("WorkshopDraft for this Workshop exists. Workshop can`t be updated.");
         }
 
-        if (AreModeratedFieldsChanged(workshopV2Dto, existingWorkshop))
+        if (ShouldBeModerate(workshopV2Dto, existingWorkshop))
         {
             logger.LogDebug("Moderated fields was changed. WorkshopDraft creation initiated. Workshop Id = {Id}.", workshopV2Dto.Id);
 
@@ -1271,7 +1271,7 @@ public class WorkshopDraftService(
         }).ToList();
     }
 
-    private static bool AreModeratedFieldsChanged(WorkshopV2Dto workshopV2Dto, WorkshopDto existingWorkshop)
+    private static bool ShouldBeModerate(WorkshopV2Dto workshopV2Dto, WorkshopDto existingWorkshop)
     {
         if (workshopV2Dto.CoverImage != null ||
             workshopV2Dto.ImageFiles != null)
@@ -1306,7 +1306,7 @@ public class WorkshopDraftService(
             var newValue = field(workshopV2Dto);
             var oldValue = field(existingWorkshop);
 
-            return !string.Equals(newValue, oldValue, StringComparison.Ordinal);
+            return !string.Equals(newValue, oldValue, StringComparison.Ordinal) && !string.IsNullOrEmpty(newValue);
         });
     }
     private async Task SetLanguageNameOrThrow(WorkshopV2Dto dto)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/JsonTools/JsonModelBinder.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/JsonTools/JsonModelBinder.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
-using OutOfSchool.BusinessLogic.Models.Workshops;
-using System.Text.Json;
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace OutOfSchool.BusinessLogic.Util.JsonTools;
 

--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -174,7 +174,7 @@ public static class Constants
     public const int MaxProviderShortTitleLength = 60;
 
     /// <summary>
-    /// Maximum length of position desctiption.
+    /// Maximum length of position description.
     /// </summary>
     public const int MaxPositionDescriptionLength = 500;
 
@@ -184,9 +184,9 @@ public static class Constants
     public const int EnrollmentProcedureDescription = 500;
 
     /// <summary>
-    /// Maximum length of terms of participation.
+    /// Maximum length of competitive selection description.
     /// </summary>
-    public const int MaxTermsOfParticipationLength = 2000;
+    public const int MaxCompetitiveSelectionDescriptionLength = 500;
 
     /// <summary>
     /// Maximum length of preferential terms of participation.

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEventDrafts/CompetitiveEventDraftContent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEventDrafts/CompetitiveEventDraftContent.cs
@@ -36,7 +36,7 @@ public class CompetitiveEventDraftContent : IHasContacts
 
     public string VenueName { get; set; }
 
-    public string TermsOfParticipation { get; set; }
+    public string CompetitiveSelectionDescription { get; set; }
 
     public bool AreThereBenefits { get; set; }
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEvents/CompetitiveEvent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEvents/CompetitiveEvent.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using OutOfSchool.Common;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Enums.CompetitiveEvent;
 using OutOfSchool.Services.Models.ContactInfo;
@@ -64,8 +65,8 @@ public class CompetitiveEvent : BusinessEntity, IHasContacts, IImageDependentEnt
     [MaxLength(200)]
     public string VenueName { get; set; }
 
-    [MaxLength(2000)]
-    public string TermsOfParticipation { get; set; }
+    [MaxLength(Constants.MaxCompetitiveSelectionDescriptionLength)]
+    public string CompetitiveSelectionDescription { get; set; }
   
     public bool AreThereBenefits { get; set; }
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Workshop.cs
@@ -72,7 +72,7 @@ public class Workshop : BusinessEntity, IImageDependentEntity<Workshop>, IHasEnt
 
     #endregion
 
-    [MaxLength(500)]
+    [MaxLength(Constants.MaxCompetitiveSelectionDescriptionLength)]
     public string CompetitiveSelectionDescription { get; set; }
 
     public OwnershipType ProviderOwnership { get; set; }

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/ESCompetitiveEventProvider.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/ESCompetitiveEventProvider.cs
@@ -118,7 +118,7 @@ public class ESCompetitiveEventProvider(ElasticsearchClient elasticClient) :
                     Infer.Field<CompetitiveEventES>(e => e.CompetitiveEventAccountingType),
                     Infer.Field<CompetitiveEventES>(e => e.DescriptionOfTheEnrollmentProcedure),
                     Infer.Field<CompetitiveEventES>(e => e.VenueName),
-                    Infer.Field<CompetitiveEventES>(e => e.TermsOfParticipation),
+                    Infer.Field<CompetitiveEventES>(e => e.CompetitiveSelectionDescription),
                     Infer.Field<CompetitiveEventES>(e => e.PreferentialTermsOfParticipation),
                     Infer.Field<CompetitiveEventES>(e => e.Benefits),
                     Infer.Field<CompetitiveEventES>(e => e.Coverage),

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/Models/CompetitiveEventES.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/Models/CompetitiveEventES.cs
@@ -43,7 +43,7 @@ public class CompetitiveEventES
 
     public string VenueName { get; set; }
 
-    public string TermsOfParticipation { get; set; }
+    public string CompetitiveSelectionDescription { get; set; }
 
     public string PreferentialTermsOfParticipation { get; set; }
 

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20251020131959_RenameTermsOfParticipationToCompetitiveSelectionDescription.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20251020131959_RenameTermsOfParticipationToCompetitiveSelectionDescription.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OutOfSchool.Services;
 
@@ -11,9 +12,11 @@ using OutOfSchool.Services;
 namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    partial class OutOfSchoolDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251020131959_RenameTermsOfParticipationToCompetitiveSelectionDescription")]
+    partial class RenameTermsOfParticipationToCompetitiveSelectionDescription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20251020131959_RenameTermsOfParticipationToCompetitiveSelectionDescription.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20251020131959_RenameTermsOfParticipationToCompetitiveSelectionDescription.cs
@@ -96,7 +96,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
             // Next, rename the column back to its original name
             migrationBuilder.RenameColumn(
                 name: "CompetitiveSelectionDescription",
-                table: "Customers",
+                table: "CompetitiveEvents",
                 newName: "TermsOfParticipation");
 
             migrationBuilder.AlterColumn<string>(

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20251020131959_RenameTermsOfParticipationToCompetitiveSelectionDescription.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20251020131959_RenameTermsOfParticipationToCompetitiveSelectionDescription.cs
@@ -1,0 +1,142 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+{
+    /// <inheritdoc />
+    public partial class RenameTermsOfParticipationToCompetitiveSelectionDescription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // First, rename the column to avoid data loss
+            migrationBuilder.RenameColumn(
+                name: "TermsOfParticipation",
+                table: "CompetitiveEvents",
+                newName: "CompetitiveSelectionDescription");
+
+            // Next, alter the column to change its max length
+            migrationBuilder.AlterColumn<string>(
+                name: "CompetitiveSelectionDescription",
+                table: "CompetitiveEvents",
+                type: "varchar(500)",
+                maxLength: 500,
+                nullable: true,
+                oldType: "varchar(2000)",
+                oldMaxLength: 2000,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CompetitiveSelectionDescription",
+                table: "CompetitiveEvents",
+                type: "varchar(500)",
+                maxLength: 500,
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "Workshops_Contacts_Emails",
+                type: "varchar(254)",
+                maxLength: 254,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "Providers_Contacts_Emails",
+                type: "varchar(254)",
+                maxLength: 254,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "CompetitiveEvents_Contacts_Emails",
+                type: "varchar(254)",
+                maxLength: 254,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // First, alter the column back to its original length
+            migrationBuilder.AlterColumn<string>(
+                name: "CompetitiveSelectionDescription",
+                table: "CompetitiveEvents",
+                type: "varchar(2000)",
+                maxLength: 2000,
+                nullable: true,
+                oldType: "varchar(500)",
+                oldMaxLength: 500,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            // Next, rename the column back to its original name
+            migrationBuilder.RenameColumn(
+                name: "CompetitiveSelectionDescription",
+                table: "Customers",
+                newName: "TermsOfParticipation");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "Workshops_Contacts_Emails",
+                type: "varchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(254)",
+                oldMaxLength: 254,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "Providers_Contacts_Emails",
+                type: "varchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(254)",
+                oldMaxLength: 254,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "CompetitiveEvents_Contacts_Emails",
+                type: "varchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(254)",
+                oldMaxLength: 254,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -1275,5 +1275,69 @@ public class CompetitiveEventDraftServiceTests
         Mock.VerifyAll();
     }
 
+    [Test]
+    public async Task UpdateCompetitiveEvent_CallUpdateV2_IfModeratedFieldsChangedButNewValueIsNull()
+    {
+        // Arrange
+        CompetitiveEventV2Dto v2dto = CompetitiveEventV2DtoGenerator.Generate();
+        CompetitiveEventDraft draft = v2dto.ToDraft();
+        CompetitiveEventDto dto = draft.ToDto();
+        v2dto.Benefits = null;
+        var drafts = new List<CompetitiveEventDraft>();
+
+        mockCompetitiveEventService.Setup(repo => repo.GetById(v2dto.Id))
+            .ReturnsAsync(dto)
+            .Verifiable(Times.Once);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Get(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
+            It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
+            .Returns(drafts.AsTestAsyncEnumerableQuery)
+            .Verifiable(Times.Once);
+        mockCompetitiveEventService.Setup(s => s.UpdateV2(v2dto, false))
+            .ReturnsAsync(new CompetitiveEventResultDto() { CompetitiveEventV2 = draft.ToDto() })
+            .Verifiable(Times.Once);
+
+        // Act 
+        var result = await competitiveEventDraftService.UpdateCompetitiveEvent(v2dto);
+
+        // Assert
+        mockCompetitiveEventService.Verify(s => s.UpdateV2(It.IsAny<CompetitiveEventV2Dto>(), false), Times.Once);
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOf<CompetitiveEventV2Dto>(result);
+        Assert.AreEqual(result.Title, v2dto.Title);
+        Mock.VerifyAll();
+    }
+
+    [Test]
+    public async Task UpdateCompetitiveEvent_CallUpdateV2_IfModeratedFieldsChangedButNewValueIsEmptyString()
+    {
+        // Arrange
+        CompetitiveEventV2Dto v2dto = CompetitiveEventV2DtoGenerator.Generate();
+        CompetitiveEventDraft draft = v2dto.ToDraft();
+        CompetitiveEventDto dto = draft.ToDto();
+        v2dto.Benefits = string.Empty;
+        var drafts = new List<CompetitiveEventDraft>();
+
+        mockCompetitiveEventService.Setup(repo => repo.GetById(v2dto.Id))
+            .ReturnsAsync(dto)
+            .Verifiable(Times.Once);
+        mockCompetitiveEventDraftRepository.Setup(repo => repo.Get(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Expression<Func<CompetitiveEventDraft, bool>>>(),
+            It.IsAny<Dictionary<Expression<Func<CompetitiveEventDraft, object>>, SortDirection>>()))
+            .Returns(drafts.AsTestAsyncEnumerableQuery)
+            .Verifiable(Times.Once);
+        mockCompetitiveEventService.Setup(s => s.UpdateV2(v2dto, false))
+            .ReturnsAsync(new CompetitiveEventResultDto() { CompetitiveEventV2 = draft.ToDto() })
+            .Verifiable(Times.Once);
+
+        // Act 
+        var result = await competitiveEventDraftService.UpdateCompetitiveEvent(v2dto);
+
+        // Assert
+        mockCompetitiveEventService.Verify(s => s.UpdateV2(It.IsAny<CompetitiveEventV2Dto>(), false), Times.Once);
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOf<CompetitiveEventV2Dto>(result);
+        Assert.AreEqual(result.Title, v2dto.Title);
+        Mock.VerifyAll();
+    }
+
     #endregion
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SensitiveCompetitiveEventDraftServiceTest.cs
@@ -157,7 +157,7 @@ public class SensitiveCompetitiveEventDraftServiceTest
             DescriptionOfTheEnrollmentProcedure = "Updated Procedure",
             AdditionalDescription = "Updated Additional Description",
             VenueName = "Updated Venue",
-            TermsOfParticipation = "Updated Terms",
+            CompetitiveSelectionDescription = "Updated Terms",
             PreferentialTermsOfParticipation = "Updated Preferential Terms",
             Benefits = "Updated Benefits",
             Contacts = new List<ContactsDto>(),
@@ -198,7 +198,7 @@ public class SensitiveCompetitiveEventDraftServiceTest
         Assert.AreEqual("Updated Short Title", competitiveEventDraft.CompetitiveEventDraftContent.ShortTitle);
         Assert.AreEqual("Updated Procedure", competitiveEventDraft.CompetitiveEventDraftContent.DescriptionOfTheEnrollmentProcedure);
         Assert.AreEqual("Updated Venue", competitiveEventDraft.CompetitiveEventDraftContent.VenueName);
-        Assert.AreEqual("Updated Terms", competitiveEventDraft.CompetitiveEventDraftContent.TermsOfParticipation);
+        Assert.AreEqual("Updated Terms", competitiveEventDraft.CompetitiveEventDraftContent.CompetitiveSelectionDescription);
         Assert.AreEqual("Updated Benefits", competitiveEventDraft.CompetitiveEventDraftContent.Benefits);
     }
     

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
@@ -35,11 +35,11 @@ public static class CompetitiveEventContactsDtoGenerator
         .RuleFor(x => x.Contacts, f => new List<ContactsDto> { })
         .RuleFor(x => x.SubDirectionIds, f => new List<long> { f.Random.Long(1, 100) })
         .RuleFor(x => x.AreThereBenefits, true)
-        .RuleFor(x => x.Benefits, f => f.Lorem.Text())
+        .RuleFor(x => x.Benefits, f => f.Lorem.Sentences(3))
         .RuleFor(x => x.CompetitiveSelection, true)
-        .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Text())
+        .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Sentences(3))
         .RuleFor(x => x.VenueName, f => f.Lorem.Text())
-        .RuleFor(x => x.DescriptionOfTheEnrollmentProcedure, f => f.Lorem.Text())
+        .RuleFor(x => x.DescriptionOfTheEnrollmentProcedure, f => f.Lorem.Sentences(3))
         .RuleFor(x => x.Price, f => f.Random.Int(1, 100))
         .RuleFor(x => x.PlannedFormatOfClasses, f => f.PickRandom<FormOfLearning>());
 

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
@@ -38,7 +38,7 @@ public static class CompetitiveEventContactsDtoGenerator
         .RuleFor(x => x.Benefits, f => f.Lorem.Sentences(3))
         .RuleFor(x => x.CompetitiveSelection, true)
         .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Sentences(3))
-        .RuleFor(x => x.VenueName, f => f.Lorem.Text())
+        .RuleFor(x => x.VenueName, f => f.Lorem.Sentences(3))
         .RuleFor(x => x.DescriptionOfTheEnrollmentProcedure, f => f.Lorem.Sentences(3))
         .RuleFor(x => x.Price, f => f.Random.Int(1, 100))
         .RuleFor(x => x.PlannedFormatOfClasses, f => f.PickRandom<FormOfLearning>());

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
@@ -37,7 +37,7 @@ public static class CompetitiveEventContactsDtoGenerator
         .RuleFor(x => x.AreThereBenefits, true)
         .RuleFor(x => x.Benefits, f => f.Lorem.Text())
         .RuleFor(x => x.CompetitiveSelection, true)
-        .RuleFor(x => x.TermsOfParticipation, f => f.Lorem.Text())
+        .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Text())
         .RuleFor(x => x.VenueName, f => f.Lorem.Text())
         .RuleFor(x => x.DescriptionOfTheEnrollmentProcedure, f => f.Lorem.Text())
         .RuleFor(x => x.Price, f => f.Random.Int(1, 100))

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventV2DtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventV2DtoGenerator.cs
@@ -33,9 +33,13 @@ public static class CompetitiveEventV2DtoGenerator
         .RuleFor(x => x.OrganizerOfTheEventId, f => f.Random.Guid())
         .RuleFor(x => x.MinimumAge, f => f.Random.Int(5, 18))
         .RuleFor(x => x.CoverImageId, f => f.Image.LoremFlickrUrl())
-        .RuleFor(x => x.ImageIds, f => new List<string>() { f.Image.LoremFlickrUrl()})
+        .RuleFor(x => x.ImageIds, f => new List<string>() { f.Image.LoremFlickrUrl() })
         .RuleFor(x => x.Contacts, f => new List<ContactsDto> { })
-        .RuleFor(x => x.SubDirectionIds, f => new List<long> { f.Random.Long(1, 100) });
+        .RuleFor(x => x.SubDirectionIds, f => new List<long> { f.Random.Long(1, 100) })
+        .RuleFor(x => x.AreThereBenefits, true)
+        .RuleFor(x => x.Benefits, f => f.Lorem.Sentence(10))
+        .RuleFor(x => x.CompetitiveSelection, true)
+        .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Sentence(10));
 
     public static CompetitiveEventV2Dto Generate() => Faker.Generate();
 


### PR DESCRIPTION
Change the CompetitiveEvent and Workshops moderation conditions - 
if the new value of the changed field is Null or an empty string, the entity does not require moderation. 

1) renamed the AreModeratedFieldsChanged method to ShouldBeModerated in classes - WorkshopDraftService and CompetitiveEventDraftService, changed the moderation condition in it, corrected the docstrings; 
2) added tests to the CompetitiveEventDraftServiceTests class, changed the CompetitiveEventV2DtoGenerator and CompetitiveEventContactsDtoGenerator classes;
3) removed redundant using-directive from the JsonModelBinder;
4) renamed the TermsOfParticipation property to CompetitiveSelectionDescription in classes - CompetitiveEvent, CompetitiveEventBaseDto, CompetitiveEventDraftContent, CompetitiveEventInfoDto, CompetitiveEventDescriptionDto, ModeratorCompetitiveEventDraftEditDto, CompetitiveEventES, ESCompetitiveEventProvider, ElasticsearchCompetitiveEventConfiguration, CompetitiveEventDto and CompetitiveEventV2Dto;
5) renamed the MaxTermsOfParticipationLength constant to MaxCompetitiveSelectionDescriptionLength and changed from 2000 to 500;
6) fixed tests in class - SensitiveCompetitiveEventDraftServiceTest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tests covering draft updates when moderated fields are cleared.

* **Bug Fixes**
  * Moderation now only triggers when a changed field is non-empty.

* **Refactor**
  * Renamed "Terms of participation" to "Competitive selection description" across models, DTOs and APIs.
  * Reduced max length for the field (2000 → 500) and updated search/indexing and validation to use the new field name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->