### PR TITLE
Fix removing images from drafts

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -876,9 +876,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
 
         await currentUserService.UserHasRights(
             new ProviderRights(competitiveEventDraft.ProviderId),
-            new EmployeeRights(competitiveEventDraft.ProviderId))
-            .ConfigureAwait(false);
-        await currentUserService.UserHasRights(
+            new EmployeeRights(competitiveEventDraft.ProviderId),
             new ProviderRights(competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.OrganizerOfTheEventId),
             new EmployeeRights(competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.OrganizerOfTheEventId))
             .ConfigureAwait(false);
@@ -914,13 +912,15 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         var coverImageResult = await competitiveEventDraftImagesService
             .ChangeCoverImageAsync(competitiveEventDraft,
             competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.CoverImageId,
-            competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.CoverImage)
+            competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.CoverImage,
+            true)
             .ConfigureAwait(false);
 
         var imagesResult = await competitiveEventDraftImagesService
             .ChangeImagesAsync(competitiveEventDraft,
             competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.ImageIds,
-            competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.ImageFiles)
+            competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.ImageFiles,
+            true)
             .ConfigureAwait(false);
 
         await competitiveEventDraftRepository.Update(competitiveEventDraft);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Images/IEntityCoverImageInteractionService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Images/IEntityCoverImageInteractionService.cs
@@ -27,6 +27,7 @@ public interface IEntityCoverImageInteractionService<in TEntity>
     /// <param name="entity">Entity.</param>
     /// <param name="dtoImageId">Image id to change.</param>
     /// <param name="newImage">Image we should add to the entity.</param>
+    /// <param name="isFromDraft">Flag to signal if the updated value is taken from draft.</param>
     /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="ImageChangingResult"/> of the operation.</returns>
-    public Task<ImageChangingResult> ChangeCoverImageAsync(TEntity entity, string dtoImageId, IFormFile newImage);
+    public Task<ImageChangingResult> ChangeCoverImageAsync(TEntity entity, string dtoImageId, IFormFile newImage, bool isFromDraft = false);
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Images/IEntitySetOfImagesInteractionService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Images/IEntitySetOfImagesInteractionService.cs
@@ -53,6 +53,7 @@ public interface IEntitySetOfImagesInteractionService<in TEntity>
     /// <param name="entity">Entity.</param>
     /// <param name="oldImageIds">Image ids we shouldn't remove from entities.</param>
     /// <param name="newImages">Images we should add to the entity.</param>
+    /// <param name="isFromDraft">Flag to signal if the updated value is taken from draft.</param>
     /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="MultipleImageChangingResult"/> of the operation.</returns>
-    public Task<MultipleImageChangingResult> ChangeImagesAsync(TEntity entity, IList<string> oldImageIds, IList<IFormFile> newImages);
+    public Task<MultipleImageChangingResult> ChangeImagesAsync(TEntity entity, IList<string> oldImageIds, IList<IFormFile> newImages, bool isFromDraft = false);
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/Images/ImageDependentEntityImagesInteractionService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/Images/ImageDependentEntityImagesInteractionService.cs
@@ -95,7 +95,7 @@ public class ImageDependentEntityImagesInteractionService<TEntity> : IImageDepen
         => await RemoveManyImagesProcessAsync(entity, imageIds).ConfigureAwait(false);
 
     /// <inheritdoc/>
-    public async Task<MultipleImageChangingResult> ChangeImagesAsync(TEntity entity, IList<string> oldImageIds, IList<IFormFile> newImages)
+    public async Task<MultipleImageChangingResult> ChangeImagesAsync(TEntity entity, IList<string> oldImageIds, IList<IFormFile> newImages, bool isFromDraft = false)
     {
         _ = entity ?? throw new ArgumentNullException(nameof(entity));
         _ = entity.Images ?? throw new NullReferenceException($"Entity {nameof(entity.Images)} cannot be null collection");
@@ -170,7 +170,7 @@ public class ImageDependentEntityImagesInteractionService<TEntity> : IImageDepen
     }
 
     /// <inheritdoc/>
-    public async Task<ImageChangingResult> ChangeCoverImageAsync(TEntity entity, string dtoImageId, IFormFile newImage)
+    public async Task<ImageChangingResult> ChangeCoverImageAsync(TEntity entity, string dtoImageId, IFormFile newImage, bool isFromDraft = false)
     {
         _ = entity ?? throw new ArgumentNullException(nameof(entity));
 


### PR DESCRIPTION
1) Fixed the private UpdateDraftWithImagesAsync() method - improved user rights checking.
2) Changed the signatures of the methods (ChangeImagesAsync() and ChangeCoverImageAsync()) in the interfaces (IEntityCoverImageInteractionService and IEntitySetOfImagesInteractionService) as well as in the ImageDependentEntityImagesInteractionService class.
