### PR TITLE
Fixed problem when Service Provider could resubmit rejected Workshop without changes.

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -279,6 +279,11 @@ public class WorkshopDraftService(
                 }
             }
 
+            if (workshopDraft.DraftStatus == WorkshopDraftStatus.Rejected)
+            {
+                workshopDraft.DraftStatus = WorkshopDraftStatus.Draft;
+            }
+
             await workshopDraftRepository.Update(workshopDraft);
             logger.LogDebug("WorkshopDraft was successfully updated. Draft Id = {DraftId}.", workshopDraftUpdateDto.Id);
 
@@ -327,7 +332,7 @@ public class WorkshopDraftService(
 
         await currentUserService.UserHasRights(new ProviderRights(workshopDraft.ProviderId), new EmployeeRights(workshopDraft.ProviderId)).ConfigureAwait(false);
 
-        if (workshopDraft.DraftStatus == WorkshopDraftStatus.PendingModeration)
+        if (workshopDraft.DraftStatus == WorkshopDraftStatus.PendingModeration || workshopDraft.DraftStatus == WorkshopDraftStatus.Rejected)
         {
             throw new ArgumentException("This WorkshopDraft can`t be sent for moderation.");
         }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/WorkshopDrafts/WorkshopDraftService.cs
@@ -332,9 +332,13 @@ public class WorkshopDraftService(
 
         await currentUserService.UserHasRights(new ProviderRights(workshopDraft.ProviderId), new EmployeeRights(workshopDraft.ProviderId)).ConfigureAwait(false);
 
-        if (workshopDraft.DraftStatus == WorkshopDraftStatus.PendingModeration || workshopDraft.DraftStatus == WorkshopDraftStatus.Rejected)
+        if (workshopDraft.DraftStatus == WorkshopDraftStatus.PendingModeration)
         {
-            throw new ArgumentException("This WorkshopDraft can`t be sent for moderation.");
+            throw new ArgumentException("This draft is pending moderation and cannot be resubmitted.");
+        }
+        if (workshopDraft.DraftStatus == WorkshopDraftStatus.Rejected)
+        {
+            throw new ArgumentException("This draft was rejected and must be updated before resubmitting.");
         }
 
         workshopDraft.DraftStatus = WorkshopDraftStatus.PendingModeration;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rejected drafts now automatically revert to Draft when updated, restoring editability and allowing resubmission without manual state fixes.
  * Prevent resubmission of drafts that are pending moderation or still rejected; users receive clear messages explaining that pending drafts cannot be resubmitted and rejected drafts must be updated before sending for moderation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->