### PR TITLE
Changed maximum length validation for workshop's title

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopBaseDto.cs
@@ -17,8 +17,8 @@ public class WorkshopBaseDto : IValidatableObject, IHasContactsDto<Workshop>
     public Guid Id { get; set; }
 
     [Required(ErrorMessage = "Workshop title is required")]
-    [MinLength(Constants.MinWorkshopTitleLength,ErrorMessage = "Title field must contain from 3 to 120 characters.")]
-    [MaxLength(Constants.MaxWorkshopTitleLength,ErrorMessage = "Title field must contain from 3 to 120 characters.")]
+    [MinLength(Constants.MinWorkshopTitleLength,ErrorMessage = "Title field must contain from 3 to 250 characters.")]
+    [MaxLength(Constants.MaxWorkshopTitleLength,ErrorMessage = "Title field must contain from 3 to 250 characters.")]
     [MustContain(RequiredCharacterType.AnyLetter, ErrorMessage = "Title field must contain at least one letter.")]
     [RegularExpression(@"^[\p{IsCyrillic}\p{IsBasicLatin}0-9\s\p{P}\p{S}]+$", ErrorMessage = "Only Cyrillic, Latin, numbers and symbols are allowed.")]
     public string Title { get; set; } = string.Empty;

--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -140,7 +140,7 @@ public static class Constants
     /// <summary>
     /// Maximum length of workshop title.
     /// </summary>
-    public const int MaxWorkshopTitleLength = 120;
+    public const int MaxWorkshopTitleLength = 250;
 
     /// <summary>
     /// Minimum length of workshop short title.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum allowed length for workshop titles from 120 to 250 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->