### PR TITLE
Hotfix - Updating CompetitiveEventDraft after moderation

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -908,6 +908,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         }
 
         competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.SetToDraft(competitiveEventDraft);
+        competitiveEventDraft.DraftStatus = CompetitiveEventDraftStatus.Draft;
 
         var coverImageResult = await competitiveEventDraftImagesService
             .ChangeCoverImageAsync(competitiveEventDraft,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -503,6 +503,7 @@ public class CompetitiveEventDraftServiceTests
         Assert.That(result.Succeeded, Is.True);
         Assert.That(result.Value, Is.Not.Null);
         Assert.That(result.Value.CompetitiveEventDraft.CompetitiveEventDraftId, Is.EqualTo(draft.ToResponseDto().CompetitiveEventDraftId));
+        Assert.That(result.Value.CompetitiveEventDraft.DraftStatus, Is.EqualTo(CompetitiveEventDraftStatus.Draft));
         Mock.VerifyAll();
     }
 
@@ -575,6 +576,7 @@ public class CompetitiveEventDraftServiceTests
         Assert.That(result.Succeeded, Is.True);
         Assert.That(result.Value, Is.Not.Null);
         Assert.That(result.Value.CompetitiveEventDraft.CompetitiveEventDraftId, Is.EqualTo(draft.ToResponseDto().CompetitiveEventDraftId));
+        Assert.That(result.Value.CompetitiveEventDraft.DraftStatus, Is.EqualTo(CompetitiveEventDraftStatus.Draft));
         Mock.VerifyAll();
     }
 


### PR DESCRIPTION
Fixed the private method UpdateDraftWithImagesAsync() of the CompetitiveEventDraftService class – added a line of code:

competitiveEventDraft.DraftStatus = CompetitiveEventDraftStatus.Draft;
![Competitive event statuses](https://github.com/user-attachments/assets/b5c08168-868d-4402-950d-896bedf62538)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure competitive event drafts consistently remain in "Draft" status during image updates and subsequent repository operations.

* **Tests**
  * Added assertions to verify drafts retain the "Draft" status after update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->