### PR TITLE
Fix validation for CompetitiveEvent.

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventBaseDto.cs
@@ -103,6 +103,9 @@ public class CompetitiveEventBaseDto : IValidatableObject, IHasContactsDto<OutOf
     [Range(0, 120, ErrorMessage = "Max age should be a number from 0 to 120")]
     public int? MaximumAge { get; set; }
 
+    public bool IsPaid { get; set; } = false;
+
+    [RequiredIf(nameof(IsPaid), true, ErrorMessage = "Price is required")]
     [Range(0, 100000, ErrorMessage = "Field value should be in a range from 0 to 100 000")]
     public decimal? Price { get; set; } = default;
 
@@ -186,6 +189,7 @@ public static class CompetitiveEventBaseDtoExtensions
         Benefits = dto.Benefits,
         MinimumAge = dto.MinimumAge,
         MaximumAge = dto.MaximumAge ?? 0,
+        IsPaid = dto.IsPaid,
         Price = dto.Price ?? 0,
         CompetitiveSelection = dto.CompetitiveSelection ?? false,
         Contacts = dto.Contacts?.ToModel(),
@@ -224,6 +228,7 @@ public static class CompetitiveEventBaseDtoExtensions
         model.Benefits = dto.Benefits;
         model.MinimumAge = dto.MinimumAge;
         model.MaximumAge = dto.MaximumAge ?? model.MaximumAge;
+        model.IsPaid = dto.IsPaid;
         model.Price = dto.Price ?? model.Price;
         model.CompetitiveSelection = dto.CompetitiveSelection ?? model.CompetitiveSelection;
         model.Contacts = dto.Contacts?.ToModel() ?? model.Contacts;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventBaseDto.cs
@@ -63,8 +63,8 @@ public class CompetitiveEventBaseDto : IValidatableObject, IHasContactsDto<OutOf
     public int CompetitiveEventAccountingTypeId { get; set; }
 
     [Required(ErrorMessage = "Information about the selection is required")]
-    [MinLength(3)]
-    [MaxLength(Constants.EnrollmentProcedureDescription)]
+    [MinLength(Constants.MinLengthOfDescriptionOfTheEnrollmentProcedureForCompetitiveEvent)]
+    [MaxLength(Constants.MaxLengthOfDescriptionOfTheEnrollmentProcedureForCompetitiveEvent)]
     [MustContain(RequiredCharacterType.AnyLetter, ErrorMessage = "Field must contain at least one letter.")]
     [RegularExpression(@"^[\p{IsCyrillic}\p{IsBasicLatin}0-9\s\p{P}\p{S}]+$", ErrorMessage = "Only Cyrillic, Latin, numbers and symbols are allowed.")]
     public string DescriptionOfTheEnrollmentProcedure { get; set; }
@@ -76,12 +76,12 @@ public class CompetitiveEventBaseDto : IValidatableObject, IHasContactsDto<OutOf
     [EnumDataType(typeof(FormOfLearning), ErrorMessage = Constants.EnumErrorMessage)]
     public FormOfLearning? PlannedFormatOfClasses { get; set; }
 
-    [MinLength(3)]
+    [MinLength(Constants.MinVenueNameLength)]
     [MaxLength(Constants.MaxVenueNameLength)]
     [MustContain(RequiredCharacterType.AnyLetter)]
     public string VenueName { get; set; }
 
-    [MinLength(3)]
+    [MinLength(Constants.MinCompetitiveSelectionDescriptionLength)]
     [MaxLength(Constants.MaxCompetitiveSelectionDescriptionLength)]
     [RequiredIf(nameof(CompetitiveSelection), true, ErrorMessage = "Competitive selection description is required")]
     [MustContain(RequiredCharacterType.AnyLetter, ErrorMessage = "Participation terms must contain at least one letter.")]
@@ -90,7 +90,7 @@ public class CompetitiveEventBaseDto : IValidatableObject, IHasContactsDto<OutOf
 
     public bool? AreThereBenefits { get; set; }
 
-    [MinLength(3)]
+    [MinLength(Constants.MinBenefitsLength)]
     [MaxLength(Constants.MaxBenefitsLength)]
     [RequiredIf(nameof(AreThereBenefits), true, ErrorMessage = "Benefits is required")]
     [MustContain(RequiredCharacterType.AnyLetter)]
@@ -104,7 +104,7 @@ public class CompetitiveEventBaseDto : IValidatableObject, IHasContactsDto<OutOf
     public int? MaximumAge { get; set; }
 
     [Range(0, 100000, ErrorMessage = "Field value should be in a range from 0 to 100 000")]
-    public int? Price { get; set; }
+    public decimal? Price { get; set; } = default;
 
     public bool? CompetitiveSelection { get; set; }
 
