### PR TITLE
Fixed problen when ministry admin couldnt get a workshop draft

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -520,13 +520,16 @@ public class WorkshopDraftService(
     {
         var draft = await GetByIdWithProviderDetails(id);
 
-        await currentUserService.UserHasRights(
-            new ProviderRights(draft.ProviderId),
-            new EmployeeRights(draft.ProviderId),
-            new ModeratorRights(),
-            new TechAdminRights()
-        ).ConfigureAwait(false);
+        var isAdmin = currentUserService.IsAdmin();
 
+        if (!isAdmin)
+        {
+                await currentUserService.UserHasRights(
+                new ProviderRights(draft.ProviderId),
+                new EmployeeRights(draft.ProviderId),
+                new ModeratorRights()
+            ).ConfigureAwait(false);
+        }
 
         return await MapWorkshopDraftWithDetails(draft);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access permissions for administrators managing workshop drafts. Admin users now experience streamlined access without redundant permission verification, while other user roles maintain existing security protocols. This change optimizes the permission check process while preserving security controls for non-admin users during workshop draft operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->