### PR TITLE
feat(validation): changed validation rules of building numbers 

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/ContactsAddressDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/ContactsAddressDto.cs
@@ -21,7 +21,8 @@ public sealed class ContactsAddressDto : IContentComparable<ContactsAddress>, IE
     [MinLength(1)]
     [MaxLength(15)]
     [MustContain(RequiredCharacterType.Digit, ErrorMessage = "Building number must contain at least one number.")]
-    [RegularExpression(@"^[\p{IsCyrillic}0-9\s\-\/]+$", ErrorMessage = "Only Cyrillic letters, numbers, spaces, '-', and '/' are allowed.")]
+    [RegularExpression(@"^[0-9А-Яа-яЇїІіЄєҐґA-Za-z\-\/]+$", 
+        ErrorMessage = "Only Cyrillic or Latin letters, digits, '-' and '/' are allowed, without spaces.")]
     public string BuildingNumber { get; set; } = string.Empty;
 
     public double Latitude { get; set; }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/ContactsAddressDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/ContactsAddressDto.cs
@@ -21,7 +21,7 @@ public sealed class ContactsAddressDto : IContentComparable<ContactsAddress>, IE
     [MinLength(1)]
     [MaxLength(15)]
     [MustContain(RequiredCharacterType.Digit, ErrorMessage = "Building number must contain at least one number.")]
-    [RegularExpression(@"^[0-9А-Яа-яЇїІіЄєҐґA-Za-z\-\/]+$", ErrorMessage = "Only Cyrillic or Latin letters, digits, '-' and '/' are allowed, without spaces.")]
+    [RegularExpression(@"^[0-9]+[0-9А-Яа-яЇїІіЄєҐґA-Za-z\-\/]*$", ErrorMessage = "Building number must start with a digit and may only contain Cyrillic or Latin letters, digits, '-' and '/', without spaces.")]
     public string BuildingNumber { get; set; } = string.Empty;
 
     public double Latitude { get; set; }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/ContactsAddressDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/ContactsAddressDto.cs
@@ -21,8 +21,7 @@ public sealed class ContactsAddressDto : IContentComparable<ContactsAddress>, IE
     [MinLength(1)]
     [MaxLength(15)]
     [MustContain(RequiredCharacterType.Digit, ErrorMessage = "Building number must contain at least one number.")]
-    [RegularExpression(@"^[0-9А-Яа-яЇїІіЄєҐґA-Za-z\-\/]+$", 
-        ErrorMessage = "Only Cyrillic or Latin letters, digits, '-' and '/' are allowed, without spaces.")]
+    [RegularExpression(@"^[0-9А-Яа-яЇїІіЄєҐґA-Za-z\-\/]+$", ErrorMessage = "Only Cyrillic or Latin letters, digits, '-' and '/' are allowed, without spaces.")]
     public string BuildingNumber { get; set; } = string.Empty;
 
     public double Latitude { get; set; }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -24,8 +24,8 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
     public string Title { get; set; } = string.Empty;
 
     [Required(ErrorMessage = "Workshop short title is required")]
-    [MinLength(Constants.MinWorkshopTitleLength,ErrorMessage = "This field must contain from 3 to 120 characters.")]
-    [MaxLength(Constants.MaxWorkshopTitleLength,ErrorMessage = "This field must contain from 3 to 120 characters.")]
+    [MinLength(Constants.MinWorkshopShortTitleLength,ErrorMessage = "This field must contain from 1 to 60 characters.")]
+    [MaxLength(Constants.MaxWorkshopShortTitleLength,ErrorMessage = "This field must contain from 1 to 60 characters.")]
     [MustContain(RequiredCharacterType.AnyLetter, ErrorMessage = "This field must contain at least one letter.")]
     [RegularExpression(@"^[\p{IsCyrillic}\p{IsBasicLatin}0-9\s\p{P}\p{S}]+$", ErrorMessage = "Only Cyrillic, Latin, numbers and symbols are allowed.")]
     public string ShortTitle { get; set; } = string.Empty;


### PR DESCRIPTION
Додано валідацію для поля BuildingNumber, що відповідає вимогам Порядку присвоєння адрес об’єктам будівництва та об’єктам нерухомого майна, затвердженого постановою КМУ № 690 від 07.07.2021 р.
Валідація забезпечує правильність структури номера будинку/будівлі згідно з українською системою адресації.

## Нормативна основа:

Постанова Кабінету Міністрів України № 690 від 07.07.2021 р. «Про затвердження Порядку присвоєння адрес об’єктам будівництва, об’єктам нерухомого майна»
Закон України “Про регулювання містобудівної діяльності” № 3038-VI від 17.02.2011 р.

Відповідно до зазначених документів, адреса об’єкта містить реквізит «номер об’єкта (будинку/будівлі/споруди)», який має бути унікальним у межах вулиці та містити принаймні одну цифру.
У практиці державних реєстрів і муніципальних систем допускаються такі складові номера будівлі:

числова частина (обов’язкова);

літерний суфікс (кириличний або латинський);

дефіс або коса риска як роздільник;

додаткові позначення корпусів / секцій у форматі 12А/1, 12-Б.

Closes #1998 
---
### Test Cases for `BuildingNumber`

| № | Введене значення | Очікуваний результат | Пояснення |
|:-:|------------------|----------------------|------------|
| 1 | `12` | ✅ Валідно | Простий числовий номер |
| 2 | `12А` | ✅ Валідно | Цифра + літера (кирилиця) |
| 3 | `12A` | ✅ Валідно | Цифра + літера (латиниця) |
| 4 | `12-Б` | ✅ Валідно | Цифра + дефіс + літера |
| 5 | `12/1` | ✅ Валідно | Допустимий формат з косою рискою |
| 6 | `12А/2` | ✅ Валідно | Комбінація цифр, літери і дробу |
| 7 | `12-1А` | ✅ Валідно | Дефіс між частинами номера |
| 8 | `12А-Б` | ✅ Валідно | Подвійний суфікс, часто використовується для секцій |
| 9 | `12А/Б` | ✅ Валідно | Змішаний формат (дріб + літера) |
| 10 | `12а` | ✅ Валідно | Малі літери також дозволені |
| 11 | `12-А/1` | ✅ Валідно | Комбінація цифр, літери, дефісу і дробу |
| 12 | `12АБ` | ✅ Валідно | Подвійна літера (наприклад, секція «АБ») |
| 13 | `А` | ❌ Невалідно | Відсутня цифра |
| 14 | `12 А` | ❌ Невалідно | Пробіл між цифрою і літерою |
| 15 | `12_А` | ❌ Невалідно | Символ `_` недозволений |
| 16 | `12#1` | ❌ Невалідно | Символ `#` недозволений |
| 17 | `12 А/1` | ❌ Невалідно | Пробіл у середині рядка |
| 18 | ` 12А` | ❌ Невалідно | Пробіл на початку |
| 19 | `12А ` | ❌ Невалідно | Пробіл у кінці |
| 20 | `12@1` | ❌ Невалідно | Символ `@` недозволений |
| 21 | `А12` | ❌ Невалідно | Немає цифри на початку |
| 22 | `12ААААААААААААААА` | ❌ Невалідно | Перевищено максимальну довжину (15 символів) |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Building number validation tightened: must start with a digit, no spaces, and may include Cyrillic or Latin letters, digits, hyphens, and slashes; error message updated to reflect the rule.
  * Workshop short title validation adjusted to allow 1–60 characters (previously 3–120); validation messages updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->