@@ -138,12 +138,12 @@ public class CompetitiveEventBaseDto : IValidatableObject, IHasContactsDto<OutOf
 
         if (NumberOfSeats != uint.MaxValue && (NumberOfSeats < 1 || NumberOfSeats > 100000))
         {
-            yield return new ValidationResult("NumberOfSeats field should be in the range from 1 to 100000.", new[] { nameof(NumberOfSeats) });
+            yield return new ValidationResult("NumberOfSeats field should be in the range from 1 to 100000.", [nameof(NumberOfSeats)]);
         }
 
         if (MinimumAge >= MaximumAge)
         {
-            yield return new ValidationResult("Minimum age should be less than Maximum age", new[] { nameof(MinimumAge), nameof(MaximumAge) });
+            yield return new ValidationResult("Minimum age should be less than Maximum age", [nameof(MinimumAge), nameof(MaximumAge)]);
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDescriptionItemDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDescriptionItemDto.cs
@@ -8,11 +8,13 @@ public class CompetitiveEventDescriptionItemDto
     public Guid Id { get; set; }
 
     [Required]
-    [MaxLength(200)]
+    [MinLength(Constants.MinLengthForSectionNameOfCompetitiveEventDescriptionItem)]
+    [MaxLength(Constants.MaxLengthForSectionNameOfCompetitiveEventDescriptionItem)]
     public string SectionName { get; set; }
 
     [Required]
-    [MaxLength(2000)]
+    [MinLength(Constants.MinLengthForDescriptionOfCompetitiveEventDescriptionItem)]
+    [MaxLength(Constants.MaxLengthForDescriptionOfCompetitiveEventDescriptionItem)]
     public string Description { get; set; }
 
     public Guid CompetitiveEventId { get; set; }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDto.cs
@@ -62,6 +62,7 @@ public static class CompetitiveEventDtoExtensions
             Benefits = model.Benefits,
             MinimumAge = model.MinimumAge,
             MaximumAge = model.MaximumAge,
+            IsPaid = model.IsPaid,
             Price = model.Price,
             CompetitiveSelection = model.CompetitiveSelection,
             Contacts = model.Contacts?.ToDto(),

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventAboutDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventAboutDto.cs
@@ -72,12 +72,12 @@ public class CompetitiveEventAboutDto : IValidatableObject
 
         if (NumberOfSeats != uint.MaxValue && (NumberOfSeats < 1 || NumberOfSeats > 100000))
         {
-            yield return new ValidationResult("NumberOfSeats field should be in the range from 1 to 100000.", new[] { nameof(NumberOfSeats) });
+            yield return new ValidationResult("NumberOfSeats field should be in the range from 1 to 100000.", [nameof(NumberOfSeats)]);
         }
 
         if (MinimumAge >= MaximumAge)
         {
-            yield return new ValidationResult("Minimum age should be less than Maximum age", new[] { nameof(MinimumAge), nameof(MaximumAge) });
+            yield return new ValidationResult("Minimum age should be less than Maximum age", [nameof(MinimumAge), nameof(MaximumAge)]);
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventDescriptionDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventDescriptionDto.cs
@@ -70,14 +70,5 @@ public class CompetitiveEventDescriptionDto : CompetitiveEventAboutDto
         // Run validations from CompetitiveEventAboutDto
         foreach (var error in base.Validate(validationContext))
             yield return error;
-
-        // validate Price when IsPaid is true
-        if (IsPaid)
-        {
-            if ((Price ?? 0) <= 0.00m)
-            {
-                yield return new ValidationResult("The price must be greater than 0.00 if the workshop is paid.", [nameof(Price)]);
-            }
-        }
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventDescriptionDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventDescriptionDto.cs
@@ -52,6 +52,7 @@ public class CompetitiveEventDescriptionDto : CompetitiveEventAboutDto
 
     public bool IsPaid { get; set; } = false;
 
+    [RequiredIf(nameof(IsPaid), true, ErrorMessage = "Price is required")]
     [Range(0, 100000, ErrorMessage = "Field value should be in a range from 0 to 100 000")]
     public decimal? Price { get; set; } = default;
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventDescriptionDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventDescriptionDto.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Util.CustomValidation;
 using OutOfSchool.BusinessLogic.Util.JsonTools;
 using OutOfSchool.BusinessLogic.Validators;
 using OutOfSchool.Common.Enums;
-using System.ComponentModel.DataAnnotations;
 using static OutOfSchool.BusinessLogic.Validators.ConditionalValidationAttributes;
 
 namespace OutOfSchool.BusinessLogic.Models.CompetitiveEvent.TempSave;
@@ -34,28 +34,28 @@ public class CompetitiveEventDescriptionDto : CompetitiveEventAboutDto
 
     public bool? CompetitiveSelection { get; set; }
 
-    [MinLength(3)]
+    [MinLength(Constants.MinCompetitiveSelectionDescriptionLength)]
     [MaxLength(Constants.MaxCompetitiveSelectionDescriptionLength)]
     [RequiredIf(nameof(CompetitiveSelection), true, ErrorMessage = "Competitive selection description is required")]
     [MustContain(RequiredCharacterType.AnyLetter)]
     public string CompetitiveSelectionDescription { get; set; }
 
-    [MinLength(3)]
+    [MinLength(Constants.MinVenueNameLength)]
     [MaxLength(Constants.MaxVenueNameLength)]
     [MustContain(RequiredCharacterType.AnyLetter)]
     public string VenueName { get; set; }
 
-    [MinLength(3)]
-    [MaxLength(Constants.EnrollmentProcedureDescription)]
+    [MinLength(Constants.MinLengthOfDescriptionOfTheEnrollmentProcedureForCompetitiveEvent)]
+    [MaxLength(Constants.MaxLengthOfDescriptionOfTheEnrollmentProcedureForCompetitiveEvent)]
     [MustContain(RequiredCharacterType.AnyLetter)]
     public string DescriptionOfTheEnrollmentProcedure { get; set; }
 
-    [Range(0, 100000, ErrorMessage = "Field value should be in a range from 0 to 100 000")]
-    public int? Price { get; set; }
+    [Range(0, 100000, ErrorMessage = "Field value should be in a range from 1 to 100 000")]
+    public decimal? Price { get; set; } = default;
 
     public bool? AreThereBenefits { get; set; }
 
-    [MinLength(3)]
+    [MinLength(Constants.MinBenefitsLength)]
     [MaxLength(Constants.MaxBenefitsLength)]
     [RequiredIf(nameof(AreThereBenefits), true, ErrorMessage = "Benefits is required")]
     [MustContain(RequiredCharacterType.AnyLetter)]

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventDescriptionDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventDescriptionDto.cs
@@ -50,6 +50,8 @@ public class CompetitiveEventDescriptionDto : CompetitiveEventAboutDto
     [MustContain(RequiredCharacterType.AnyLetter)]
     public string DescriptionOfTheEnrollmentProcedure { get; set; }
 
+    public bool IsPaid { get; set; } = false;
+
     [Range(0, 100000, ErrorMessage = "Field value should be in a range from 0 to 100 000")]
     public decimal? Price { get; set; } = default;
 
@@ -68,5 +70,14 @@ public class CompetitiveEventDescriptionDto : CompetitiveEventAboutDto
         // Run validations from CompetitiveEventAboutDto
         foreach (var error in base.Validate(validationContext))
             yield return error;
+
+        // validate Price when IsPaid is true
+        if (IsPaid)
+        {
+            if ((Price ?? 0) <= 0.00m)
+            {
+                yield return new ValidationResult("The price must be greater than 0.00 if the workshop is paid.", [nameof(Price)]);
+            }
+        }
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
@@ -89,6 +89,7 @@ public static class CompetitiveEventV2DtoExtensions
         Benefits = model.Benefits,
         MinimumAge = model.MinimumAge,
         MaximumAge = model.MaximumAge,
+        IsPaid = model.IsPaid,
         Price = model.Price,
         CompetitiveSelection = model.CompetitiveSelection,
         Contacts = model.Contacts?.ToDto(),
@@ -145,6 +146,7 @@ public static class CompetitiveEventV2DtoExtensions
             Benefits = draft.CompetitiveEventDraftContent?.Benefits,
             MinimumAge = draft.CompetitiveEventDraftContent?.MinimumAge ?? 0,
             MaximumAge = draft.CompetitiveEventDraftContent?.MaximumAge,
+            IsPaid = draft.CompetitiveEventDraftContent.IsPaid,
             Price = draft.CompetitiveEventDraftContent?.Price,
             CompetitiveSelection = draft.CompetitiveEventDraftContent?.CompetitiveSelection,
             Contacts = draft.CompetitiveEventDraftContent?.Contacts?.ToDto() ?? [],
@@ -198,7 +200,7 @@ public static class CompetitiveEventV2DtoExtensions
         AreThereBenefits = competitiveEventV2Dto.AreThereBenefits ?? default,
         Benefits = competitiveEventV2Dto.Benefits,
         CompetitiveSelection = competitiveEventV2Dto.CompetitiveSelection ?? default,
-        Contacts = competitiveEventV2Dto.Contacts?.ToModel() ?? new List<Contacts>(),
+        Contacts = competitiveEventV2Dto.Contacts?.ToModel() ?? [],
         DescriptionOfTheEnrollmentProcedure = competitiveEventV2Dto.DescriptionOfTheEnrollmentProcedure,
         MaximumAge = competitiveEventV2Dto.MaximumAge ?? default,
         MinimumAge = competitiveEventV2Dto.MinimumAge,
@@ -206,6 +208,7 @@ public static class CompetitiveEventV2DtoExtensions
         OrganizerOfTheEventId = competitiveEventV2Dto.OrganizerOfTheEventId,
         ParentId = competitiveEventV2Dto.ParentId,
         PlannedFormatOfClasses = competitiveEventV2Dto.PlannedFormatOfClasses ?? default,
+        IsPaid = competitiveEventV2Dto.IsPaid,
         Price = competitiveEventV2Dto.Price ?? default,
         RegistrationEndTime = competitiveEventV2Dto.RegistrationEndTime ?? default,
         RegistrationStartTime = competitiveEventV2Dto.RegistrationStartTime ?? default,
@@ -247,6 +250,7 @@ public static class CompetitiveEventV2DtoExtensions
         model.Benefits = dto.Benefits;
         model.MinimumAge = dto.MinimumAge;
         model.MaximumAge = dto.MaximumAge ?? model.MaximumAge;
+        model.IsPaid = dto.IsPaid;
         model.Price = dto.Price ?? model.Price;
         model.CompetitiveSelection = dto.CompetitiveSelection ?? model.CompetitiveSelection;
         model.Contacts = dto.Contacts?.ToModel() ?? model.Contacts;
@@ -284,6 +288,7 @@ public static class CompetitiveEventV2DtoExtensions
         Benefits = dto.Benefits,
         MinimumAge = dto.MinimumAge,
         MaximumAge = dto.MaximumAge ?? 120,
+        IsPaid = dto.IsPaid,
         Price = dto.Price ?? 0,
         CompetitiveSelection = dto.CompetitiveSelection ?? false,
         Contacts = dto.Contacts?.ToModel(),

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
@@ -28,9 +28,9 @@ public class CompetitiveEventV2Dto : CompetitiveEventDto, IHasCoverImage, IHasIm
         bool hasInvalidIds = ImageIds?.Any(id => string.IsNullOrWhiteSpace(id)) ?? false;
 
         if (hasInvalidFiles)
-            yield return new ValidationResult("ImageFiles must not contain empty files.", new[] { nameof(ImageFiles) });
+            yield return new ValidationResult("ImageFiles must not contain empty files.", [nameof(ImageFiles)]);
         if (hasInvalidIds)
-            yield return new ValidationResult("ImageIds must not contain empty or whitespace strings.", new[] { nameof(ImageIds) });
+            yield return new ValidationResult("ImageIds must not contain empty or whitespace strings.", [nameof(ImageIds)]);
 
         if (hasCoverImage == hasCoverImageId)
         {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
@@ -19,18 +19,35 @@ public class CompetitiveEventV2Dto : CompetitiveEventDto, IHasCoverImage, IHasIm
         foreach (var error in base.Validate(validationContext))
             yield return error;
 
-        if ((CoverImage is null) == string.IsNullOrEmpty(CoverImageId))
+        bool hasCoverImage = CoverImage is { Length: > 0 };
+        bool hasCoverImageId = !string.IsNullOrWhiteSpace(CoverImageId);
+        bool hasImageFiles = ImageFiles?.Any(f => f is { Length: > 0 }) ?? false;
+        bool hasImageIds = ImageIds?.Any(id => !string.IsNullOrWhiteSpace(id)) ?? false;
+
+        bool hasInvalidFiles = ImageFiles?.Any(f => f is null || f.Length == 0) ?? false;
+        bool hasInvalidIds = ImageIds?.Any(id => string.IsNullOrWhiteSpace(id)) ?? false;
+
+        if (hasInvalidFiles)
+            yield return new ValidationResult("ImageFiles must not contain empty files.", new[] { nameof(ImageFiles) });
+        if (hasInvalidIds)
+            yield return new ValidationResult("ImageIds must not contain empty or whitespace strings.", new[] { nameof(ImageIds) });
+
+        if (hasCoverImage == hasCoverImageId)
         {
-            yield return new ValidationResult(
-                "Either CoverImage or CoverImageId must be filled in, but not both.",
+            yield return new ValidationResult("Either CoverImage or CoverImageId should be provided, not both.",
                 [nameof(CoverImage), nameof(CoverImageId)]);
         }
 
-        if ((ImageFiles ?? []).Count == 0 && (ImageIds ?? []).Count == 0)
+        if (!hasImageFiles && !hasImageIds)
         {
-            yield return new ValidationResult(
-            "At least one of the ImageFiles or ImageIds fields must be filled in.",
-            [nameof(ImageFiles), nameof(ImageIds)]);
+            yield return new ValidationResult("At least one of the ImageFiles or ImageIds fields must be filled in.",
+                [nameof(ImageFiles), nameof(ImageIds)]);
+        }
+
+        if ((ImageFiles ?? []).Count + (ImageIds ?? []).Count > Constants.MaxCountOfImagesForCompetitiveEvent)
+        {
+            yield return new ValidationResult($"A maximum of {Constants.MaxCountOfImagesForCompetitiveEvent} images are allowed for a competitive event.",
+                [nameof(ImageFiles), nameof(ImageIds)]);
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/ContactsAddressDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/ContactsAddressDto.cs
@@ -11,15 +11,15 @@ namespace OutOfSchool.BusinessLogic.Models.ContactInfo;
 public sealed class ContactsAddressDto : IContentComparable<ContactsAddress>, IEquatable<ContactsAddressDto>
 {
     [Required(ErrorMessage = "Street is required")]
-    [MinLength(1)]
-    [MaxLength(60)]
+    [MinLength(Constants.MinStreetNameLength)]
+    [MaxLength(Constants.MaxStreetNameLength)]
     [MustContain(RequiredCharacterType.AnyLetter, ErrorMessage = "Street must contain at least one Cyrillic letter.")]
     [RegularExpression(@"^[\p{IsCyrillic}0-9\s\-'’\.]+$", ErrorMessage = "Only Cyrillic letters, numbers, spaces, '-', '.', and apostrophe are allowed.")]
     public string Street { get; set; } = string.Empty;
 
     [Required(ErrorMessage = "Building number is required")]
-    [MinLength(1)]
-    [MaxLength(15)]
+    [MinLength(Constants.MinBuildingNumberLength)]
+    [MaxLength(Constants.MaxBuildingNumberLength)]
     [MustContain(RequiredCharacterType.Digit, ErrorMessage = "Building number must contain at least one number.")]
     [RegularExpression(@"^[0-9]+[0-9А-Яа-яЇїІіЄєҐґA-Za-z\-\/]*$", ErrorMessage = "Building number must start with a digit and may only contain Cyrillic or Latin letters, digits, '-' and '/', without spaces.")]
     public string BuildingNumber { get; set; } = string.Empty;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/EmailDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/ContactInfo/EmailDto.cs
@@ -11,7 +11,7 @@ public sealed class EmailDto : IContentComparable<Email>, IEquatable<EmailDto>
     [Required(ErrorMessage = "Email type is required")]
     [MustContain(RequiredCharacterType.AnyLetter, ErrorMessage = "Contact type must contain at least one letter.")]
     [RegularExpression(@"^[\p{IsCyrillic}\p{IsBasicLatin}0-9\s\p{P}\p{S}]+$", ErrorMessage = "Only Cyrillic, Latin, numbers, and symbols are allowed.")]
-    [StringLength(Constants.MaxEmailTypeLength, MinimumLength = 3,ErrorMessage = "Email type must be between 3 and 60 characters")]
+    [StringLength(Constants.MaxEmailTypeLength, MinimumLength = Constants.MinEmailTypeLength, ErrorMessage = "Email type must be between 3 and 60 characters")]
     public string Type { get; set; } = null!;
 
     [DataType(DataType.EmailAddress)]

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Exported/CompetitiveEvents/CompetitiveEventInfoDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Exported/CompetitiveEvents/CompetitiveEventInfoDto.cs
@@ -72,8 +72,7 @@ public class CompetitiveEventInfoDto : CompetitiveEventInfoBaseDto, IExternalRat
     [Range(0, 120, ErrorMessage = "Max age should be a number from 0 to 120")]
     public int MaximumAge { get; set; } = 0;
 
-    [Range(0, 100000, ErrorMessage = "Field value should be in a range from 1 to 100 000")]
-    public int Price { get; set; } = 0;
+    public decimal Price { get; set; } = 0;
 
     public bool CompetitiveSelection { get; set; }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -68,10 +68,11 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             }
         }
 
-
         async Task<Result<(CompetitiveEventDraft createdCompetitiveEventDraft, UploadCompetitiveEventDraftImagesResult uploadImagesResult)>>
         CreateCompetitiveEventDraftWithImages()
         {
+            competitiveEventV2Dto.Price = competitiveEventV2Dto.Price ?? 0;
+
             var createdCompetitiveEventDraft = await CreateCompetitiveEventDraft(competitiveEventV2Dto)
                 .ConfigureAwait(false);
 
@@ -151,6 +152,8 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         }
 
         logger.LogDebug("Updating competitive event draft with ID: {DraftId}", competitiveEventDraftUpdateDto.Id);
+
+        competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Price = competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Price ?? 0;
 
         var draftImageUpdateResult = await competitiveEventDraftRepository
             .RunInTransaction(() => UpdateDraftWithImagesAsync(competitiveEventDraftUpdateDto))
@@ -403,6 +406,8 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
 
             throw new InvalidOperationException("CompetitiveEvent draft for this CompetitiveEvent exists. CompetitiveEvent can`t be updated.");
         }
+
+        competitiveEventV2Dto.Price = competitiveEventV2Dto.Price ?? 0;
 
         if (ShouldBeModerate(competitiveEventV2Dto, existingCompetitiveEvent))
         {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -71,7 +71,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         async Task<Result<(CompetitiveEventDraft createdCompetitiveEventDraft, UploadCompetitiveEventDraftImagesResult uploadImagesResult)>>
         CreateCompetitiveEventDraftWithImages()
         {
-            competitiveEventV2Dto.Price = competitiveEventV2Dto.IsPaid ? competitiveEventV2Dto.Price : 0;
+            NormalizePriceForPaymentStatus(competitiveEventV2Dto);
 
             var createdCompetitiveEventDraft = await CreateCompetitiveEventDraft(competitiveEventV2Dto)
                 .ConfigureAwait(false);
@@ -153,7 +153,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
 
         logger.LogDebug("Updating competitive event draft with ID: {DraftId}", competitiveEventDraftUpdateDto.Id);
 
-        competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Price = competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.IsPaid ? competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Price : 0;
+        NormalizePriceForPaymentStatus(competitiveEventDraftUpdateDto.CompetitiveEventV2Dto);
 
         var draftImageUpdateResult = await competitiveEventDraftRepository
             .RunInTransaction(() => UpdateDraftWithImagesAsync(competitiveEventDraftUpdateDto))
@@ -407,7 +407,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             throw new InvalidOperationException("CompetitiveEvent draft for this CompetitiveEvent exists. CompetitiveEvent can`t be updated.");
         }
 
-        competitiveEventV2Dto.Price = competitiveEventV2Dto.IsPaid ? competitiveEventV2Dto.Price : 0;
+        NormalizePriceForPaymentStatus(competitiveEventV2Dto);
 
         if (ShouldBeModerate(competitiveEventV2Dto, existingCompetitiveEvent))
         {
@@ -1107,5 +1107,10 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             return responseDto;
 
         }).ToList();
+    }
+
+    private static void NormalizePriceForPaymentStatus(CompetitiveEventV2Dto dto)
+    {
+        dto.Price = dto.IsPaid ? dto.Price : 0;
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -879,6 +879,19 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
     {
         var competitiveEventDraft = await GetDraftById(competitiveEventDraftUpdateDto.Id).ConfigureAwait(false);
 
+        if (competitiveEventDraft == null)
+        {
+            logger.LogWarning("Competitive event draft with ID = {DraftId} doesn't exist in DB, so it cannot be updated.", competitiveEventDraftUpdateDto.Id);
+
+            return Result<(CompetitiveEventDraft competitiveEventDraft, ImageChangingResult coverImageResult, MultipleImageChangingResult imagesResult)>
+                .Failed(
+                new OperationError
+                {
+                    Code = "400",
+                    Description = $"Competitive event draft with ID = {competitiveEventDraftUpdateDto.Id} doesn't exist in DB, so it cannot be updated."
+                });
+        }
+
         await currentUserService.UserHasRights(
             new ProviderRights(competitiveEventDraft.ProviderId),
             new EmployeeRights(competitiveEventDraft.ProviderId),
@@ -904,12 +917,13 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         if (competitiveEventDraft.DraftStatus == CompetitiveEventDraftStatus.PendingModeration)
         {
             logger.LogWarning("Competitive event draft with ID {DraftId} can't be updated.", competitiveEventDraftUpdateDto.Id);
+
             return Result<(CompetitiveEventDraft competitiveEventDraft, ImageChangingResult coverImageResult,
-           MultipleImageChangingResult imagesResult)>.Failed(new OperationError
-           {
-               Code = "400",
-               Description = "Competitive event draft can't be updated when it is in PendingModeration status."
-           });
+                MultipleImageChangingResult imagesResult)>.Failed(new OperationError
+                {
+                    Code = "400",
+                    Description = "Competitive event draft can't be updated when it is in PendingModeration status."
+                });
         }
 
         competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.SetToDraft(competitiveEventDraft);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -887,7 +887,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
                 .Failed(
                 new OperationError
                 {
-                    Code = "400",
+                    Code = "404",
                     Description = $"Competitive event draft with ID = {competitiveEventDraftUpdateDto.Id} doesn't exist in DB, so it cannot be updated."
                 });
         }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/CompetitiveEventDrafts/CompetitiveEventDraftService.cs
@@ -71,7 +71,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
         async Task<Result<(CompetitiveEventDraft createdCompetitiveEventDraft, UploadCompetitiveEventDraftImagesResult uploadImagesResult)>>
         CreateCompetitiveEventDraftWithImages()
         {
-            competitiveEventV2Dto.Price = competitiveEventV2Dto.Price ?? 0;
+            competitiveEventV2Dto.Price = competitiveEventV2Dto.IsPaid ? competitiveEventV2Dto.Price : 0;
 
             var createdCompetitiveEventDraft = await CreateCompetitiveEventDraft(competitiveEventV2Dto)
                 .ConfigureAwait(false);
@@ -153,7 +153,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
 
         logger.LogDebug("Updating competitive event draft with ID: {DraftId}", competitiveEventDraftUpdateDto.Id);
 
-        competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Price = competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Price ?? 0;
+        competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Price = competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.IsPaid ? competitiveEventDraftUpdateDto.CompetitiveEventV2Dto.Price : 0;
 
         var draftImageUpdateResult = await competitiveEventDraftRepository
             .RunInTransaction(() => UpdateDraftWithImagesAsync(competitiveEventDraftUpdateDto))
@@ -407,7 +407,7 @@ public class CompetitiveEventDraftService(ILogger<CompetitiveEventDraftService> 
             throw new InvalidOperationException("CompetitiveEvent draft for this CompetitiveEvent exists. CompetitiveEvent can`t be updated.");
         }
 
-        competitiveEventV2Dto.Price = competitiveEventV2Dto.Price ?? 0;
+        competitiveEventV2Dto.Price = competitiveEventV2Dto.IsPaid ? competitiveEventV2Dto.Price : 0;
 
         if (ShouldBeModerate(competitiveEventV2Dto, existingCompetitiveEvent))
         {

--- a/OutOfSchool/OutOfSchool.Common/Constants.cs
+++ b/OutOfSchool/OutOfSchool.Common/Constants.cs
@@ -8,6 +8,8 @@ public static class Constants
     /// </summary>
     public const int MaxUnifiedUrlLength = 2048;
 
+    public const int MinEmailTypeLength = 3;
+
     public const int MaxEmailTypeLength = 60;
 
     public const int MaxEmailAddressLength = 254;
@@ -183,9 +185,24 @@ public static class Constants
     public const int EnrollmentProcedureDescription = 500;
 
     /// <summary>
+    /// Maximum length of description of the enrollment procedure for competitive events.
+    /// </summary>
+    public const int MaxLengthOfDescriptionOfTheEnrollmentProcedureForCompetitiveEvent = 2000;
+
+    /// <summary>
+    /// Minimum length of description of the enrollment procedure for competitive events.
+    /// </summary>
+    public const int MinLengthOfDescriptionOfTheEnrollmentProcedureForCompetitiveEvent = 3;
+
+    /// <summary>
     /// Maximum length of competitive selection description.
     /// </summary>
-    public const int MaxCompetitiveSelectionDescriptionLength = 500;
+    public const int MaxCompetitiveSelectionDescriptionLength = 2000;
+
+    /// <summary>
+    /// Minimum length of competitive selection description.
+    /// </summary>
+    public const int MinCompetitiveSelectionDescriptionLength = 3;
 
     /// <summary>
     /// Maximum length of preferential terms of participation.
@@ -255,12 +272,12 @@ public static class Constants
     /// <summary>
     /// The maximum length allowed for the competitive event short title.
     /// </summary>
-    public const int MaxCompetitiveEventShortTitleLength = 100;
+    public const int MaxCompetitiveEventShortTitleLength = 120;
 
     /// <summary>
     /// The minimum length required for the competitive event short title.
     /// </summary>
-    public const int MinCompetitiveEventShortTitleLength = 1;
+    public const int MinCompetitiveEventShortTitleLength = 3;
 
     /// <summary>
     /// Maximum length allowed for the competitive event draft's rejection message.
@@ -270,7 +287,12 @@ public static class Constants
     /// <summary>
     /// The maximum length allowed for the benefits for competitive event.
     /// </summary>
-    public const int MaxBenefitsLength = 500;
+    public const int MaxBenefitsLength = 2000;
+
+    /// <summary>
+    /// The minimum length allowed for the benefits for competitive event.
+    /// </summary>
+    public const int MinBenefitsLength = 3;
 
     /// <summary>
     /// The maximum length allowed for the description.
@@ -280,7 +302,32 @@ public static class Constants
     /// <summary>
     /// The maximum length allowed for the venue name.
     /// </summary>
-    public const int MaxVenueNameLength = 500;
+    public const int MaxVenueNameLength = 60;
+
+    /// <summary>
+    /// The minimum length allowed for the venue name.
+    /// </summary>
+    public const int MinVenueNameLength = 3;
+
+    /// <summary>
+    /// The maximum length allowed for the street name.
+    /// </summary>
+    public const int MaxStreetNameLength = 60;
+
+    /// <summary>
+    /// The minimum length allowed for the street name.
+    /// </summary>
+    public const int MinStreetNameLength = 1;
+
+    /// <summary>
+    /// The maximum length allowed for the building number.
+    /// </summary>
+    public const int MaxBuildingNumberLength = 15;
+
+    /// <summary>
+    /// The minimum length allowed for the building number.
+    /// </summary>
+    public const int MinBuildingNumberLength = 1;
 
     /// <summary>
     /// The maximum length allowed for the Judge's description.
@@ -306,6 +353,31 @@ public static class Constants
     /// Maximum allowed length for phone number's type.
     /// </summary>
     public const int PhoneNumberTypeMaxLength = 60;
+
+    /// <summary>
+    /// Maximum count of images for CompetitiveEvent.
+    /// </summary>
+    public const int MaxCountOfImagesForCompetitiveEvent = 10;
+
+    /// <summary>
+    /// The maximum length allowed for the section name of the competitive event description item.
+    /// </summary>
+    public const int MaxLengthForSectionNameOfCompetitiveEventDescriptionItem = 120;
+
+    /// <summary>
+    /// The minimum length allowed for the section name of the competitive event description item.
+    /// </summary>
+    public const int MinLengthForSectionNameOfCompetitiveEventDescriptionItem = 3;
+
+    /// <summary>
+    /// The maximum length allowed for the description of the competitive event description item.
+    /// </summary>
+    public const int MaxLengthForDescriptionOfCompetitiveEventDescriptionItem = 2000;
+
+    /// <summary>
+    /// The minimum length allowed for the description of the competitive event description item.
+    /// </summary>
+    public const int MinLengthForDescriptionOfCompetitiveEventDescriptionItem = 3;
 
     public static class ExternalImages
     {

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEventDrafts/CompetitiveEventDraftContent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEventDrafts/CompetitiveEventDraftContent.cs
@@ -46,6 +46,8 @@ public class CompetitiveEventDraftContent : IHasContacts
 
     public int MaximumAge { get; set; }
 
+    public bool IsPaid { get; set; } = false;
+
     public decimal Price { get; set; } = default;
 
     public bool CompetitiveSelection { get; set; }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEventDrafts/CompetitiveEventDraftContent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEventDrafts/CompetitiveEventDraftContent.cs
@@ -1,8 +1,8 @@
-﻿using OutOfSchool.Common.Enums;
+﻿using System;
+using System.Collections.Generic;
+using OutOfSchool.Common.Enums;
 using OutOfSchool.Services.Models.CompetitiveEvents;
 using OutOfSchool.Services.Models.ContactInfo;
-using System;
-using System.Collections.Generic;
 
 namespace OutOfSchool.Services.Models.CompetitiveEventDrafts;
 
@@ -46,7 +46,7 @@ public class CompetitiveEventDraftContent : IHasContacts
 
     public int MaximumAge { get; set; }
 
-    public int Price { get; set; } = default;
+    public decimal Price { get; set; } = default;
 
     public bool CompetitiveSelection { get; set; }
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEvents/CompetitiveEvent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEvents/CompetitiveEvent.cs
@@ -14,14 +14,14 @@ public class CompetitiveEvent : BusinessEntity, IHasContacts, IImageDependentEnt
 {
     [Required(ErrorMessage = "Title is required")]
     [DataType(DataType.Text)]
-    [MaxLength(250)]
-    [MinLength(1)]
+    [MaxLength(Constants.MaxCompetitiveEventTitleLength)]
+    [MinLength(Constants.MinCompetitiveEventTitleLength)]
     public string Title { get; set; }
 
     [Required(ErrorMessage = "ShortTitle is required")]
     [DataType(DataType.Text)]
-    [MaxLength(100)]
-    [MinLength(1)]
+    [MaxLength(Constants.MaxCompetitiveEventShortTitleLength)]
+    [MinLength(Constants.MinCompetitiveEventShortTitleLength)]
     public string ShortTitle { get; set; }
 
     [Required]
@@ -54,23 +54,27 @@ public class CompetitiveEvent : BusinessEntity, IHasContacts, IImageDependentEnt
     [MaxLength(256)]
     public string CoverImageId { get; set; } = string.Empty;
 
-
-    [MaxLength(2000)]
+    [MinLength(Constants.MinLengthOfDescriptionOfTheEnrollmentProcedureForCompetitiveEvent)]
+    [MaxLength(Constants.MaxLengthOfDescriptionOfTheEnrollmentProcedureForCompetitiveEvent)]
     public string DescriptionOfTheEnrollmentProcedure { get; set; }
 
     public Guid OrganizerOfTheEventId { get; set; }
 
+    [EnumDataType(typeof(FormOfLearning), ErrorMessage = Constants.EnumErrorMessage)]
     public FormOfLearning PlannedFormatOfClasses { get; set; }
 
-    [MaxLength(200)]
+    [MaxLength(Constants.MaxVenueNameLength)]
+    [MinLength(Constants.MinVenueNameLength)]
     public string VenueName { get; set; }
 
+    [MinLength(Constants.MinCompetitiveSelectionDescriptionLength)]
     [MaxLength(Constants.MaxCompetitiveSelectionDescriptionLength)]
     public string CompetitiveSelectionDescription { get; set; }
   
     public bool AreThereBenefits { get; set; }
 
-    [MaxLength(2000)]
+    [MinLength(Constants.MinBenefitsLength)]
+    [MaxLength(Constants.MaxBenefitsLength)]
     public string Benefits {  get; set; }
 
     [Range(0, 120, ErrorMessage = "Min age should be a number from 0 to 120")]
@@ -79,8 +83,9 @@ public class CompetitiveEvent : BusinessEntity, IHasContacts, IImageDependentEnt
     [Range(0, 120, ErrorMessage = "Max age should be a number from 0 to 120")]
     public int MaximumAge { get; set; }
 
-    [Range(0, 100000, ErrorMessage = "Field value should be in a range from 1 to 100 000")]
-    public int Price { get; set; } = default;
+    [Column(TypeName = "decimal(18,2)")]
+    [Range(0, 100000, ErrorMessage = "Field value should be in a range from 0 to 100 000")]
+    public decimal Price { get; set; } = default;
 
     public bool CompetitiveSelection { get; set; }
 

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEvents/CompetitiveEvent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEvents/CompetitiveEvent.cs
@@ -83,6 +83,8 @@ public class CompetitiveEvent : BusinessEntity, IHasContacts, IImageDependentEnt
     [Range(0, 120, ErrorMessage = "Max age should be a number from 0 to 120")]
     public int MaximumAge { get; set; }
 
+    public bool IsPaid { get; set; } = false;
+
     [Column(TypeName = "decimal(18,2)")]
     [Range(0, 100000, ErrorMessage = "Field value should be in a range from 0 to 100 000")]
     public decimal Price { get; set; } = default;

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEvents/CompetitiveEventDescriptionItem.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/CompetitiveEvents/CompetitiveEventDescriptionItem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using OutOfSchool.Common;
 
 namespace OutOfSchool.Services.Models.CompetitiveEvents;
 
@@ -8,11 +9,13 @@ public class CompetitiveEventDescriptionItem : IKeyedEntity<Guid>
     public Guid Id { get; set; }
 
     [Required(ErrorMessage = "Description heading is required")]
-    [MaxLength(200)]
+    [MaxLength(Constants.MaxLengthForSectionNameOfCompetitiveEventDescriptionItem)]
+    [MinLength(Constants.MinLengthForSectionNameOfCompetitiveEventDescriptionItem)]
     public string SectionName { get; set; }
 
     [Required(ErrorMessage = "Description text is required")]
-    [MaxLength(2000)]
+    [MaxLength(Constants.MaxLengthForDescriptionOfCompetitiveEventDescriptionItem)]
+    [MinLength(Constants.MinLengthForDescriptionOfCompetitiveEventDescriptionItem)]
     public string Description { get; set; }
 
     public Guid? CompetitiveEventId { get; set; }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/Base/BusinessEntityWithContactsConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/Base/BusinessEntityWithContactsConfiguration.cs
@@ -25,11 +25,11 @@ public abstract class BusinessEntityWithContactsConfiguration<TBase> : BusinessE
             {
                 a.Property(p => p.Street)
                     .IsRequired()
-                    .HasMaxLength(60);
+                    .HasMaxLength(Constants.MaxStreetNameLength);
 
                 a.Property(p => p.BuildingNumber)
                     .IsRequired()
-                    .HasMaxLength(15);
+                    .HasMaxLength(Constants.MaxBuildingNumberLength);
 
                 a.Property(p => p.CATOTTGId)
                     .IsRequired();

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/Contacts.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/Contacts.cs
@@ -1,9 +1,14 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using OutOfSchool.Common;
 
 namespace OutOfSchool.Services.Models.ContactInfo;
 
 public class Contacts
 {
+    [Required(ErrorMessage = "Title is required")]
+    [MinLength(Constants.ContactsTitleMinLength)]
+    [MaxLength(Constants.ContactsTitleMaxLength)]
     public string Title { get; set; }
     
     public bool IsDefault { get; set; }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/ContactsAddress.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/ContactsAddress.cs
@@ -1,12 +1,18 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using OutOfSchool.Common;
 
 namespace OutOfSchool.Services.Models.ContactInfo;
 
 public class ContactsAddress
 {
+    [Required(ErrorMessage = "Street is required")]
+    [MinLength(Constants.MinStreetNameLength)]
+    [MaxLength(Constants.MaxStreetNameLength)]
     public string Street { get; set; }
 
+    [MinLength(Constants.MinBuildingNumberLength)]
+    [MaxLength(Constants.MaxBuildingNumberLength)]
     public string BuildingNumber { get; set; }
 
     [Range(-90, 90, ErrorMessage = "Latitude must be between -90 and 90 degrees")]

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/ContactsAddress.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/ContactsAddress.cs
@@ -8,11 +8,11 @@ public class ContactsAddress
 {
     [Required(ErrorMessage = "Street is required")]
     [MinLength(Constants.MinStreetNameLength)]
-    [MaxLength(Constants.MaxStreetNameLength)]
+    // Maximum length of the Street name set in BusinessEntityWithContactsConfiguration
     public string Street { get; set; }
 
     [MinLength(Constants.MinBuildingNumberLength)]
-    [MaxLength(Constants.MaxBuildingNumberLength)]
+    // Maximum length of BuildingNumber set in BusinessEntityWithContactsConfiguration
     public string BuildingNumber { get; set; }
 
     [Range(-90, 90, ErrorMessage = "Latitude must be between -90 and 90 degrees")]

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/Email.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/Email.cs
@@ -5,8 +5,13 @@ namespace OutOfSchool.Services.Models.ContactInfo;
 
 public class Email
 {
+    [Required(ErrorMessage = "Email type is required")]
+    [StringLength(Constants.MaxEmailTypeLength, MinimumLength = Constants.MinEmailTypeLength, ErrorMessage = "Email type must be between 3 and 60 characters")]
     public string Type { get; set; }
 
     [DataType(DataType.EmailAddress)]
+    [Required(ErrorMessage = "Email address is required")]
+    [StringLength(Constants.MaxEmailAddressLength, ErrorMessage = "Email address cannot exceed 254 characters")]
+    [EmailAddress(ErrorMessage = "Invalid email address format (e.g., name@example.com)")]
     public string Address { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/PhoneNumber.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/PhoneNumber.cs
@@ -6,6 +6,9 @@ namespace OutOfSchool.Services.Models.ContactInfo;
 
 public class PhoneNumber
 {
+    [Required]
+    [MinLength(Constants.PhoneNumberTypeMinLength, ErrorMessage = "Phone type should contain at least 3 characters")]
+    [MaxLength(Constants.PhoneNumberTypeMaxLength, ErrorMessage = "Phone type cannot exceed 60 characters")]
     public string Type { get; set; }
 
     [DataType(DataType.PhoneNumber)]

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/SocialNetwork.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/ContactInfo/SocialNetwork.cs
@@ -1,10 +1,14 @@
-﻿using OutOfSchool.Common.Enums;
+﻿using System.ComponentModel.DataAnnotations;
+using OutOfSchool.Common;
+using OutOfSchool.Common.Enums;
 
 namespace OutOfSchool.Services.Models.ContactInfo;
 
 public class SocialNetwork
 {
+    [EnumDataType(typeof(SocialNetworkContactType), ErrorMessage = Constants.EnumErrorMessage)]
     public SocialNetworkContactType Type { get; set; }
 
+    [StringLength(Constants.MaxUnifiedUrlLength, ErrorMessage = "URL cannot exceed allowed length.")]
     public string Url { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/ESCompetitiveEventProvider.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/ESCompetitiveEventProvider.cs
@@ -91,6 +91,7 @@ public class ESCompetitiveEventProvider(ElasticsearchClient elasticClient) :
         AddStatesQuery(query, filter);
         AddPlannedFormatOfClassesQuery(query, filter);
         AddAreThereBenefitsQuery(query, filter);
+        AddIsPaidQuery(query, filter);
         AddCompetitiveSelectionQuery(query, filter);
         if (includePrice)
         {
@@ -164,6 +165,17 @@ public class ESCompetitiveEventProvider(ElasticsearchClient elasticClient) :
             query.Filter.Add(new TermQuery(Infer.Field<CompetitiveEventES>(e => e.AreThereBenefits))
             {
                 Value = filter.AreThereBenefits,
+            });
+        }
+    }
+
+    private void AddIsPaidQuery(BoolQuery query, CompetitiveEventFilterES filter)
+    {
+        if (filter.IsPaid)
+        {
+            query.Filter.Add(new TermQuery(Infer.Field<CompetitiveEventES>(e => e.IsPaid))
+            {
+                Value = filter.IsPaid,
             });
         }
     }

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/Models/CompetitiveEventES.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/Models/CompetitiveEventES.cs
@@ -57,6 +57,8 @@ public class CompetitiveEventES
 
     public string Coverage { get; set; } //coverage title
 
+    public bool IsPaid { get; set; }
+
     public decimal Price { get; set; }
 
     public bool CompetitiveSelection { get; set; }

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/Models/CompetitiveEventES.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/Models/CompetitiveEventES.cs
@@ -57,7 +57,7 @@ public class CompetitiveEventES
 
     public string Coverage { get; set; } //coverage title
 
-    public int Price { get; set; }
+    public decimal Price { get; set; }
 
     public bool CompetitiveSelection { get; set; }
 

--- a/OutOfSchool/OutOfSchool.ElasticsearchData/Models/CompetitiveEventFilterES.cs
+++ b/OutOfSchool/OutOfSchool.ElasticsearchData/Models/CompetitiveEventFilterES.cs
@@ -38,4 +38,6 @@ public class CompetitiveEventFilterES
     public int MaxPrice { get; set; } = int.MaxValue;
 
     public bool CompetitiveSelection { get; set; }
+
+    public bool IsPaid { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20251108101458_AddIsPaidToCompetitiveEvent.Designer.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20251108101458_AddIsPaidToCompetitiveEvent.Designer.cs
@@ -12,8 +12,8 @@ using OutOfSchool.Services;
 namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 {
     [DbContext(typeof(OutOfSchoolDbContext))]
-    [Migration("20251101101418_AddIndexesToImages")]
-    partial class AddIndexesToImages
+    [Migration("20251108101458_AddIsPaidToCompetitiveEvent")]
+    partial class AddIsPaidToCompetitiveEvent
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -940,8 +940,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         .HasColumnType("tinyint(1)");
 
                     b.Property<string>("CompetitiveSelectionDescription")
-                        .HasMaxLength(500)
-                        .HasColumnType("varchar(500)");
+                        .HasMaxLength(2000)
+                        .HasColumnType("varchar(2000)");
 
                     b.Property<string>("CoverImageId")
                         .HasMaxLength(256)
@@ -982,6 +982,9 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         .HasColumnType("tinyint(1)")
                         .HasDefaultValue(false);
 
+                    b.Property<bool>("IsPaid")
+                        .HasColumnType("tinyint(1)");
+
                     b.Property<bool>("IsSystemProtected")
                         .HasColumnType("tinyint(1)");
 
@@ -1007,8 +1010,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                     b.Property<int>("PlannedFormatOfClasses")
                         .HasColumnType("int");
 
-                    b.Property<int>("Price")
-                        .HasColumnType("int");
+                    b.Property<decimal>("Price")
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<DateTimeOffset>("RegistrationEndTime")
                         .HasColumnType("datetime(6)");
@@ -1024,8 +1027,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 
                     b.Property<string>("ShortTitle")
                         .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("varchar(100)");
+                        .HasMaxLength(120)
+                        .HasColumnType("varchar(120)");
 
                     b.Property<int>("State")
                         .HasColumnType("int");
@@ -1039,8 +1042,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         .HasColumnType("datetime(6)");
 
                     b.Property<string>("VenueName")
-                        .HasMaxLength(200)
-                        .HasColumnType("varchar(200)");
+                        .HasMaxLength(60)
+                        .HasColumnType("varchar(60)");
 
                     b.HasKey("Id");
 
@@ -1205,8 +1208,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 
                     b.Property<string>("SectionName")
                         .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("varchar(200)");
+                        .HasMaxLength(120)
+                        .HasColumnType("varchar(120)");
 
                     b.HasKey("Id");
 
@@ -3908,8 +3911,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         .HasColumnType("tinyint(1)");
 
                     b.Property<string>("CompetitiveSelectionDescription")
-                        .HasMaxLength(500)
-                        .HasColumnType("varchar(500)");
+                        .HasMaxLength(2000)
+                        .HasColumnType("varchar(2000)");
 
                     b.Property<string>("CoverImageId")
                         .HasMaxLength(256)
@@ -3942,8 +3945,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         .HasColumnType("int");
 
                     b.Property<string>("EnrollmentProcedureDescription")
-                        .HasMaxLength(500)
-                        .HasColumnType("varchar(500)");
+                        .HasMaxLength(2000)
+                        .HasColumnType("varchar(2000)");
 
                     b.Property<string>("File")
                         .HasColumnType("longtext");
@@ -4004,8 +4007,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         .HasColumnType("int");
 
                     b.Property<string>("PreferentialTermsOfParticipation")
-                        .HasMaxLength(500)
-                        .HasColumnType("varchar(500)");
+                        .HasMaxLength(2000)
+                        .HasColumnType("varchar(2000)");
 
                     b.Property<decimal>("Price")
                         .HasColumnType("decimal(18,2)");
@@ -4658,6 +4661,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                     MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b2.Property<long>("Id"));
 
                                     b2.Property<string>("Address")
+                                        .IsRequired()
                                         .HasMaxLength(254)
                                         .HasColumnType("varchar(254)");
 
@@ -4665,6 +4669,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("bigint");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 
@@ -4697,6 +4702,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("varchar(16)");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 
@@ -5092,6 +5098,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                     MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b2.Property<long>("Id"));
 
                                     b2.Property<string>("Address")
+                                        .IsRequired()
                                         .HasMaxLength(254)
                                         .HasColumnType("varchar(254)");
 
@@ -5099,6 +5106,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("bigint");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 
@@ -5131,6 +5139,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("varchar(16)");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 
@@ -5430,6 +5439,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                     MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b2.Property<long>("Id"));
 
                                     b2.Property<string>("Address")
+                                        .IsRequired()
                                         .HasMaxLength(254)
                                         .HasColumnType("varchar(254)");
 
@@ -5437,6 +5447,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("bigint");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 
@@ -5469,6 +5480,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("varchar(16)");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20251108101458_AddIsPaidToCompetitiveEvent.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/20251108101458_AddIsPaidToCompetitiveEvent.cs
@@ -1,0 +1,407 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
+{
+    /// <inheritdoc />
+    public partial class AddIsPaidToCompetitiveEvent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Workshops_Contacts_Phones",
+                keyColumn: "Type",
+                keyValue: null,
+                column: "Type",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "Workshops_Contacts_Phones",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.UpdateData(
+                table: "Workshops_Contacts_Emails",
+                keyColumn: "Type",
+                keyValue: null,
+                column: "Type",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "Workshops_Contacts_Emails",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.UpdateData(
+                table: "Workshops_Contacts_Emails",
+                keyColumn: "Address",
+                keyValue: null,
+                column: "Address",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "Workshops_Contacts_Emails",
+                type: "varchar(254)",
+                maxLength: 254,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(254)",
+                oldMaxLength: 254,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.UpdateData(
+                table: "Providers_Contacts_Phones",
+                keyColumn: "Type",
+                keyValue: null,
+                column: "Type",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "Providers_Contacts_Phones",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.UpdateData(
+                table: "Providers_Contacts_Emails",
+                keyColumn: "Type",
+                keyValue: null,
+                column: "Type",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "Providers_Contacts_Emails",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.UpdateData(
+                table: "Providers_Contacts_Emails",
+                keyColumn: "Address",
+                keyValue: null,
+                column: "Address",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "Providers_Contacts_Emails",
+                type: "varchar(254)",
+                maxLength: 254,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(254)",
+                oldMaxLength: 254,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.UpdateData(
+                table: "CompetitiveEvents_Contacts_Phones",
+                keyColumn: "Type",
+                keyValue: null,
+                column: "Type",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "CompetitiveEvents_Contacts_Phones",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.UpdateData(
+                table: "CompetitiveEvents_Contacts_Emails",
+                keyColumn: "Type",
+                keyValue: null,
+                column: "Type",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "CompetitiveEvents_Contacts_Emails",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.UpdateData(
+                table: "CompetitiveEvents_Contacts_Emails",
+                keyColumn: "Address",
+                keyValue: null,
+                column: "Address",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "CompetitiveEvents_Contacts_Emails",
+                type: "varchar(254)",
+                maxLength: 254,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(254)",
+                oldMaxLength: 254,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "VenueName",
+                table: "CompetitiveEvents",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(200)",
+                oldMaxLength: 200,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ShortTitle",
+                table: "CompetitiveEvents",
+                type: "varchar(120)",
+                maxLength: 120,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldMaxLength: 100)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Price",
+                table: "CompetitiveEvents",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPaid",
+                table: "CompetitiveEvents",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SectionName",
+                table: "CompetitiveEventDescriptionItems",
+                type: "varchar(120)",
+                maxLength: 120,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(200)",
+                oldMaxLength: 200)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsPaid",
+                table: "CompetitiveEvents");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "Workshops_Contacts_Phones",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "Workshops_Contacts_Emails",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "Workshops_Contacts_Emails",
+                type: "varchar(254)",
+                maxLength: 254,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(254)",
+                oldMaxLength: 254)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "Providers_Contacts_Phones",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "Providers_Contacts_Emails",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "Providers_Contacts_Emails",
+                type: "varchar(254)",
+                maxLength: 254,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(254)",
+                oldMaxLength: 254)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "CompetitiveEvents_Contacts_Phones",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "CompetitiveEvents_Contacts_Emails",
+                type: "varchar(60)",
+                maxLength: 60,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "CompetitiveEvents_Contacts_Emails",
+                type: "varchar(254)",
+                maxLength: 254,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(254)",
+                oldMaxLength: 254)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "VenueName",
+                table: "CompetitiveEvents",
+                type: "varchar(200)",
+                maxLength: 200,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(60)",
+                oldMaxLength: 60,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ShortTitle",
+                table: "CompetitiveEvents",
+                type: "varchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(120)",
+                oldMaxLength: 120)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Price",
+                table: "CompetitiveEvents",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SectionName",
+                table: "CompetitiveEventDescriptionItems",
+                type: "varchar(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(120)",
+                oldMaxLength: 120)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/OutOfSchoolDbContextModelSnapshot.cs
+++ b/OutOfSchool/OutOfSchool.Migrations/Data/Migrations/OutOfSchoolMigrations/OutOfSchoolDbContextModelSnapshot.cs
@@ -979,6 +979,9 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         .HasColumnType("tinyint(1)")
                         .HasDefaultValue(false);
 
+                    b.Property<bool>("IsPaid")
+                        .HasColumnType("tinyint(1)");
+
                     b.Property<bool>("IsSystemProtected")
                         .HasColumnType("tinyint(1)");
 
@@ -1004,8 +1007,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                     b.Property<int>("PlannedFormatOfClasses")
                         .HasColumnType("int");
 
-                    b.Property<int>("Price")
-                        .HasColumnType("int");
+                    b.Property<decimal>("Price")
+                        .HasColumnType("decimal(18,2)");
 
                     b.Property<DateTimeOffset>("RegistrationEndTime")
                         .HasColumnType("datetime(6)");
@@ -1021,8 +1024,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 
                     b.Property<string>("ShortTitle")
                         .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("varchar(100)");
+                        .HasMaxLength(120)
+                        .HasColumnType("varchar(120)");
 
                     b.Property<int>("State")
                         .HasColumnType("int");
@@ -1036,8 +1039,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                         .HasColumnType("datetime(6)");
 
                     b.Property<string>("VenueName")
-                        .HasMaxLength(200)
-                        .HasColumnType("varchar(200)");
+                        .HasMaxLength(60)
+                        .HasColumnType("varchar(60)");
 
                     b.HasKey("Id");
 
@@ -1202,8 +1205,8 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
 
                     b.Property<string>("SectionName")
                         .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("varchar(200)");
+                        .HasMaxLength(120)
+                        .HasColumnType("varchar(120)");
 
                     b.HasKey("Id");
 
@@ -4655,6 +4658,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                     MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b2.Property<long>("Id"));
 
                                     b2.Property<string>("Address")
+                                        .IsRequired()
                                         .HasMaxLength(254)
                                         .HasColumnType("varchar(254)");
 
@@ -4662,6 +4666,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("bigint");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 
@@ -4694,6 +4699,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("varchar(16)");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 
@@ -5089,6 +5095,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                     MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b2.Property<long>("Id"));
 
                                     b2.Property<string>("Address")
+                                        .IsRequired()
                                         .HasMaxLength(254)
                                         .HasColumnType("varchar(254)");
 
@@ -5096,6 +5103,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("bigint");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 
@@ -5128,6 +5136,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("varchar(16)");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 
@@ -5427,6 +5436,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                     MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b2.Property<long>("Id"));
 
                                     b2.Property<string>("Address")
+                                        .IsRequired()
                                         .HasMaxLength(254)
                                         .HasColumnType("varchar(254)");
 
@@ -5434,6 +5444,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("bigint");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 
@@ -5466,6 +5477,7 @@ namespace OutOfSchool.Migrations.Data.Migrations.OutOfSchoolMigrations
                                         .HasColumnType("varchar(16)");
 
                                     b2.Property<string>("Type")
+                                        .IsRequired()
                                         .HasMaxLength(60)
                                         .HasColumnType("varchar(60)");
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/ElasticsearchData/ESCompetitiveEventProviderTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/ElasticsearchData/ESCompetitiveEventProviderTests.cs
@@ -110,6 +110,7 @@ public class ESCompetitiveEventProviderTests
             MaxPrice = 1000,
             MaxRegistrationEndTime = DateTime.UtcNow.AddDays(7),
             MaxScheduledStartTime = DateTime.UtcNow.AddDays(7),
+            IsPaid = true
         };
 
         var response = CreateSuccessfulSearchResponse(expectedTotal, expectedEntities);

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -696,7 +696,7 @@ public class CompetitiveEventDraftServiceTests
 
         // Assert
         Assert.That(result.Succeeded, Is.False);
-        Assert.That(result.OperationResult.Errors.FirstOrDefault().Code, Is.EqualTo("400"));
+        Assert.That(result.OperationResult.Errors.FirstOrDefault().Code, Is.EqualTo("404"));
         Assert.That(result.OperationResult.Errors.FirstOrDefault().Description, 
             Is.EqualTo($"Competitive event draft with ID = {id} doesn't exist in DB, so it cannot be updated."));
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventDraftServiceTests.cs
@@ -669,6 +669,40 @@ public class CompetitiveEventDraftServiceTests
         Mock.VerifyAll();
     }
 
+    [Test]
+    public async Task Update_ReturnsFailedResult_WhenDraftDoesNotExistInDB()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        var competitiveEventV2Dto = CompetitiveEventV2DtoGenerator.Generate();
+        var dto = new CompetitiveEventDraftUpdateDto()
+        {
+            Id = id,
+            CompetitiveEventV2Dto = competitiveEventV2Dto
+        };
+        var draft = (CompetitiveEventDraft)null;
+
+        mockCompetitiveEventDraftRepository
+           .Setup(r => r.RunInTransaction(It.IsAny<Func<Task<Result<(CompetitiveEventDraft, ImageChangingResult, MultipleImageChangingResult)>>>>()))
+           .Returns((Func<Task<Result<(CompetitiveEventDraft, ImageChangingResult, MultipleImageChangingResult)>>> f) => f.Invoke())
+           .Verifiable(Times.Once);
+        mockCompetitiveEventDraftRepository
+            .Setup(repo => repo.GetById(id))
+            .ReturnsAsync(draft)
+            .Verifiable(Times.Once);
+
+        // Act
+        var result = await competitiveEventDraftService.Update(id, dto);
+
+        // Assert
+        Assert.That(result.Succeeded, Is.False);
+        Assert.That(result.OperationResult.Errors.FirstOrDefault().Code, Is.EqualTo("400"));
+        Assert.That(result.OperationResult.Errors.FirstOrDefault().Description, 
+            Is.EqualTo($"Competitive event draft with ID = {id} doesn't exist in DB, so it cannot be updated."));
+
+        Mock.VerifyAll();
+    }
+
     #endregion
 
     #region Delete

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Validators/CompetitiveEventV2DtoValidationTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Validators/CompetitiveEventV2DtoValidationTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.V2;
 using OutOfSchool.Tests.Common.TestDataGenerators;
@@ -25,7 +27,7 @@ public class CompetitiveEventV2DtoValidationTests
         date4 = date3.Add(new TimeSpan(30, 0, 0, 0));
     }
 
-        [Test]
+    [Test]
     public void Validate_WhenAllPropertiesAreCorrect_ShouldReturnNoValidationErrors()
     {
         // Arrange
@@ -123,9 +125,93 @@ public class CompetitiveEventV2DtoValidationTests
             result.ErrorMessage.Contains("Minimum age should be less than Maximum age"));
     }
 
+    [Test]
+    public void Validate_WhenCoverImageAndCoverImageIdValuesAreNotNull_ShouldReturnValidationError()
+    {
+        // Arrange
+        var dto = CreateTheCorrectDto();
+        var validationContext = new ValidationContext(dto);
+        dto.CoverImage = FakeFile();
+
+        // Act
+        var results = dto.Validate(validationContext).ToList();
+
+        // Assert
+        results.Should().ContainSingle(result =>
+            result.ErrorMessage.Contains("Either CoverImage or CoverImageId should be provided, not both."));
+    }
+
+    [Test]
+    public void Validate_WhenImageFilesContainEmptyFiles_ShouldReturnValidationError()
+    {
+        // Arrange
+        var dto = CreateTheCorrectDto();
+        var validationContext = new ValidationContext(dto);
+        dto.ImageFiles = dto.ImageFiles = [FakeFile("img.jpg", 0)];
+
+        // Act
+        var results = dto.Validate(validationContext).ToList();
+
+        // Assert
+        results.Should().ContainSingle(result =>
+            result.ErrorMessage.Contains("ImageFiles must not contain empty files."));
+    }
+
+    [Test]
+    public void Validate_WhenImageIdsContainEmptyOrWhitespaceStrings_ShouldReturnValidationError()
+    {
+        // Arrange
+        var dto = CreateTheCorrectDto();
+        var validationContext = new ValidationContext(dto);
+        dto.ImageIds = [Guid.NewGuid().ToString(), string.Empty];
+
+        // Act
+        var results = dto.Validate(validationContext).ToList();
+
+        // Assert
+        results.Should().ContainSingle(result =>
+            result.ErrorMessage.Contains("ImageIds must not contain empty or whitespace strings."));
+    }
+
+    [Test]
+    public void Validate_WhenImageFilesAndImageIdsAreEmpty_ShouldReturnValidationError()
+    {
+        // Arrange
+        var dto = CreateTheCorrectDto();
+        var validationContext = new ValidationContext(dto);
+        dto.ImageFiles = [];
+        dto.ImageIds = [];
+
+        // Act
+        var results = dto.Validate(validationContext).ToList();
+
+        // Assert
+        results.Should().ContainSingle(result =>
+            result.ErrorMessage.Contains("At least one of the ImageFiles or ImageIds fields must be filled in."));
+    }
+
+    [Test]
+    public void Validate_WhenCountOfImageFilesAndImageIdsMoreThanAllowed_ShouldReturnValidationError()
+    {
+        // Arrange
+        var dto = CreateTheCorrectDto();
+        var validationContext = new ValidationContext(dto);
+        dto.ImageIds = [Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(),
+                        Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(),
+                        Guid.NewGuid().ToString(), Guid.NewGuid().ToString(),];
+        dto.ImageFiles = [FakeFile()];
+
+
+        // Act
+        var results = dto.Validate(validationContext).ToList();
+
+        // Assert
+        results.Should().ContainSingle(result =>
+            result.ErrorMessage.Contains($"A maximum of 10 images are allowed for a competitive event."));
+    }
+
     #region Helpers
 
-    // 
     private CompetitiveEventV2Dto CreateTheCorrectDto()
     {
         var dto = CompetitiveEventV2DtoGenerator.Generate();
@@ -137,7 +223,18 @@ public class CompetitiveEventV2DtoValidationTests
         dto.MaximumAge = 10;
         dto.MinimumAge = 5;
 
+        dto.CoverImageId = Guid.NewGuid().ToString();
+        dto.ImageIds = [Guid.NewGuid().ToString(), Guid.NewGuid().ToString()];
+        dto.ImageFiles = [FakeFile()];
+
         return dto;
+    }
+
+    private static IFormFile FakeFile(string name = "img.jpg", int size = 10)
+    {
+        var bytes = new byte[size];
+        var ms = new MemoryStream(bytes);
+        return new FormFile(ms, 0, bytes.Length, "file", name);
     }
 
     #endregion

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
@@ -1,9 +1,9 @@
-﻿using Bogus;
+﻿using System.Collections.Generic;
+using Bogus;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.TempSave;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
 using OutOfSchool.Common.Enums;
-using System.Collections.Generic;
 
 namespace OutOfSchool.Tests.Common.TestDataGenerators;
 
@@ -40,7 +40,8 @@ public static class CompetitiveEventContactsDtoGenerator
         .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Sentences(3))
         .RuleFor(x => x.VenueName, f => f.Lorem.Sentences(3))
         .RuleFor(x => x.DescriptionOfTheEnrollmentProcedure, f => f.Lorem.Sentences(3))
-        .RuleFor(x => x.Price, f => f.Random.Int(1, 100))
+        .RuleFor(x => x.IsPaid, true)
+        .RuleFor(x => x.Price, f => f.Random.Int(1, 100000))
         .RuleFor(x => x.PlannedFormatOfClasses, f => f.PickRandom<FormOfLearning>());
 
     public static CompetitiveEventContactsDto Generate() => Faker.Generate();

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
@@ -41,7 +41,7 @@ public static class CompetitiveEventContactsDtoGenerator
         .RuleFor(x => x.VenueName, f => f.Lorem.Sentences(3))
         .RuleFor(x => x.DescriptionOfTheEnrollmentProcedure, f => f.Lorem.Sentences(3))
         .RuleFor(x => x.IsPaid, true)
-        .RuleFor(x => x.Price, f => f.Random.Int(1, 100000))
+        .RuleFor(x => x.Price, f => f.Random.Decimal(1, 100000))
         .RuleFor(x => x.PlannedFormatOfClasses, f => f.PickRandom<FormOfLearning>());
 
     public static CompetitiveEventContactsDto Generate() => Faker.Generate();

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftContentGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftContentGenerator.cs
@@ -1,8 +1,8 @@
-﻿using Bogus;
+﻿using System.Collections.Generic;
+using Bogus;
 using OutOfSchool.Services.Models.CompetitiveEventDrafts;
 using OutOfSchool.Services.Models.CompetitiveEvents;
 using OutOfSchool.Services.Models.ContactInfo;
-using System.Collections.Generic;
 
 namespace OutOfSchool.Tests.Common.TestDataGenerators;
 public static class CompetitiveEventDraftContentGenerator
@@ -28,7 +28,13 @@ public static class CompetitiveEventDraftContentGenerator
         .RuleFor(x => x.OrganizerOfTheEventId, f => f.Random.Guid())
         .RuleFor(x => x.MinimumAge, f => f.Random.Int(5, 18))
         .RuleFor(x => x.Contacts, f => new List<Contacts> { })
-        .RuleFor(x => x.SubDirectionIds, f => new List<long> { f.Random.Long(1, 100) });
+        .RuleFor(x => x.SubDirectionIds, f => new List<long> { f.Random.Long(1, 100) })
+        .RuleFor(x => x.AreThereBenefits, true)
+        .RuleFor(x => x.Benefits, f => f.Lorem.Sentence(10))
+        .RuleFor(x => x.CompetitiveSelection, true)
+        .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Sentence(10))
+        .RuleFor(x => x.IsPaid, true)
+        .RuleFor(x => x.Price, f => f.Random.UInt(1, 100000));
 
     public static CompetitiveEventDraftContent Generate() => Faker.Generate();
 

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftContentGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftContentGenerator.cs
@@ -34,7 +34,7 @@ public static class CompetitiveEventDraftContentGenerator
         .RuleFor(x => x.CompetitiveSelection, true)
         .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Sentence(10))
         .RuleFor(x => x.IsPaid, true)
-        .RuleFor(x => x.Price, f => f.Random.UInt(1, 100000));
+        .RuleFor(x => x.Price, f => f.Random.Decimal(1, 100000));
 
     public static CompetitiveEventDraftContent Generate() => Faker.Generate();
 

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventDraftGenerator.cs
@@ -1,7 +1,7 @@
-﻿using Bogus;
+﻿using System.Collections.Generic;
+using Bogus;
 using OutOfSchool.Services.Enums.CompetitiveEventStatus;
 using OutOfSchool.Services.Models.CompetitiveEventDrafts;
-using System.Collections.Generic;
 
 namespace OutOfSchool.Tests.Common.TestDataGenerators;
 public static class CompetitiveEventDraftGenerator

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventV2DtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventV2DtoGenerator.cs
@@ -1,9 +1,9 @@
-﻿using Bogus;
+﻿using System.Collections.Generic;
+using Bogus;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.V2;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
 using OutOfSchool.Common.Enums.CompetitiveEvent;
-using System.Collections.Generic;
 
 namespace OutOfSchool.Tests.Common.TestDataGenerators;
 public static class CompetitiveEventV2DtoGenerator
@@ -39,7 +39,9 @@ public static class CompetitiveEventV2DtoGenerator
         .RuleFor(x => x.AreThereBenefits, true)
         .RuleFor(x => x.Benefits, f => f.Lorem.Sentence(10))
         .RuleFor(x => x.CompetitiveSelection, true)
-        .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Sentence(10));
+        .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Sentence(10))
+        .RuleFor(x => x.IsPaid, true)
+        .RuleFor(x => x.Price, f => f.Random.UInt(1, 100000));
 
     public static CompetitiveEventV2Dto Generate() => Faker.Generate();
 

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventV2DtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventV2DtoGenerator.cs
@@ -41,7 +41,7 @@ public static class CompetitiveEventV2DtoGenerator
         .RuleFor(x => x.CompetitiveSelection, true)
         .RuleFor(x => x.CompetitiveSelectionDescription, f => f.Lorem.Sentence(10))
         .RuleFor(x => x.IsPaid, true)
-        .RuleFor(x => x.Price, f => f.Random.UInt(1, 100000));
+        .RuleFor(x => x.Price, f => f.Random.Decimal(1, 100000));
 
     public static CompetitiveEventV2Dto Generate() => Faker.Generate();
 


### PR DESCRIPTION
1) Fixed validation for CompetitiveEvent.
2) Fixed Data Annotation attributes for properties of CompetitiveEvent. Added constants for values of parameters Data Annotation attributes.
3) Added IsPaid property to CompetitiveEvent.
4) Added default value for Price property in Create(), Update() and UpdateCompetitiveEvent() methods of CompetitiveEventDraftService class for the case when IsPaid = false.
5) Added checking for the presence of CompetitiveEventDraft in the DB to the private method UpdateDraftWithImagesAsync().
6) Added migration — 20251108101458_AddIsPaidToCompetitiveEvent.
7) Added appropriate tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mark events as paid/free (IsPaid) and use decimal pricing; filter/search by paid status
  * Expanded contact details: address, phones, emails, social links

* **Improvements**
  * Centralized length/validation constants for titles, descriptions, venue, address and contacts
  * Enhanced image validation and clearer error messages; enforced image count limits
  * Price normalization applied across create/update flows and consistent defaults

* **Tests**
  * Added image validation tests and a test for missing draft update handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->