### PR TITLE
Add SportsSectionSyncService and scheduled job

### DIFF
--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Config/QuartzCronScheduleConfig.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Config/QuartzCronScheduleConfig.cs
@@ -19,4 +19,6 @@ public class QuartzCronScheduleConfig
     public string EmailSenderCronScheduleString { get; set; }
     
     public string SportKindSyncCronScheduleString { get; set; }
+
+    public string SportsSectionSyncCronScheduleString { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/SportsSectionSyncExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Extensions/Startup/SportsSectionSyncExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using global::OutOfSchool.Common.QuartzConstants;
+using OutOfSchool.BackgroundJobs.Config;
+using OutOfSchool.BackgroundJobs.Jobs;
+using OutOfSchool.Common.QuartzConstants;
+using Quartz;
+
+namespace OutOfSchool.BackgroundJobs.Extensions.Startup;
+
+public static class SportsSectionSyncExtensions
+{
+    public static void AddSportsSectionSync(
+        this IServiceCollectionQuartzConfigurator quartz,
+        QuartzConfig quartzConfig)
+    {
+        _ = quartzConfig ?? throw new ArgumentNullException(nameof(quartzConfig));
+
+        var jobKey = new JobKey("SportsSectionSync", GroupConstants.SportsSections);
+
+        quartz.AddJob<SportsSectionSyncQuartzJob>(j => j.WithIdentity(jobKey));
+
+        quartz.AddTrigger(t => t
+            .WithIdentity("SportsSectionSyncTrigger", GroupConstants.SportsSections)
+            .ForJob(jobKey)
+            .StartNow()
+            .WithCronSchedule(
+                quartzConfig.CronSchedules.SportsSectionSyncCronScheduleString
+            ));
+    }
+}

--- a/OutOfSchool/OutOfSchool.BackgroundJobs/Jobs/SportsSectionSyncQuartzJob.cs
+++ b/OutOfSchool/OutOfSchool.BackgroundJobs/Jobs/SportsSectionSyncQuartzJob.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Logging;
+using OutOfSchool.BusinessLogic.Services.SportsRegistry;
+using Quartz;
+
+namespace OutOfSchool.BackgroundJobs.Jobs;
+
+[DisallowConcurrentExecution]
+public class SportsSectionSyncQuartzJob : IJob
+{
+    private readonly ISportsSectionSyncService sportsSectionSyncService;
+    private readonly ILogger<SportsSectionSyncQuartzJob> logger;
+
+    public SportsSectionSyncQuartzJob(
+        ISportsSectionSyncService sportsSectionSyncService,
+        ILogger<SportsSectionSyncQuartzJob> logger)
+    {
+        this.sportsSectionSyncService = sportsSectionSyncService;
+        this.logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        logger.LogInformation("SportsSection sync Quartz job started");
+
+        try
+        {
+            var changedCount = await sportsSectionSyncService.SyncSportsSectionsAsync().ConfigureAwait(false);
+            logger.LogInformation("SportsSection sync finished. {Count} entities changed.", changedCount);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "SportsSection sync failed");
+            throw;
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftToSportSectionExtensions.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/WorkshopDraft/WorkshopDraftToSportSectionExtensions.cs
@@ -23,7 +23,7 @@ public static class WorkshopDraftToSportSectionExtensions
     public static SportsSectionUpdateRequest ToSportSectionUpdateRequest(
         this WorkshopDraft draft, [NotNull] string baseImageUrl)
     {
-        var sectionId = draft.WorkshopDraftContent?.MinsportSectionId
+        var sectionId = draft.MinsportSectionId
             ?? throw new ArgumentException("SectionId is required for update.", nameof(draft));
 
         return new SportsSectionUpdateRequest

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateRequestDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateRequestDto.cs
@@ -51,5 +51,6 @@ public static class WorkshopCreateRequestDtoExtensions
 
             LanguageOfEducationId = dto.LanguageOfEducationId,
             IsChampionPath = dto.IsChampionPath,
+            MinsportSectionId = dto.MinsportSectionId,
         };
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2CreateRequestDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2CreateRequestDto.cs
@@ -109,6 +109,6 @@ public static class WorkshopV2CreateRequestDtoExtensions
             CoverImageId = draft.CoverImageId,
             ImageIds = draft.Images?.Select(i => i.ExternalStorageId).ToList() ?? [],
             IsChampionPath = draft.WorkshopDraftContent?.IsChampionPath ?? default,
-            MinsportSectionId = draft.WorkshopDraftContent?.MinsportSectionId,
+            MinsportSectionId = draft.MinsportSectionId,
         };
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
@@ -142,7 +142,7 @@ public static class WorkshopV2DtoExtensions
             ImageIds = draft.Images?.Select(x => x.ExternalStorageId).ToList() ?? [],
             Status = draft.WorkshopDraftContent?.WorkshopStatus ?? default,
             ProviderOwnership = draft.WorkshopDraftContent?.OwnershipType ?? default,
-            MinsportSectionId = draft.WorkshopDraftContent?.MinsportSectionId ?? default,
+            MinsportSectionId = draft.MinsportSectionId ?? default,
         };
 
     public static List<WorkshopV2Dto> ToDto(this IEnumerable<OutOfSchool.Services.Models.WorkshopDrafts.WorkshopDraft> list)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopV2Dto.cs
@@ -64,8 +64,8 @@ public static class WorkshopV2DtoExtensions
             ParentWorkshopId = dto.ParentWorkshopId,
             Contacts = dto.Contacts?.ToModel() ?? [],
             IsChampionPath = dto.IsChampionPath,
-            NoAgeRestrictions = dto.NoAgeRestrictions,
-            MinsportSectionId = dto.MinsportSectionId
+            NoAgeRestrictions = dto.NoAgeRestrictions
+            //MinsportSectionId = dto.MinsportSectionId
         };
 
     public static void SetToDraft(this WorkshopV2Dto dto, OutOfSchool.Services.Models.WorkshopDrafts.WorkshopDraft model)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/ISportsSectionSyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/ISportsSectionSyncService.cs
@@ -1,0 +1,16 @@
+﻿namespace OutOfSchool.BusinessLogic.Services.SportsRegistry;
+
+/// <summary>
+/// Service responsible for synchronizing sports sections (workshops) 
+/// with the external Ministry of Sports Registry.
+/// Pulls section data from the registry and updates or creates corresponding local workshops.
+/// </summary>
+public interface ISportsSectionSyncService
+{
+    /// <summary>
+    /// Synchronizes sports sections (workshops) with the external Sports Registry.
+    /// Creates new draft workshops for records not found locally and updates existing drafts when data has changed.
+    /// </summary>
+    /// <returns>The total number of workshops created or updated during synchronization.</returns>
+    Task<int> SyncSportsSectionsAsync();
+}

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/RegistrySyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/RegistrySyncService.cs
@@ -179,7 +179,7 @@ public class RegistrySyncService : IRegistrySyncService
             },
             success =>
             {
-                draft.WorkshopDraftContent!.MinsportSectionId = success.ResultVariables.SectionId;
+                draft.MinsportSectionId = success.ResultVariables.SectionId;
                 var action = isCreate ? "created" : "updated";
                 logger.LogInformation(
                     "Draft was successfully {Action} in Sports Registry. DraftId={DraftId}, SectionId={SectionId}",

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/RegistrySyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/RegistrySyncService.cs
@@ -58,7 +58,7 @@ public class RegistrySyncService : IRegistrySyncService
         var institutionHierarchyId = draft.WorkshopDraftContent.InstitutionHierarchyId
             ?? throw new ArgumentException("InstitutionHierarchyId cannot be null.");
 
-        if (draft.WorkshopDraftContent?.MinsportSectionId is null)
+        if (draft.MinsportSectionId is null)
         {
             // Create
             var request = draft.ToSportSectionPostRequest(baseImageUrl);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/RegistrySyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/RegistrySyncService.cs
@@ -179,7 +179,10 @@ public class RegistrySyncService : IRegistrySyncService
             },
             success =>
             {
-                draft.MinsportSectionId = success.ResultVariables.SectionId;
+                if(success.ResultVariables.SectionId is not null)
+                {
+                    draft.MinsportSectionId = success.ResultVariables.SectionId;
+                }
                 var action = isCreate ? "created" : "updated";
                 logger.LogInformation(
                     "Draft was successfully {Action} in Sports Registry. DraftId={DraftId}, SectionId={SectionId}",

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
@@ -1,12 +1,15 @@
-﻿using OutOfSchool.Services.Models.WorkshopDrafts;
+﻿//using System.Linq;
+using OutOfSchool.BusinessLogic.Util.Mappers;
+using OutOfSchool.Services.Enums.WorkshopStatus;
+using OutOfSchool.Services.Models.WorkshopDrafts;
 using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.SportsRegistryApiClient.Interfaces;
-using System.Linq;
-
 namespace OutOfSchool.BusinessLogic.Services.SportsRegistry;
 public class SportsSectionSyncService(
     ISportsRegistryWorkshopProvider workshopProvider,
+    IWorkshopDraftRepository workshopDraftRepository,
     IWorkshopRepository workshopRepository,
+    ICodeficatorRepository codeficatorRepository,
     ILogger<SportsSectionSyncService> logger)
     : ISportsSectionSyncService
 {
@@ -34,45 +37,86 @@ public class SportsSectionSyncService(
             .GetByFilter(w => w.MinsportSectionId.HasValue && registrySectionsId.Contains(w.MinsportSectionId.Value))
             .ConfigureAwait(false);
 
+        var existingWorkshopDrafts = await workshopDraftRepository
+            .GetByFilter(w => w.MinsportSectionId.HasValue && registrySectionsId.Contains(w.MinsportSectionId.Value))
+            .ConfigureAwait(false);
+
         var existingLookup = existingWorkshops.ToDictionary(w => w.MinsportSectionId!.Value);
+        var existingDraftLookup = existingWorkshopDrafts.ToDictionary(w => w.MinsportSectionId!.Value);
 
-        var toCreate = new List<Workshop>(); // WorkshopDraft?
-        var toUpdate = new List<Workshop>();
+        var toCreate = new List<WorkshopDraft>();
+        var toUpdate = new List<WorkshopDraft>();
 
-        foreach (var section in sportsSections)
+        foreach (var section in sportsSections) // check
         {
-            if (!existingLookup.TryGetValue(section.SectionId, out var workshop))
+            existingDraftLookup.TryGetValue(section.SectionId, out var existingDraft);
+            existingLookup.TryGetValue(section.SectionId, out var existingWorkshop);
+
+            DateTimeOffset? lastUpdate = existingDraft?.ModifiedAt
+                              ?? (existingWorkshop?.UpdatedAt.HasValue == true
+                                  ? new DateTimeOffset(existingWorkshop.UpdatedAt.Value)
+                                  : (DateTimeOffset?)null);
+
+            if (!lastUpdate.HasValue || section.UpdatedInRegistryAt > lastUpdate.Value)
             {
-                //Create draft
-                toCreate.Add(new Workshop() // section.ToWorkshopDraft()
+                WorkshopDraft draft;
+
+                if (existingDraft != null)
                 {
-                    Id = Guid.NewGuid(),
-                   
-                    Title = section.SectionName,
-                  
-                    // TODO: map other fields
-                });
+                    // update existing draft
+                    draft = section.MapToExistingDraft(existingDraft);
+                    draft.DraftStatus = WorkshopDraftStatus.PendingModeration; // to ask Dima
+                    toUpdate.Add(draft);
+                }
+                else if (existingWorkshop != null)
+                {
+                    // no draft,  only workshop - create draft
+                    draft = section.ToWorkshopDraft(existingWorkshop.ProviderId);
+
+                    //draft = existingWorkshop.ToDraft(); // may be this way?
+                    //draft = section.MapToExistingDraft(draft);
+
+                    toCreate.Add(draft);
+                }
+                else
+                {
+                    // no workshop, no draft - new draft
+                    draft = section.ToWorkshopDraft(GetProviderId());
+                    toCreate.Add(draft);
+                }
+
+                //  update CATOTTGId
+                draft.CATOTTGId = await GetIdByCatottgCode(section.SectionAddressLocalityDictIdCode) ?? 0;
+                break; // temporary for testing purposes
             }
-            //else if (section.UpdatedAt > workshop.RegistrySyncDate)
-            //{
-            //    // Update draft
-            //    workshop.Title = section.Name;
-              //}
         }
 
-        // need to review
         if (toCreate.Any() || toUpdate.Any())
         {
-            await workshopRepository.RunInTransaction(async () =>
+            await workshopDraftRepository.RunInTransaction(async () =>
             {
                 if (toCreate.Any())
                 {
-                    await workshopRepository.Create(toCreate).ConfigureAwait(false);
+                    foreach (var draft in toCreate)
+                    {
+                        logger.LogDebug(
+                            "Creating WorkshopDraft. SectionId: {SectionId}, Title: {Title}",
+                            draft.MinsportSectionId, draft.WorkshopDraftContent.Title);
+                    }
+                    await workshopDraftRepository.Create(toCreate).ConfigureAwait(false);
                 }
 
                 if (toUpdate.Any())
                 {
-                    await workshopRepository.SaveChangesAsync().ConfigureAwait(false);
+                    foreach (var draft in toUpdate)
+                    {
+                        logger.LogDebug(
+                            "Updating WorkshopDraft. SectionId: {SectionId}, Title: {Title}, DraftStatus: {DraftStatus}",
+                            draft.MinsportSectionId,
+                            draft.WorkshopDraftContent.Title,
+                            draft.DraftStatus);
+                    }
+                    await workshopDraftRepository.SaveChangesAsync().ConfigureAwait(false);
                 }
 
                 logger.LogInformation(
@@ -82,5 +126,20 @@ public class SportsSectionSyncService(
         }
 
         return toCreate.Count + toUpdate.Count;
+    }
+
+    private async Task<long?> GetIdByCatottgCode(string sectionAddressLocalityDictIdCode)
+    {
+        return await codeficatorRepository.GetIdByCodeAsync(sectionAddressLocalityDictIdCode);
+    }
+    private Guid GetProviderIdForExistingWorkshop() // TO DO
+    {
+        return Guid.Parse("08da842d-12fc-4865-85c5-ec6e6142abad"); // sleep@gmail.com temporary
+    }
+
+
+    private Guid GetProviderId() // TO DO 
+    {
+        return Guid.Parse("08da842d-12fc-4865-85c5-ec6e6142abad"); // sleep@gmail.com temporary
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
@@ -17,185 +17,194 @@ public class SportsSectionSyncService(
 {
     public async Task<int> SyncSportsSectionsAsync()
     {
-        logger.LogInformation("Starting synchronization of workshops (sports sections) with Sports Registry...");
-
-        var updatedAtTo = DateTimeOffset.UtcNow;
-        var updatedAtFrom = updatedAtTo.AddMinutes(-30);
-
-        logger.LogInformation("Fetching only updated sections from {From} to {To}", updatedAtFrom, updatedAtTo);
-        
-        var response = await workshopProvider.GetAllSportsSectionsAsync(updatedAtFrom, updatedAtTo).ConfigureAwait(false);
-
-        if (response.TryGetLeft(out var error)) // ????? if filtered fetch failed, fallback to full fetch
+        try
         {
-            logger.LogWarning("Filtered fetch failed, fallback to full fetch");
-            response = await workshopProvider.GetAllSportsSectionsAsync().ConfigureAwait(false);
-        }
+            logger.LogInformation("Starting synchronization of workshops (sports sections) with Sports Registry...");
 
-        var sportsSections = response.Match(
-            error => throw new InvalidOperationException($"Failed to fetch sports sections: {error.Message}"),
-            success => success);
+            var updatedAtTo = DateTimeOffset.UtcNow;
+            var updatedAtFrom = updatedAtTo.AddMinutes(-30);
 
-        if (!sportsSections.Any())
-        {
-            logger.LogWarning("No sports sections were fetched from Sports Registry.");
-            return 0;
-        }
+            logger.LogInformation("Fetching only updated sections from {From} to {To}", updatedAtFrom, updatedAtTo);
 
-        var registrySectionsId = sportsSections
-            .Select(x => x.SectionId)
-            .ToList();
+            var response = await workshopProvider.GetAllSportsSectionsAsync(updatedAtFrom, updatedAtTo).ConfigureAwait(false);
 
-        var existingWorkshops = await workshopRepository
-            .GetByFilter(w => w.MinsportSectionId.HasValue && registrySectionsId.Contains(w.MinsportSectionId.Value))
-            .ConfigureAwait(false);
-
-        var existingWorkshopDrafts = await workshopDraftRepository
-            .GetByFilter(w => w.MinsportSectionId.HasValue && registrySectionsId.Contains(w.MinsportSectionId.Value))
-            .ConfigureAwait(false);
-
-        var existingLookup = existingWorkshops.ToDictionary(w => w.MinsportSectionId!.Value);
-        var existingDraftLookup = existingWorkshopDrafts.ToDictionary(w => w.MinsportSectionId!.Value);
-
-        var existingHierarchies = await hierarchyRepository
-           .GetByFilter(x => x.SportRegistryIdCode.HasValue)
-           .ConfigureAwait(false);
-        var lookupHierarchy = existingHierarchies.ToDictionary(x => x.SportRegistryIdCode!.Value);
-       
-        var toCreate = new List<WorkshopDraft>();
-        var toUpdate = new List<WorkshopDraft>();
-
-        var tempSectionList = sportsSections.Where(s => s.OrganizationCode == "45080641").ToList(); // temporary for testing purposes
-        foreach (var section in tempSectionList) 
-        //foreach (var section in sportsSections) // check
-        {
-            existingDraftLookup.TryGetValue(section.SectionId, out var existingDraft);
-            existingLookup.TryGetValue(section.SectionId, out var existingWorkshop);
-
-            DateTimeOffset? lastUpdate = existingDraft?.ModifiedAt
-                              ?? (existingWorkshop?.UpdatedAt.HasValue == true
-                                  ? new DateTimeOffset(existingWorkshop.UpdatedAt.Value)
-                                  : null);
-
-
-            if (!lastUpdate.HasValue || section.UpdatedInRegistryAt > lastUpdate.Value)
+            if (response.TryGetLeft(out var error)) //  if filtered fetch failed, fallback to full fetch
             {
-                // try to find hierarchy for section's sport kind
-                if (!lookupHierarchy.TryGetValue(section.SectionSportKindDictIdCode, out var hierarchy))
+                logger.LogWarning("Filtered fetch failed, fallback to full fetch");
+                response = await workshopProvider.GetAllSportsSectionsAsync().ConfigureAwait(false);
+            }
+
+            var sportsSections = response.Match(
+                error => throw new InvalidOperationException($"Failed to fetch sports sections: {error.Message}"),
+                success => success);
+
+            if (!sportsSections.Any())
+            {
+                logger.LogWarning("No sports sections were fetched from Sports Registry.");
+                return 0;
+            }
+
+            var registrySectionsId = sportsSections
+                .Select(x => x.SectionId)
+                .ToList();
+
+            var existingWorkshops = await workshopRepository
+                .GetByFilter(w => w.MinsportSectionId.HasValue && registrySectionsId.Contains(w.MinsportSectionId.Value))
+                .ConfigureAwait(false);
+
+            var existingWorkshopDrafts = await workshopDraftRepository
+                .GetByFilter(w => w.MinsportSectionId.HasValue && registrySectionsId.Contains(w.MinsportSectionId.Value))
+                .ConfigureAwait(false);
+
+            var existingLookup = existingWorkshops.ToDictionary(w => w.MinsportSectionId!.Value);
+            var existingDraftLookup = existingWorkshopDrafts.ToDictionary(w => w.MinsportSectionId!.Value);
+
+            var existingHierarchies = await hierarchyRepository
+               .GetByFilter(x => x.SportRegistryIdCode.HasValue)
+               .ConfigureAwait(false);
+            var lookupHierarchy = existingHierarchies.ToDictionary(x => x.SportRegistryIdCode!.Value);
+
+            var toCreate = new List<WorkshopDraft>();
+            var toUpdate = new List<WorkshopDraft>();
+
+            // var tempSectionList = sportsSections.Where(s => s.OrganizationCode == "45080641").ToList(); // temporary for testing purposes
+                                                                                                        //foreach (var section in tempSectionList) 
+            foreach (var section in sportsSections)
+            {
+                existingDraftLookup.TryGetValue(section.SectionId, out var existingDraft);
+                existingLookup.TryGetValue(section.SectionId, out var existingWorkshop);
+
+                DateTimeOffset? lastUpdate = existingDraft?.ModifiedAt
+                                  ?? (existingWorkshop?.UpdatedAt.HasValue == true
+                                      ? new DateTimeOffset(existingWorkshop.UpdatedAt.Value)
+                                      : null);
+
+
+                if (!lastUpdate.HasValue || section.UpdatedInRegistryAt > lastUpdate.Value)
                 {
-                    logger.LogWarning(
-                        "Skipping section {SectionId} because no InstitutionHierarchy found for SportKindIdCode {SportKindIdCode}.",
-                        section.SectionId,
-                        section.SectionSportKindDictIdCode);
-                    continue; // skip sections without valid hierarchy
-                }
-
-                // try to retrieve CATOTTGId before creating/updating draft
-                var catottgId = await TryGetCatottgIdAsync(section).ConfigureAwait(false);
-                if (!catottgId.HasValue)
-                { 
-                    continue; // skip sections without valid CATOTTGId
-                }
-
-                WorkshopDraft draft;
-
-                if (existingDraft != null)
-                {
-                    // update existing draft
-                    draft = section.MapToExistingDraft(existingDraft, catottgId.Value);
-                    draft.DraftStatus = WorkshopDraftStatus.PendingModeration;
-                    draft.WorkshopDraftContent.InstitutionHierarchyId = hierarchy.Id;
-                    draft.WorkshopDraftContent.InstitutionId = hierarchy.InstitutionId;
-
-                    toUpdate.Add(draft);
-                    logger.LogDebug(
-                        "Updating existing draft for section {SectionId}. DraftId={DraftId}, ProviderId={ProviderId}",
-                        section.SectionId, draft.Id, draft.ProviderId);
-                }
-                else if (existingWorkshop != null)
-                {
-                    if (existingWorkshop.MinsportSectionId != section.SectionId)
+                    // try to find hierarchy for section's sport kind
+                    if (!lookupHierarchy.TryGetValue(section.SectionSportKindDictIdCode, out var hierarchy))
                     {
                         logger.LogWarning(
-                            "Mismatch between MinsportSectionId and SectionId for workshop {WorkshopId}: expected {Expected}, got {Actual}. Skipping sync for this section.",
-                            existingWorkshop.Id,
-                            existingWorkshop.MinsportSectionId,
-                            section.SectionId);
-                        continue; //skip sync section to not create draft for wrong section
+                            "Skipping section {SectionId} because no InstitutionHierarchy found for SportKindIdCode {SportKindIdCode}.",
+                            section.SectionId,
+                            section.SectionSportKindDictIdCode);
+                        continue; // skip sections without valid hierarchy
                     }
-                    // no draft,  only workshop - create draft
-                    draft = section.ToWorkshopDraft(existingWorkshop.ProviderId, catottgId.Value);
-                    draft.WorkshopId = existingWorkshop.Id;
-                    draft.MinsportSectionId = existingWorkshop.MinsportSectionId;
 
-                    toCreate.Add(draft);
-                    logger.LogInformation(
-                        "Creating new draft for existing workshop {WorkshopId} from section {SectionId}. ProviderId={ProviderId}",
-                        existingWorkshop.Id, section.SectionId, draft.ProviderId);
+                    // try to retrieve CATOTTGId before creating/updating draft
+                    var catottgId = await TryGetCatottgIdAsync(section).ConfigureAwait(false);
+                    if (!catottgId.HasValue)
+                    {
+                        continue; // skip sections without valid CATOTTGId
+                    }
+
+                    WorkshopDraft draft;
+
+                    if (existingDraft != null)
+                    {
+                        // update existing draft
+                        draft = section.MapToExistingDraft(existingDraft, catottgId.Value);
+                        draft.DraftStatus = WorkshopDraftStatus.PendingModeration;
+                        draft.WorkshopDraftContent.InstitutionHierarchyId = hierarchy.Id;
+                        draft.WorkshopDraftContent.InstitutionId = hierarchy.InstitutionId;
+
+                        toUpdate.Add(draft);
+                        logger.LogDebug(
+                            "Updating existing draft for section {SectionId}. DraftId={DraftId}, ProviderId={ProviderId}",
+                            section.SectionId, draft.Id, draft.ProviderId);
+                    }
+                    else if (existingWorkshop != null)
+                    {
+                        if (existingWorkshop.MinsportSectionId != section.SectionId)
+                        {
+                            logger.LogWarning(
+                                "Mismatch between MinsportSectionId and SectionId for workshop {WorkshopId}: expected {Expected}, got {Actual}. Skipping sync for this section.",
+                                existingWorkshop.Id,
+                                existingWorkshop.MinsportSectionId,
+                                section.SectionId);
+                            continue; //skip sync section to not create draft for wrong section
+                        }
+                        // no draft,  only workshop - create draft
+                        draft = section.ToWorkshopDraft(existingWorkshop.ProviderId, catottgId.Value);
+                        draft.WorkshopId = existingWorkshop.Id;
+                        draft.MinsportSectionId = existingWorkshop.MinsportSectionId;
+
+                        toCreate.Add(draft);
+                        logger.LogInformation(
+                            "Creating new draft for existing workshop {WorkshopId} from section {SectionId}. ProviderId={ProviderId}",
+                            existingWorkshop.Id, section.SectionId, draft.ProviderId);
+                    }
+                    else
+                    {
+                        // no workshop, no draft - new draft
+                        var providerId = await GetProviderIdAsync(section.OrganizationCode).ConfigureAwait(false);
+                        if (!providerId.HasValue)
+                        {
+                            logger.LogWarning("Skipping section {SectionId} because provider was not found.", section.SectionId);
+                            continue; // skip sections without valid provider
+                        }
+
+                        draft = section.ToWorkshopDraft(providerId.Value, catottgId.Value);
+                        draft.WorkshopDraftContent.InstitutionHierarchyId = hierarchy.Id;
+                        draft.WorkshopDraftContent.InstitutionId = hierarchy.InstitutionId;
+
+                        toCreate.Add(draft);
+                    }
+
+                    //break; // temporary for testing purposes
                 }
                 else
                 {
-                    // no workshop, no draft - new draft
-                    var providerId = await GetProviderIdAsync(section.OrganizationCode).ConfigureAwait(false);
-                    if (!providerId.HasValue)
+                    logger.LogDebug(
+                        "Section {SectionId} not updated (UpdatedInRegistryAt={UpdatedAt}). Last known update={LastUpdate}",
+                        section.SectionId, section.UpdatedInRegistryAt, lastUpdate);
+                }
+            }
+
+            if (toCreate.Any() || toUpdate.Any())
+            {
+                await workshopDraftRepository.RunInTransaction(async () =>
+                {
+                    if (toCreate.Any())
                     {
-                        logger.LogWarning("Skipping section {SectionId} because provider was not found.", section.SectionId);
-                        continue; // skip sections without valid provider
+                        foreach (var draft in toCreate)
+                        {
+                            logger.LogDebug(
+                                "Creating WorkshopDraft. SectionId: {SectionId}, Title: {Title}",
+                                draft.MinsportSectionId, draft.WorkshopDraftContent.Title);
+                        }
+                        await workshopDraftRepository.Create(toCreate).ConfigureAwait(false);
                     }
 
-                    draft = section.ToWorkshopDraft(providerId.Value, catottgId.Value);
-                    draft.WorkshopDraftContent.InstitutionHierarchyId = hierarchy.Id;
-                    draft.WorkshopDraftContent.InstitutionId = hierarchy.InstitutionId;
+                    if (toUpdate.Any())
+                    {
+                        foreach (var draft in toUpdate)
+                        {
+                            logger.LogDebug(
+                                "Updating WorkshopDraft. SectionId: {SectionId}, Title: {Title}, DraftStatus: {DraftStatus}",
+                                draft.MinsportSectionId,
+                                draft.WorkshopDraftContent.Title,
+                                draft.DraftStatus);
+                            await workshopDraftRepository.Update(draft);
+                        }
+                        await workshopDraftRepository.SaveChangesAsync().ConfigureAwait(false);
+                    }
 
-                    toCreate.Add(draft);
-                }
-               
-                break; // temporary for testing purposes
+                    logger.LogInformation(
+                        "Sports sections sync finished. {CreatedCount} created, {UpdatedCount} updated.",
+                        toCreate.Count, toUpdate.Count);
+                });
             }
-            else
-            {
-                logger.LogDebug(
-                    "Section {SectionId} not updated (UpdatedInRegistryAt={UpdatedAt}). Last known update={LastUpdate}",
-                    section.SectionId, section.UpdatedInRegistryAt, lastUpdate);
-            }
+
+            return toCreate.Count + toUpdate.Count;
         }
-
-        if (toCreate.Any() || toUpdate.Any())
+        catch (Exception ex)
         {
-            await workshopDraftRepository.RunInTransaction(async () =>
-            {
-                if (toCreate.Any())
-                {
-                    foreach (var draft in toCreate)
-                    {
-                        logger.LogDebug(
-                            "Creating WorkshopDraft. SectionId: {SectionId}, Title: {Title}",
-                            draft.MinsportSectionId, draft.WorkshopDraftContent.Title);
-                    }
-                    await workshopDraftRepository.Create(toCreate).ConfigureAwait(false);
-                }
-
-                if (toUpdate.Any())
-                {
-                    foreach (var draft in toUpdate)
-                    {
-                        logger.LogDebug(
-                            "Updating WorkshopDraft. SectionId: {SectionId}, Title: {Title}, DraftStatus: {DraftStatus}",
-                            draft.MinsportSectionId,
-                            draft.WorkshopDraftContent.Title,
-                            draft.DraftStatus);
-                        await workshopDraftRepository.Update(draft);
-                    }
-                    await workshopDraftRepository.SaveChangesAsync().ConfigureAwait(false);
-                }
-
-                logger.LogInformation(
-                    "Sports sections sync finished. {CreatedCount} created, {UpdatedCount} updated.",
-                    toCreate.Count, toUpdate.Count);
-            });
+            logger.LogError(ex, "Error during sports sections sync.");
+            return 0;
         }
 
-        return toCreate.Count + toUpdate.Count;
     }
 
     private async Task<long?> TryGetCatottgIdAsync(ExternalSportsSectionDto section)

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
@@ -44,7 +44,7 @@ public class SportsSectionSyncService(
             if (!existingLookup.TryGetValue(section.SectionId, out var workshop))
             {
                 //Create draft
-                toCreate.Add(new Workshop() // WorkshopDraft
+                toCreate.Add(new Workshop() // section.ToWorkshopDraft()
                 {
                     Id = Guid.NewGuid(),
                    

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
@@ -4,6 +4,8 @@ using OutOfSchool.Services.Enums.WorkshopStatus;
 using OutOfSchool.Services.Models.WorkshopDrafts;
 using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.SportsRegistryApiClient.Interfaces;
+using OutOfSchool.SportsRegistryApiClient.Models.External;
+using static System.Collections.Specialized.BitVector32;
 namespace OutOfSchool.BusinessLogic.Services.SportsRegistry;
 public class SportsSectionSyncService(
     ISportsRegistryWorkshopProvider workshopProvider,
@@ -49,7 +51,7 @@ public class SportsSectionSyncService(
         var toUpdate = new List<WorkshopDraft>();
 
         var tempSectionList = sportsSections.Where(s => s.OrganizationCode == "45080641").ToList(); // temporary for testing purposes
-        foreach (var section in tempSectionList ) // check
+        foreach (var section in tempSectionList) 
         //foreach (var section in sportsSections) // check
         {
             existingDraftLookup.TryGetValue(section.SectionId, out var existingDraft);
@@ -62,38 +64,66 @@ public class SportsSectionSyncService(
 
             if (!lastUpdate.HasValue || section.UpdatedInRegistryAt > lastUpdate.Value)
             {
+                // try to retrieve CATOTTGId before creating/updating draft
+                var catottgId = await TryGetCatottgIdAsync(section).ConfigureAwait(false);
+                if (!catottgId.HasValue)
+                { 
+                    continue; // skip sections without valid CATOTTGId
+                }
+
                 WorkshopDraft draft;
 
                 if (existingDraft != null)
                 {
                     // update existing draft
-                    draft = section.MapToExistingDraft(existingDraft);
-                    draft.DraftStatus = WorkshopDraftStatus.PendingModeration; // to ask Dima
+                    draft = section.MapToExistingDraft(existingDraft, catottgId.Value);
+                    draft.DraftStatus = WorkshopDraftStatus.PendingModeration;
                     toUpdate.Add(draft);
+                    logger.LogDebug(
+                        "Updating existing draft for section {SectionId}. DraftId={DraftId}, ProviderId={ProviderId}",
+                        section.SectionId, draft.Id, draft.ProviderId);
                 }
                 else if (existingWorkshop != null)
                 {
+                    if (existingWorkshop.MinsportSectionId != section.SectionId)
+                    {
+                        logger.LogWarning(
+                            "Mismatch between MinsportSectionId and SectionId for workshop {WorkshopId}: expected {Expected}, got {Actual}. Skipping sync for this section.",
+                            existingWorkshop.Id,
+                            existingWorkshop.MinsportSectionId,
+                            section.SectionId);
+                        continue; //skip sync section to not create draft for wrong section
+                    }
                     // no draft,  only workshop - create draft
-                    draft = section.ToWorkshopDraft(existingWorkshop.ProviderId);
-
-                    //draft = existingWorkshop.ToDraft(); // may be this way?
-                    //draft = section.MapToExistingDraft(draft);
+                    draft = section.ToWorkshopDraft(existingWorkshop.ProviderId, catottgId.Value);
+                    draft.WorkshopId = existingWorkshop.Id;
+                    draft.MinsportSectionId = existingWorkshop.MinsportSectionId;
 
                     toCreate.Add(draft);
+                    logger.LogInformation(
+                        "Creating new draft for existing workshop {WorkshopId} from section {SectionId}. ProviderId={ProviderId}",
+                        existingWorkshop.Id, section.SectionId, draft.ProviderId);
                 }
                 else
                 {
                     // no workshop, no draft - new draft
                     var providerId = await GetProviderIdAsync(section.OrganizationCode).ConfigureAwait(false);
                     if (!providerId.HasValue)
+                    {
+                        logger.LogWarning("Skipping section {SectionId} because provider was not found.", section.SectionId);
                         continue; // skip sections without valid provider
-                    draft = section.ToWorkshopDraft(providerId.Value);
+                    }
+                    draft = section.ToWorkshopDraft(providerId.Value, catottgId.Value);
                     toCreate.Add(draft);
                 }
-
-                //  update CATOTTGId
-                draft.CATOTTGId = await GetIdByCatottgCode(section.SectionAddressLocalityDictIdCode) ?? 0;
+               
                 break; // temporary for testing purposes
+            }
+            else
+            {
+                logger.LogDebug(
+                    "Section {SectionId} not updated (UpdatedInRegistryAt={UpdatedAt}). Last known update={LastUpdate}",
+                    section.SectionId, section.UpdatedInRegistryAt, lastUpdate);
             }
         }
 
@@ -134,11 +164,22 @@ public class SportsSectionSyncService(
         return toCreate.Count + toUpdate.Count;
     }
 
-    private async Task<long?> GetIdByCatottgCode(string sectionAddressLocalityDictIdCode)
+    private async Task<long?> TryGetCatottgIdAsync(ExternalSportsSectionDto section)
     {
-        return await codeficatorRepository.GetIdByCodeAsync(sectionAddressLocalityDictIdCode);
+        var catottgId = await codeficatorRepository.GetIdByCodeAsync(section.SectionAddressLocalityDictIdCode)
+            .ConfigureAwait(false);
+
+        if (!catottgId.HasValue)
+        {
+            logger.LogWarning(
+                "Skipping section {SectionId} because CATOTTG code '{CatottgCode}' was not found.",
+                section.SectionId,
+                section.SectionAddressLocalityDictIdCode);
+        }
+
+        return catottgId;
     }
-   
+
     private async Task<Guid?> GetProviderIdAsync(string edrpou)
     {
         return await providerRepository.GetIdByEdrpouAsync(edrpou);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
@@ -10,6 +10,7 @@ public class SportsSectionSyncService(
     IWorkshopDraftRepository workshopDraftRepository,
     IWorkshopRepository workshopRepository,
     ICodeficatorRepository codeficatorRepository,
+    IProviderRepository providerRepository,
     ILogger<SportsSectionSyncService> logger)
     : ISportsSectionSyncService
 {
@@ -47,7 +48,9 @@ public class SportsSectionSyncService(
         var toCreate = new List<WorkshopDraft>();
         var toUpdate = new List<WorkshopDraft>();
 
-        foreach (var section in sportsSections) // check
+        var tempSectionList = sportsSections.Where(s => s.OrganizationCode == "45080641").ToList(); // temporary for testing purposes
+        foreach (var section in tempSectionList ) // check
+        //foreach (var section in sportsSections) // check
         {
             existingDraftLookup.TryGetValue(section.SectionId, out var existingDraft);
             existingLookup.TryGetValue(section.SectionId, out var existingWorkshop);
@@ -55,7 +58,7 @@ public class SportsSectionSyncService(
             DateTimeOffset? lastUpdate = existingDraft?.ModifiedAt
                               ?? (existingWorkshop?.UpdatedAt.HasValue == true
                                   ? new DateTimeOffset(existingWorkshop.UpdatedAt.Value)
-                                  : (DateTimeOffset?)null);
+                                  : null);
 
             if (!lastUpdate.HasValue || section.UpdatedInRegistryAt > lastUpdate.Value)
             {
@@ -81,7 +84,10 @@ public class SportsSectionSyncService(
                 else
                 {
                     // no workshop, no draft - new draft
-                    draft = section.ToWorkshopDraft(GetProviderId());
+                    var providerId = await GetProviderIdAsync(section.OrganizationCode).ConfigureAwait(false);
+                    if (!providerId.HasValue)
+                        continue; // skip sections without valid provider
+                    draft = section.ToWorkshopDraft(providerId.Value);
                     toCreate.Add(draft);
                 }
 
@@ -132,14 +138,9 @@ public class SportsSectionSyncService(
     {
         return await codeficatorRepository.GetIdByCodeAsync(sectionAddressLocalityDictIdCode);
     }
-    private Guid GetProviderIdForExistingWorkshop() // TO DO
+   
+    private async Task<Guid?> GetProviderIdAsync(string edrpou)
     {
-        return Guid.Parse("08da842d-12fc-4865-85c5-ec6e6142abad"); // sleep@gmail.com temporary
-    }
-
-
-    private Guid GetProviderId() // TO DO 
-    {
-        return Guid.Parse("08da842d-12fc-4865-85c5-ec6e6142abad"); // sleep@gmail.com temporary
+        return await providerRepository.GetIdByEdrpouAsync(edrpou);
     }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
@@ -1,11 +1,11 @@
 ﻿//using System.Linq;
+using Microsoft.Extensions.Options;
 using OutOfSchool.BusinessLogic.Util.Mappers;
 using OutOfSchool.Services.Enums.WorkshopStatus;
 using OutOfSchool.Services.Models.WorkshopDrafts;
 using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.SportsRegistryApiClient.Interfaces;
 using OutOfSchool.SportsRegistryApiClient.Models.External;
-using static System.Collections.Specialized.BitVector32;
 namespace OutOfSchool.BusinessLogic.Services.SportsRegistry;
 public class SportsSectionSyncService(
     ISportsRegistryWorkshopProvider workshopProvider,
@@ -13,6 +13,8 @@ public class SportsSectionSyncService(
     IWorkshopRepository workshopRepository,
     ICodeficatorRepository codeficatorRepository,
     IProviderRepository providerRepository,
+    IInstitutionHierarchyRepository hierarchyRepository,
+   // IOptions<InstitutionOptions> institutionOptions,
     ILogger<SportsSectionSyncService> logger)
     : ISportsSectionSyncService
 {
@@ -47,6 +49,11 @@ public class SportsSectionSyncService(
         var existingLookup = existingWorkshops.ToDictionary(w => w.MinsportSectionId!.Value);
         var existingDraftLookup = existingWorkshopDrafts.ToDictionary(w => w.MinsportSectionId!.Value);
 
+        var existingHierarchies = await hierarchyRepository
+           .GetByFilter(x => x.SportRegistryIdCode.HasValue)
+           .ConfigureAwait(false);
+        var lookupHierarchy = existingHierarchies.ToDictionary(x => x.SportRegistryIdCode!.Value);
+       
         var toCreate = new List<WorkshopDraft>();
         var toUpdate = new List<WorkshopDraft>();
 
@@ -62,8 +69,19 @@ public class SportsSectionSyncService(
                                   ? new DateTimeOffset(existingWorkshop.UpdatedAt.Value)
                                   : null);
 
+
             if (!lastUpdate.HasValue || section.UpdatedInRegistryAt > lastUpdate.Value)
             {
+                // try to find hierarchy for section's sport kind
+                if (!lookupHierarchy.TryGetValue(section.SectionSportKindDictIdCode, out var hierarchy))
+                {
+                    logger.LogWarning(
+                        "Skipping section {SectionId} because no InstitutionHierarchy found for SportKindIdCode {SportKindIdCode}.",
+                        section.SectionId,
+                        section.SectionSportKindDictIdCode);
+                    continue; // skip sections without valid hierarchy
+                }
+
                 // try to retrieve CATOTTGId before creating/updating draft
                 var catottgId = await TryGetCatottgIdAsync(section).ConfigureAwait(false);
                 if (!catottgId.HasValue)
@@ -78,6 +96,9 @@ public class SportsSectionSyncService(
                     // update existing draft
                     draft = section.MapToExistingDraft(existingDraft, catottgId.Value);
                     draft.DraftStatus = WorkshopDraftStatus.PendingModeration;
+                    draft.WorkshopDraftContent.InstitutionHierarchyId = hierarchy.Id; // ??
+                    draft.WorkshopDraftContent.InstitutionId = hierarchy.InstitutionId; // ??
+
                     toUpdate.Add(draft);
                     logger.LogDebug(
                         "Updating existing draft for section {SectionId}. DraftId={DraftId}, ProviderId={ProviderId}",
@@ -113,7 +134,11 @@ public class SportsSectionSyncService(
                         logger.LogWarning("Skipping section {SectionId} because provider was not found.", section.SectionId);
                         continue; // skip sections without valid provider
                     }
+
                     draft = section.ToWorkshopDraft(providerId.Value, catottgId.Value);
+                    draft.WorkshopDraftContent.InstitutionHierarchyId = hierarchy.Id;
+                    draft.WorkshopDraftContent.InstitutionId = hierarchy.InstitutionId;
+
                     toCreate.Add(draft);
                 }
                
@@ -151,6 +176,7 @@ public class SportsSectionSyncService(
                             draft.MinsportSectionId,
                             draft.WorkshopDraftContent.Title,
                             draft.DraftStatus);
+                        await workshopDraftRepository.Update(draft);
                     }
                     await workshopDraftRepository.SaveChangesAsync().ConfigureAwait(false);
                 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
@@ -1,6 +1,4 @@
-﻿//using System.Linq;
-using Microsoft.Extensions.Options;
-using OutOfSchool.BusinessLogic.Util.Mappers;
+﻿using OutOfSchool.BusinessLogic.Util.Mappers;
 using OutOfSchool.Services.Enums.WorkshopStatus;
 using OutOfSchool.Services.Models.WorkshopDrafts;
 using OutOfSchool.Services.Repository.Api;
@@ -14,7 +12,6 @@ public class SportsSectionSyncService(
     ICodeficatorRepository codeficatorRepository,
     IProviderRepository providerRepository,
     IInstitutionHierarchyRepository hierarchyRepository,
-   // IOptions<InstitutionOptions> institutionOptions,
     ILogger<SportsSectionSyncService> logger)
     : ISportsSectionSyncService
 {
@@ -22,7 +19,18 @@ public class SportsSectionSyncService(
     {
         logger.LogInformation("Starting synchronization of workshops (sports sections) with Sports Registry...");
 
-        var response = await workshopProvider.GetAllSportsSectionsAsync().ConfigureAwait(false);
+        var updatedAtTo = DateTimeOffset.UtcNow;
+        var updatedAtFrom = updatedAtTo.AddMinutes(-30);
+
+        logger.LogInformation("Fetching only updated sections from {From} to {To}", updatedAtFrom, updatedAtTo);
+        
+        var response = await workshopProvider.GetAllSportsSectionsAsync(updatedAtFrom, updatedAtTo).ConfigureAwait(false);
+
+        if (response.TryGetLeft(out var error)) // ????? if filtered fetch failed, fallback to full fetch
+        {
+            logger.LogWarning("Filtered fetch failed, fallback to full fetch");
+            response = await workshopProvider.GetAllSportsSectionsAsync().ConfigureAwait(false);
+        }
 
         var sportsSections = response.Match(
             error => throw new InvalidOperationException($"Failed to fetch sports sections: {error.Message}"),
@@ -96,8 +104,8 @@ public class SportsSectionSyncService(
                     // update existing draft
                     draft = section.MapToExistingDraft(existingDraft, catottgId.Value);
                     draft.DraftStatus = WorkshopDraftStatus.PendingModeration;
-                    draft.WorkshopDraftContent.InstitutionHierarchyId = hierarchy.Id; // ??
-                    draft.WorkshopDraftContent.InstitutionId = hierarchy.InstitutionId; // ??
+                    draft.WorkshopDraftContent.InstitutionHierarchyId = hierarchy.Id;
+                    draft.WorkshopDraftContent.InstitutionId = hierarchy.InstitutionId;
 
                     toUpdate.Add(draft);
                     logger.LogDebug(

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Services/SportsRegistry/SportsSectionSyncService.cs
@@ -1,0 +1,86 @@
+﻿using OutOfSchool.Services.Models.WorkshopDrafts;
+using OutOfSchool.Services.Repository.Api;
+using OutOfSchool.SportsRegistryApiClient.Interfaces;
+using System.Linq;
+
+namespace OutOfSchool.BusinessLogic.Services.SportsRegistry;
+public class SportsSectionSyncService(
+    ISportsRegistryWorkshopProvider workshopProvider,
+    IWorkshopRepository workshopRepository,
+    ILogger<SportsSectionSyncService> logger)
+    : ISportsSectionSyncService
+{
+    public async Task<int> SyncSportsSectionsAsync()
+    {
+        logger.LogInformation("Starting synchronization of workshops (sports sections) with Sports Registry...");
+
+        var response = await workshopProvider.GetAllSportsSectionsAsync().ConfigureAwait(false);
+
+        var sportsSections = response.Match(
+            error => throw new InvalidOperationException($"Failed to fetch sports sections: {error.Message}"),
+            success => success);
+
+        if (!sportsSections.Any())
+        {
+            logger.LogWarning("No sports sections were fetched from Sports Registry.");
+            return 0;
+        }
+
+        var registrySectionsId = sportsSections
+            .Select(x => x.SectionId)
+            .ToList();
+
+        var existingWorkshops = await workshopRepository
+            .GetByFilter(w => w.MinsportSectionId.HasValue && registrySectionsId.Contains(w.MinsportSectionId.Value))
+            .ConfigureAwait(false);
+
+        var existingLookup = existingWorkshops.ToDictionary(w => w.MinsportSectionId!.Value);
+
+        var toCreate = new List<Workshop>(); // WorkshopDraft?
+        var toUpdate = new List<Workshop>();
+
+        foreach (var section in sportsSections)
+        {
+            if (!existingLookup.TryGetValue(section.SectionId, out var workshop))
+            {
+                //Create draft
+                toCreate.Add(new Workshop() // WorkshopDraft
+                {
+                    Id = Guid.NewGuid(),
+                   
+                    Title = section.SectionName,
+                  
+                    // TODO: map other fields
+                });
+            }
+            //else if (section.UpdatedAt > workshop.RegistrySyncDate)
+            //{
+            //    // Update draft
+            //    workshop.Title = section.Name;
+              //}
+        }
+
+        // need to review
+        if (toCreate.Any() || toUpdate.Any())
+        {
+            await workshopRepository.RunInTransaction(async () =>
+            {
+                if (toCreate.Any())
+                {
+                    await workshopRepository.Create(toCreate).ConfigureAwait(false);
+                }
+
+                if (toUpdate.Any())
+                {
+                    await workshopRepository.SaveChangesAsync().ConfigureAwait(false);
+                }
+
+                logger.LogInformation(
+                    "Sports sections sync finished. {CreatedCount} created, {UpdatedCount} updated.",
+                    toCreate.Count, toUpdate.Count);
+            });
+        }
+
+        return toCreate.Count + toUpdate.Count;
+    }
+}

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mappers/ExternalSportsSectionToWorkshopDraftMapper.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mappers/ExternalSportsSectionToWorkshopDraftMapper.cs
@@ -44,10 +44,17 @@ public static class ExternalSportsSectionToWorkshopDraftMapper
         content.ShortTitle = section.SectionName;
         content.EnrollmentProcedureDescription = section.SectionRegistrationFlow ?? string.Empty;
         content.CompetitiveSelectionDescription = section.SectionSelectionCriteria ?? string.Empty;
-        content.Price = section.SectionPracticeCost;
         content.MinAge = section.SectionAgeFrom;
         content.MaxAge = section.SectionAgeTo;
         content.IsChampionPath = section.SectionIsInShlyahProject;
+
+        content.IsPaid = section.SectionPracticeCost > 0;
+        content.Price = content.IsPaid ? section.SectionPracticeCost : 0;
+        content.PayRate = PayRateType.Month;
+        
+        content.AvailableSeats = (uint)(section.SectionMaxStudentsAmount > MinSportMaxStudentsLimit
+            ? MinSportMaxStudentsLimit
+            : section.SectionMaxStudentsAmount);
 
         content.Keywords = string.IsNullOrWhiteSpace(section.SectionSportKindDictName)
             ? new List<string>()
@@ -116,31 +123,30 @@ public static class ExternalSportsSectionToWorkshopDraftMapper
         }
 
         content.Contacts = new List<Contacts>
-    {
-        new Contacts
         {
-            Title = "Контакт секції",
-            IsDefault = true,
-            Address = new ContactsAddress
+            new Contacts
             {
-                Street = section.SectionAddressStreet ?? string.Empty,
-                BuildingNumber = section.SectionAddressHouse ?? string.Empty,
-                CATOTTGId = catottgId
-            },
-            Phones = phones,
-            Emails = new List<Email>
-            {
-                new Email { Type = "Основний", Address = section.SectionEmail ?? string.Empty }
-            },
-            SocialNetworks = socialNetworks
-        }
-    };
+                Title = "Контакт секції",
+                IsDefault = true,
+                Address = new ContactsAddress
+                {
+                    Street = section.SectionAddressStreet ?? string.Empty,
+                    BuildingNumber = section.SectionAddressHouse ?? string.Empty,
+                    CATOTTGId = catottgId
+                },
+                Phones = phones,
+                Emails = new List<Email>
+                {
+                    new Email { Type = "Основний", Address = section.SectionEmail ?? string.Empty }
+                },
+                SocialNetworks = socialNetworks
+            }
+        };
 
         content.FormOfLearning = ToFormLearning(section.SectionPracticeFormat);
         content.LanguageOfEducationId = 2;
         content.LanguageOfEducationName = "Українська";
-        content.PayRate = PayRateType.Month;
-
+       
         return content;
     }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mappers/ExternalSportsSectionToWorkshopDraftMapper.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mappers/ExternalSportsSectionToWorkshopDraftMapper.cs
@@ -1,14 +1,11 @@
 ﻿using OutOfSchool.Common.Enums;
-using OutOfSchool.Common.Enums.Workshop;
 using OutOfSchool.Services.Enums;
 using OutOfSchool.Services.Enums.WorkshopStatus;
 using OutOfSchool.Services.Models.ContactInfo;
 using OutOfSchool.Services.Models.WorkshopDrafts;
-using OutOfSchool.SportsRegistryApiClient.Models.Enums;
 using OutOfSchool.SportsRegistryApiClient.Models.External;
 using System.Diagnostics;
 using System.Text.Json;
-using static System.Collections.Specialized.BitVector32;
 
 namespace OutOfSchool.BusinessLogic.Util.Mappers;
 
@@ -36,149 +33,6 @@ public static class ExternalSportsSectionToWorkshopDraftMapper
         return draft;
     }
 
-
-    //public static WorkshopDraft ToWorkshopDraft(this ExternalSportsSectionDto externalDto, Guid providerId)
-    //{
-
-    //   // long catottgId = 0;
-
-    //    var phones = new List<PhoneNumber>();
-    //    if (!string.IsNullOrWhiteSpace(externalDto.SectionPhones))
-    //    {
-    //        try
-    //        {
-    //            var parsedPhones = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(externalDto.SectionPhones);
-    //            if (parsedPhones is not null)
-    //            {
-    //                phones = parsedPhones
-    //                    .Select(p => new PhoneNumber
-    //                    {
-    //                        Type = "Основний",
-    //                        Number = p.GetValueOrDefault("phone") ?? string.Empty
-    //                    })
-    //                    .ToList();
-    //            }
-    //        }
-    //        catch
-    //        {
-    //            // if string is not valid JSON, ignore phones
-    //        }
-    //    }
-
-    //    var socialNetworks = new List<SocialNetwork>();
-    //    if (!string.IsNullOrWhiteSpace(externalDto.SectionFacebookUrl))
-    //    {
-    //        socialNetworks.Add(new SocialNetwork
-    //        {
-    //            Type = SocialNetworkContactType.Facebook,
-    //            Url = externalDto.SectionFacebookUrl
-    //        });
-    //    }
-    //    if (!string.IsNullOrWhiteSpace(externalDto.SectionInstagramUrl))
-    //    {
-    //        socialNetworks.Add(new SocialNetwork
-    //        {
-    //            Type = SocialNetworkContactType.Instagram,
-    //            Url = externalDto.SectionInstagramUrl
-    //        });
-    //    }
-    //    if (!string.IsNullOrWhiteSpace(externalDto.SectionUrl))
-    //    {
-    //        socialNetworks.Add(new SocialNetwork
-    //        {
-    //            Type = SocialNetworkContactType.Website,
-    //            Url = externalDto.SectionUrl
-    //        });
-    //    }
-
-    //    //if need to create keywords from sport kind name
-    //    List<string> keywords = string.IsNullOrWhiteSpace(externalDto.SectionSportKindDictName)
-    //    ? new()
-    //    : new() { externalDto.SectionSportKindDictName };
-
-    //    return new WorkshopDraft
-    //    {
-    //        Id = Guid.NewGuid(),
-    //        ProviderId = providerId,
-    //        MinsportSectionId = externalDto.SectionId,
-    //       // CATOTTGId = catottgId,
-
-    //        WorkshopDraftContent = new WorkshopDraftContent
-    //        {
-    //            Title = externalDto.SectionName,
-    //            ShortTitle = externalDto.SectionName,
-    //            EnrollmentProcedureDescription = externalDto.SectionRegistrationFlow ?? string.Empty,
-    //            CompetitiveSelectionDescription = externalDto.SectionSelectionCriteria ?? string.Empty,
-
-    //            FormOfLearning = ToFormLearning(externalDto.SectionPracticeFormat),
-    //            Price = externalDto.SectionPracticeCost,
-    //            AvailableSeats = (uint)Math.Min(externalDto.SectionMaxStudentsAmount, MinSportMaxStudentsLimit),
-
-    //            MinAge = externalDto.SectionAgeFrom,
-    //            MaxAge = externalDto.SectionAgeTo,
-    //            IsChampionPath = externalDto.SectionIsInShlyahProject,
-
-    //            StudyPeriodStartDate = DateOnly.FromDateTime(externalDto.SectionPracticePeriodDateFrom),
-    //            StudyPeriodEndDate = DateOnly.FromDateTime(externalDto.SectionPracticePeriodDateTo),
-
-    //            WorkshopDescriptionItems = new List<WorkshopDescriptionItemDraft>
-    //            {
-    //                new WorkshopDescriptionItemDraft
-    //                {
-    //                    Description = externalDto.SectionDescription ?? string.Empty
-    //                }
-    //            },
-
-    //            Keywords = keywords,
-
-    //            DateTimeRanges = MapSchedule(externalDto.SectionSchedule),
-
-    //            Contacts = new List<Contacts>
-    //            {
-    //                new Contacts
-    //                {
-    //                    Title = "Контакт секції",
-    //                    IsDefault = true,
-    //                    Address = new ContactsAddress
-    //                    {
-    //                        Street = externalDto.SectionAddressStreet ?? string.Empty,
-    //                        BuildingNumber = externalDto.SectionAddressHouse ?? string.Empty,
-    //                        //CATOTTGId = catottgId // ????
-    //                    },
-    //                    Phones = phones,
-    //                    Emails = new List<Email>
-    //                    {
-    //                        new Email
-    //                        {
-    //                            Type = "Основний",
-    //                            Address = externalDto.SectionEmail ?? string.Empty
-    //                        }
-    //                    },
-    //                    SocialNetworks = socialNetworks
-    //                }
-    //            },
-    //        },
-
-    //        // TO DO: map images
-    //        CoverImageId = externalDto.SectionTitlePhoto?.FirstOrDefault()?.Id.ToString() ?? string.Empty,
-    //        //ImageIds = externalDto.SectionPhotos?.Select(p => p.Id.ToString()).ToList() ?? new List<string>(),
-    //        DraftStatus = WorkshopDraftStatus.PendingModeration
-    //    };
-    //}
-
-    //public static WorkshopDraft MapToExistingDraft(this ExternalSportsSectionDto section, WorkshopDraft draft)
-    //{
-    //    draft.WorkshopDraftContent.Title = section.SectionName;
-    //    draft.WorkshopDraftContent.ShortTitle = section.SectionName;
-    //    draft.WorkshopDraftContent.EnrollmentProcedureDescription = section.SectionRegistrationFlow;
-    //    draft.WorkshopDraftContent.Price = section.SectionPracticeCost;
-    //    draft.WorkshopDraftContent.MinAge = section.SectionAgeFrom;
-    //    draft.WorkshopDraftContent.MaxAge = section.SectionAgeTo;
-
-    //    // TO DO: others fields  Contacts, ...
-    //    return draft;
-    //}
-
     private static WorkshopDraftContent MapContentFromExternal(
     ExternalSportsSectionDto section,
     WorkshopDraftContent? existingContent = null,
@@ -186,7 +40,6 @@ public static class ExternalSportsSectionToWorkshopDraftMapper
     {
         var content = existingContent ?? new WorkshopDraftContent();
 
-        // Загальні поля
         content.Title = section.SectionName;
         content.ShortTitle = section.SectionName;
         content.EnrollmentProcedureDescription = section.SectionRegistrationFlow ?? string.Empty;
@@ -196,25 +49,21 @@ public static class ExternalSportsSectionToWorkshopDraftMapper
         content.MaxAge = section.SectionAgeTo;
         content.IsChampionPath = section.SectionIsInShlyahProject;
 
-        // Keywords
         content.Keywords = string.IsNullOrWhiteSpace(section.SectionSportKindDictName)
             ? new List<string>()
             : new List<string> { section.SectionSportKindDictName };
 
-        // Study period
         content.StudyPeriodStartDate = DateOnly.FromDateTime(section.SectionPracticePeriodDateFrom);
         content.StudyPeriodEndDate = DateOnly.FromDateTime(section.SectionPracticePeriodDateTo);
 
-        // WorkshopDescriptionItems
         content.WorkshopDescriptionItems = new List<WorkshopDescriptionItemDraft>
-    {
-        new WorkshopDescriptionItemDraft
         {
-            Description = section.SectionDescription ?? string.Empty
-        }
-    };
+            new WorkshopDescriptionItemDraft
+            {
+                Description = section.SectionDescription ?? string.Empty
+            }
+        };
 
-        // DateTimeRanges
         content.DateTimeRanges = MapSchedule(section.SectionSchedule);
 
         // Contacts
@@ -235,7 +84,7 @@ public static class ExternalSportsSectionToWorkshopDraftMapper
             }
             catch
             {
-                // некоректний JSON – ігноруємо телефони
+                // invalid JSON – ignore phones
             }
         }
 
@@ -286,8 +135,10 @@ public static class ExternalSportsSectionToWorkshopDraftMapper
         }
     };
 
-        // Можна додати додаткові поля (Coverage, WorkshopType, FormOfLearning тощо)
         content.FormOfLearning = ToFormLearning(section.SectionPracticeFormat);
+        content.LanguageOfEducationId = 2;
+        content.LanguageOfEducationName = "Українська";
+        content.PayRate = PayRateType.Month;
 
         return content;
     }
@@ -342,27 +193,6 @@ public static class ExternalSportsSectionToWorkshopDraftMapper
             return new List<DateTimeRangeDraft>();
         }
     }
-
-    //private static List<DateTimeRangeDraft> MapSchedule(string? sectionScheduleJson)
-    //{
-    //    if (string.IsNullOrWhiteSpace(sectionScheduleJson))
-    //        return new List<DateTimeRangeDraft>();
-
-    //    try
-    //    {
-    //        var items = JsonSerializer.Deserialize<List<ExternalScheduleItem>>(sectionScheduleJson);
-    //        return items?.Select(i => new DateTimeRangeDraft
-    //        {
-    //            StartTime = TimeOnly.Parse(i.SectionScheduleTimeFrom),
-    //            EndTime = TimeOnly.Parse(i.SectionScheduleTimeTo),
-    //            Workdays = new HashSet<DaysBitMask> { ToDaysBitMask(i.SectionScheduleWeekday) }
-    //        }).ToList() ?? new List<DateTimeRangeDraft>();
-    //    }
-    //    catch
-    //    {
-    //        return new List<DateTimeRangeDraft>();
-    //    }
-    //}
 
     private static DaysBitMask ToDaysBitMask(string weekday) => weekday.ToUpperInvariant() switch
     {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mappers/ExternalSportsSectionToWorkshopDraftMapper.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mappers/ExternalSportsSectionToWorkshopDraftMapper.cs
@@ -1,0 +1,162 @@
+﻿using OutOfSchool.Common.Enums;
+using OutOfSchool.Common.Enums.Workshop;
+using OutOfSchool.Services.Enums;
+using OutOfSchool.Services.Enums.WorkshopStatus;
+using OutOfSchool.Services.Models.ContactInfo;
+using OutOfSchool.Services.Models.WorkshopDrafts;
+using OutOfSchool.SportsRegistryApiClient.Models.Enums;
+using OutOfSchool.SportsRegistryApiClient.Models.External;
+using System.Text.Json;
+
+namespace OutOfSchool.BusinessLogic.Util.Mappers;
+
+public static class ExternalSportsSectionToWorkshopDraftMapper
+{
+    private const int MinSportMaxStudentsLimit = 1000;
+
+    public static WorkshopDraft ToWorkshopDraft(this ExternalSportsSectionDto externalDto, Guid providerId)
+    {
+       
+        long catottgId = 0;
+       
+        var phones = new List<PhoneNumber>();
+        if (!string.IsNullOrWhiteSpace(externalDto.SectionPhones))
+        {
+            try
+            {
+                var parsedPhones = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(externalDto.SectionPhones);
+                if (parsedPhones is not null)
+                {
+                    phones = parsedPhones
+                        .Select(p => new PhoneNumber
+                        {
+                            Type = "Основний",
+                            Number = p.GetValueOrDefault("phone") ?? string.Empty
+                        })
+                        .ToList();
+                }
+            }
+            catch
+            {
+                // if string is not valid JSON, ignore phones
+            }
+        }
+
+        var socialNetworks = new List<SocialNetwork>();
+        if (!string.IsNullOrWhiteSpace(externalDto.SectionFacebookUrl))
+        {
+            socialNetworks.Add(new SocialNetwork
+            {
+                Type = SocialNetworkContactType.Facebook,
+                Url = externalDto.SectionFacebookUrl
+            });
+        }
+        if (!string.IsNullOrWhiteSpace(externalDto.SectionInstagramUrl))
+        {
+            socialNetworks.Add(new SocialNetwork
+            {
+                Type = SocialNetworkContactType.Instagram,
+                Url = externalDto.SectionInstagramUrl
+            });
+        }
+        if (!string.IsNullOrWhiteSpace(externalDto.SectionUrl))
+        {
+            socialNetworks.Add(new SocialNetwork
+            {
+                Type = SocialNetworkContactType.Website,
+                Url = externalDto.SectionUrl
+            });
+        }
+
+        return new WorkshopDraft
+        {
+            Id = Guid.NewGuid(),
+            ProviderId = providerId,
+            MinsportSectionId = externalDto.SectionId,
+            CATOTTGId = catottgId,
+
+            WorkshopDraftContent = new WorkshopDraftContent
+            {
+                Title = externalDto.SectionName,
+                ShortTitle = externalDto.SectionName,
+                EnrollmentProcedureDescription = externalDto.SectionRegistrationFlow ?? string.Empty,
+                CompetitiveSelectionDescription = externalDto.SectionSelectionCriteria ?? string.Empty,
+
+                FormOfLearning = ToFormLearning(externalDto.SectionPracticeFormat),
+                Price = externalDto.SectionPracticeCost,
+                AvailableSeats = (uint)Math.Min(externalDto.SectionMaxStudentsAmount, MinSportMaxStudentsLimit),
+
+                MinAge = externalDto.SectionAgeFrom,
+                MaxAge = externalDto.SectionAgeTo,
+                IsChampionPath = externalDto.SectionIsInShlyahProject,
+
+                StudyPeriodStartDate = DateOnly.FromDateTime(externalDto.SectionPracticePeriodDateFrom),
+                StudyPeriodEndDate = DateOnly.FromDateTime(externalDto.SectionPracticePeriodDateTo),
+
+                WorkshopDescriptionItems = new List<WorkshopDescriptionItemDraft>
+                {
+                    new WorkshopDescriptionItemDraft
+                    {
+                        Description = externalDto.SectionDescription ?? string.Empty
+                    }
+                },
+
+                // TODO: map SectionSchedule JSON  DateTimeRangeDraft
+                DateTimeRanges = new List<DateTimeRangeDraft>(),
+
+                Contacts = new List<Contacts>
+                {
+                    new Contacts
+                    {
+                        Title = "Контакт секції",
+                        IsDefault = true,
+                        Address = new ContactsAddress
+                        {
+                            Street = externalDto.SectionAddressStreet ?? string.Empty,
+                            BuildingNumber = externalDto.SectionAddressHouse ?? string.Empty,
+                            CATOTTGId = catottgId
+                        },
+                        Phones = phones,
+                        Emails = new List<Email>
+                        {
+                            new Email
+                            {
+                                Type = "Основний",
+                                Address = externalDto.SectionEmail ?? string.Empty
+                            }
+                        },
+                        SocialNetworks = socialNetworks
+                    }
+                },
+            },
+
+            // TO DO: map images
+            CoverImageId = externalDto.SectionTitlePhoto?.FirstOrDefault()?.Id.ToString() ?? string.Empty,
+            //ImageIds = externalDto.SectionPhotos?.Select(p => p.Id.ToString()).ToList() ?? new List<string>(),
+            DraftStatus = WorkshopDraftStatus.Draft
+        };
+    }
+
+    public static WorkshopDraft MapToExistingDraft(this ExternalSportsSectionDto section, WorkshopDraft draft)
+    {
+        draft.WorkshopDraftContent.Title = section.SectionName;
+        draft.WorkshopDraftContent.ShortTitle = section.SectionName;
+        draft.WorkshopDraftContent.EnrollmentProcedureDescription = section.SectionRegistrationFlow;
+        draft.WorkshopDraftContent.Price = section.SectionPracticeCost;
+        draft.WorkshopDraftContent.MinAge = section.SectionAgeFrom;
+        draft.WorkshopDraftContent.MaxAge = section.SectionAgeTo;
+
+        // TO DO: others fields  Contacts, ...
+        return draft;
+    }
+
+    private static FormOfLearning ToFormLearning(string? sectionPracticeFormat)
+        => sectionPracticeFormat?.ToUpperInvariant() switch
+        {
+            "ONLINE" => FormOfLearning.Online,
+            "OFFLINE" => FormOfLearning.Offline,
+            "HYBRID" => FormOfLearning.Mixed,
+            _ => FormOfLearning.Offline // default fallback
+        };
+}
+

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mappers/ExternalSportsSectionToWorkshopDraftMapper.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mappers/ExternalSportsSectionToWorkshopDraftMapper.cs
@@ -6,149 +6,292 @@ using OutOfSchool.Services.Models.ContactInfo;
 using OutOfSchool.Services.Models.WorkshopDrafts;
 using OutOfSchool.SportsRegistryApiClient.Models.Enums;
 using OutOfSchool.SportsRegistryApiClient.Models.External;
+using System.Diagnostics;
 using System.Text.Json;
+using static System.Collections.Specialized.BitVector32;
 
 namespace OutOfSchool.BusinessLogic.Util.Mappers;
 
 public static class ExternalSportsSectionToWorkshopDraftMapper
 {
     private const int MinSportMaxStudentsLimit = 1000;
-
-    public static WorkshopDraft ToWorkshopDraft(this ExternalSportsSectionDto externalDto, Guid providerId)
+    public static WorkshopDraft ToWorkshopDraft(this ExternalSportsSectionDto section, Guid providerId, long catottgId)
     {
-       
-        long catottgId = 0;
-       
-        var phones = new List<PhoneNumber>();
-        if (!string.IsNullOrWhiteSpace(externalDto.SectionPhones))
-        {
-            try
-            {
-                var parsedPhones = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(externalDto.SectionPhones);
-                if (parsedPhones is not null)
-                {
-                    phones = parsedPhones
-                        .Select(p => new PhoneNumber
-                        {
-                            Type = "Основний",
-                            Number = p.GetValueOrDefault("phone") ?? string.Empty
-                        })
-                        .ToList();
-                }
-            }
-            catch
-            {
-                // if string is not valid JSON, ignore phones
-            }
-        }
-
-        var socialNetworks = new List<SocialNetwork>();
-        if (!string.IsNullOrWhiteSpace(externalDto.SectionFacebookUrl))
-        {
-            socialNetworks.Add(new SocialNetwork
-            {
-                Type = SocialNetworkContactType.Facebook,
-                Url = externalDto.SectionFacebookUrl
-            });
-        }
-        if (!string.IsNullOrWhiteSpace(externalDto.SectionInstagramUrl))
-        {
-            socialNetworks.Add(new SocialNetwork
-            {
-                Type = SocialNetworkContactType.Instagram,
-                Url = externalDto.SectionInstagramUrl
-            });
-        }
-        if (!string.IsNullOrWhiteSpace(externalDto.SectionUrl))
-        {
-            socialNetworks.Add(new SocialNetwork
-            {
-                Type = SocialNetworkContactType.Website,
-                Url = externalDto.SectionUrl
-            });
-        }
-
         return new WorkshopDraft
         {
             Id = Guid.NewGuid(),
             ProviderId = providerId,
-            MinsportSectionId = externalDto.SectionId,
+            MinsportSectionId = section.SectionId,
             CATOTTGId = catottgId,
-
-            WorkshopDraftContent = new WorkshopDraftContent
-            {
-                Title = externalDto.SectionName,
-                ShortTitle = externalDto.SectionName,
-                EnrollmentProcedureDescription = externalDto.SectionRegistrationFlow ?? string.Empty,
-                CompetitiveSelectionDescription = externalDto.SectionSelectionCriteria ?? string.Empty,
-
-                FormOfLearning = ToFormLearning(externalDto.SectionPracticeFormat),
-                Price = externalDto.SectionPracticeCost,
-                AvailableSeats = (uint)Math.Min(externalDto.SectionMaxStudentsAmount, MinSportMaxStudentsLimit),
-
-                MinAge = externalDto.SectionAgeFrom,
-                MaxAge = externalDto.SectionAgeTo,
-                IsChampionPath = externalDto.SectionIsInShlyahProject,
-
-                StudyPeriodStartDate = DateOnly.FromDateTime(externalDto.SectionPracticePeriodDateFrom),
-                StudyPeriodEndDate = DateOnly.FromDateTime(externalDto.SectionPracticePeriodDateTo),
-
-                WorkshopDescriptionItems = new List<WorkshopDescriptionItemDraft>
-                {
-                    new WorkshopDescriptionItemDraft
-                    {
-                        Description = externalDto.SectionDescription ?? string.Empty
-                    }
-                },
-
-                // TODO: map SectionSchedule JSON  DateTimeRangeDraft
-                DateTimeRanges = new List<DateTimeRangeDraft>(),
-
-                Contacts = new List<Contacts>
-                {
-                    new Contacts
-                    {
-                        Title = "Контакт секції",
-                        IsDefault = true,
-                        Address = new ContactsAddress
-                        {
-                            Street = externalDto.SectionAddressStreet ?? string.Empty,
-                            BuildingNumber = externalDto.SectionAddressHouse ?? string.Empty,
-                            CATOTTGId = catottgId
-                        },
-                        Phones = phones,
-                        Emails = new List<Email>
-                        {
-                            new Email
-                            {
-                                Type = "Основний",
-                                Address = externalDto.SectionEmail ?? string.Empty
-                            }
-                        },
-                        SocialNetworks = socialNetworks
-                    }
-                },
-            },
-
-            // TO DO: map images
-            CoverImageId = externalDto.SectionTitlePhoto?.FirstOrDefault()?.Id.ToString() ?? string.Empty,
-            //ImageIds = externalDto.SectionPhotos?.Select(p => p.Id.ToString()).ToList() ?? new List<string>(),
-            DraftStatus = WorkshopDraftStatus.Draft
+            WorkshopDraftContent = MapContentFromExternal(section, null, catottgId),
+            CoverImageId = section.SectionTitlePhoto?.FirstOrDefault()?.Id.ToString() ?? string.Empty,
+            DraftStatus = WorkshopDraftStatus.PendingModeration
         };
     }
 
-    public static WorkshopDraft MapToExistingDraft(this ExternalSportsSectionDto section, WorkshopDraft draft)
+    public static WorkshopDraft MapToExistingDraft(this ExternalSportsSectionDto section, WorkshopDraft draft, long catottgId)
     {
-        draft.WorkshopDraftContent.Title = section.SectionName;
-        draft.WorkshopDraftContent.ShortTitle = section.SectionName;
-        draft.WorkshopDraftContent.EnrollmentProcedureDescription = section.SectionRegistrationFlow;
-        draft.WorkshopDraftContent.Price = section.SectionPracticeCost;
-        draft.WorkshopDraftContent.MinAge = section.SectionAgeFrom;
-        draft.WorkshopDraftContent.MaxAge = section.SectionAgeTo;
-
-        // TO DO: others fields  Contacts, ...
+        draft.WorkshopDraftContent = MapContentFromExternal(section, draft.WorkshopDraftContent, catottgId);
+        draft.DraftStatus = WorkshopDraftStatus.PendingModeration;
         return draft;
     }
+
+
+    //public static WorkshopDraft ToWorkshopDraft(this ExternalSportsSectionDto externalDto, Guid providerId)
+    //{
+
+    //   // long catottgId = 0;
+
+    //    var phones = new List<PhoneNumber>();
+    //    if (!string.IsNullOrWhiteSpace(externalDto.SectionPhones))
+    //    {
+    //        try
+    //        {
+    //            var parsedPhones = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(externalDto.SectionPhones);
+    //            if (parsedPhones is not null)
+    //            {
+    //                phones = parsedPhones
+    //                    .Select(p => new PhoneNumber
+    //                    {
+    //                        Type = "Основний",
+    //                        Number = p.GetValueOrDefault("phone") ?? string.Empty
+    //                    })
+    //                    .ToList();
+    //            }
+    //        }
+    //        catch
+    //        {
+    //            // if string is not valid JSON, ignore phones
+    //        }
+    //    }
+
+    //    var socialNetworks = new List<SocialNetwork>();
+    //    if (!string.IsNullOrWhiteSpace(externalDto.SectionFacebookUrl))
+    //    {
+    //        socialNetworks.Add(new SocialNetwork
+    //        {
+    //            Type = SocialNetworkContactType.Facebook,
+    //            Url = externalDto.SectionFacebookUrl
+    //        });
+    //    }
+    //    if (!string.IsNullOrWhiteSpace(externalDto.SectionInstagramUrl))
+    //    {
+    //        socialNetworks.Add(new SocialNetwork
+    //        {
+    //            Type = SocialNetworkContactType.Instagram,
+    //            Url = externalDto.SectionInstagramUrl
+    //        });
+    //    }
+    //    if (!string.IsNullOrWhiteSpace(externalDto.SectionUrl))
+    //    {
+    //        socialNetworks.Add(new SocialNetwork
+    //        {
+    //            Type = SocialNetworkContactType.Website,
+    //            Url = externalDto.SectionUrl
+    //        });
+    //    }
+
+    //    //if need to create keywords from sport kind name
+    //    List<string> keywords = string.IsNullOrWhiteSpace(externalDto.SectionSportKindDictName)
+    //    ? new()
+    //    : new() { externalDto.SectionSportKindDictName };
+
+    //    return new WorkshopDraft
+    //    {
+    //        Id = Guid.NewGuid(),
+    //        ProviderId = providerId,
+    //        MinsportSectionId = externalDto.SectionId,
+    //       // CATOTTGId = catottgId,
+
+    //        WorkshopDraftContent = new WorkshopDraftContent
+    //        {
+    //            Title = externalDto.SectionName,
+    //            ShortTitle = externalDto.SectionName,
+    //            EnrollmentProcedureDescription = externalDto.SectionRegistrationFlow ?? string.Empty,
+    //            CompetitiveSelectionDescription = externalDto.SectionSelectionCriteria ?? string.Empty,
+
+    //            FormOfLearning = ToFormLearning(externalDto.SectionPracticeFormat),
+    //            Price = externalDto.SectionPracticeCost,
+    //            AvailableSeats = (uint)Math.Min(externalDto.SectionMaxStudentsAmount, MinSportMaxStudentsLimit),
+
+    //            MinAge = externalDto.SectionAgeFrom,
+    //            MaxAge = externalDto.SectionAgeTo,
+    //            IsChampionPath = externalDto.SectionIsInShlyahProject,
+
+    //            StudyPeriodStartDate = DateOnly.FromDateTime(externalDto.SectionPracticePeriodDateFrom),
+    //            StudyPeriodEndDate = DateOnly.FromDateTime(externalDto.SectionPracticePeriodDateTo),
+
+    //            WorkshopDescriptionItems = new List<WorkshopDescriptionItemDraft>
+    //            {
+    //                new WorkshopDescriptionItemDraft
+    //                {
+    //                    Description = externalDto.SectionDescription ?? string.Empty
+    //                }
+    //            },
+
+    //            Keywords = keywords,
+
+    //            DateTimeRanges = MapSchedule(externalDto.SectionSchedule),
+
+    //            Contacts = new List<Contacts>
+    //            {
+    //                new Contacts
+    //                {
+    //                    Title = "Контакт секції",
+    //                    IsDefault = true,
+    //                    Address = new ContactsAddress
+    //                    {
+    //                        Street = externalDto.SectionAddressStreet ?? string.Empty,
+    //                        BuildingNumber = externalDto.SectionAddressHouse ?? string.Empty,
+    //                        //CATOTTGId = catottgId // ????
+    //                    },
+    //                    Phones = phones,
+    //                    Emails = new List<Email>
+    //                    {
+    //                        new Email
+    //                        {
+    //                            Type = "Основний",
+    //                            Address = externalDto.SectionEmail ?? string.Empty
+    //                        }
+    //                    },
+    //                    SocialNetworks = socialNetworks
+    //                }
+    //            },
+    //        },
+
+    //        // TO DO: map images
+    //        CoverImageId = externalDto.SectionTitlePhoto?.FirstOrDefault()?.Id.ToString() ?? string.Empty,
+    //        //ImageIds = externalDto.SectionPhotos?.Select(p => p.Id.ToString()).ToList() ?? new List<string>(),
+    //        DraftStatus = WorkshopDraftStatus.PendingModeration
+    //    };
+    //}
+
+    //public static WorkshopDraft MapToExistingDraft(this ExternalSportsSectionDto section, WorkshopDraft draft)
+    //{
+    //    draft.WorkshopDraftContent.Title = section.SectionName;
+    //    draft.WorkshopDraftContent.ShortTitle = section.SectionName;
+    //    draft.WorkshopDraftContent.EnrollmentProcedureDescription = section.SectionRegistrationFlow;
+    //    draft.WorkshopDraftContent.Price = section.SectionPracticeCost;
+    //    draft.WorkshopDraftContent.MinAge = section.SectionAgeFrom;
+    //    draft.WorkshopDraftContent.MaxAge = section.SectionAgeTo;
+
+    //    // TO DO: others fields  Contacts, ...
+    //    return draft;
+    //}
+
+    private static WorkshopDraftContent MapContentFromExternal(
+    ExternalSportsSectionDto section,
+    WorkshopDraftContent? existingContent = null,
+    long catottgId = 0)
+    {
+        var content = existingContent ?? new WorkshopDraftContent();
+
+        // Загальні поля
+        content.Title = section.SectionName;
+        content.ShortTitle = section.SectionName;
+        content.EnrollmentProcedureDescription = section.SectionRegistrationFlow ?? string.Empty;
+        content.CompetitiveSelectionDescription = section.SectionSelectionCriteria ?? string.Empty;
+        content.Price = section.SectionPracticeCost;
+        content.MinAge = section.SectionAgeFrom;
+        content.MaxAge = section.SectionAgeTo;
+        content.IsChampionPath = section.SectionIsInShlyahProject;
+
+        // Keywords
+        content.Keywords = string.IsNullOrWhiteSpace(section.SectionSportKindDictName)
+            ? new List<string>()
+            : new List<string> { section.SectionSportKindDictName };
+
+        // Study period
+        content.StudyPeriodStartDate = DateOnly.FromDateTime(section.SectionPracticePeriodDateFrom);
+        content.StudyPeriodEndDate = DateOnly.FromDateTime(section.SectionPracticePeriodDateTo);
+
+        // WorkshopDescriptionItems
+        content.WorkshopDescriptionItems = new List<WorkshopDescriptionItemDraft>
+    {
+        new WorkshopDescriptionItemDraft
+        {
+            Description = section.SectionDescription ?? string.Empty
+        }
+    };
+
+        // DateTimeRanges
+        content.DateTimeRanges = MapSchedule(section.SectionSchedule);
+
+        // Contacts
+        var phones = new List<PhoneNumber>();
+        if (!string.IsNullOrWhiteSpace(section.SectionPhones))
+        {
+            try
+            {
+                var parsedPhones = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(section.SectionPhones);
+                if (parsedPhones != null)
+                {
+                    phones = parsedPhones.Select(p => new PhoneNumber
+                    {
+                        Type = "Основний",
+                        Number = p.GetValueOrDefault("phone") ?? string.Empty
+                    }).ToList();
+                }
+            }
+            catch
+            {
+                // некоректний JSON – ігноруємо телефони
+            }
+        }
+
+        var socialNetworks = new List<SocialNetwork>();
+        if (!string.IsNullOrWhiteSpace(section.SectionFacebookUrl))
+        {
+            socialNetworks.Add(new SocialNetwork
+            {
+                Type = SocialNetworkContactType.Facebook,
+                Url = section.SectionFacebookUrl
+            });
+        }
+        if (!string.IsNullOrWhiteSpace(section.SectionInstagramUrl))
+        {
+            socialNetworks.Add(new SocialNetwork
+            {
+                Type = SocialNetworkContactType.Instagram,
+                Url = section.SectionInstagramUrl
+            });
+        }
+        if (!string.IsNullOrWhiteSpace(section.SectionUrl))
+        {
+            socialNetworks.Add(new SocialNetwork
+            {
+                Type = SocialNetworkContactType.Website,
+                Url = section.SectionUrl
+            });
+        }
+
+        content.Contacts = new List<Contacts>
+    {
+        new Contacts
+        {
+            Title = "Контакт секції",
+            IsDefault = true,
+            Address = new ContactsAddress
+            {
+                Street = section.SectionAddressStreet ?? string.Empty,
+                BuildingNumber = section.SectionAddressHouse ?? string.Empty,
+                CATOTTGId = catottgId
+            },
+            Phones = phones,
+            Emails = new List<Email>
+            {
+                new Email { Type = "Основний", Address = section.SectionEmail ?? string.Empty }
+            },
+            SocialNetworks = socialNetworks
+        }
+    };
+
+        // Можна додати додаткові поля (Coverage, WorkshopType, FormOfLearning тощо)
+        content.FormOfLearning = ToFormLearning(section.SectionPracticeFormat);
+
+        return content;
+    }
+
 
     private static FormOfLearning ToFormLearning(string? sectionPracticeFormat)
         => sectionPracticeFormat?.ToUpperInvariant() switch
@@ -158,5 +301,80 @@ public static class ExternalSportsSectionToWorkshopDraftMapper
             "HYBRID" => FormOfLearning.Mixed,
             _ => FormOfLearning.Offline // default fallback
         };
+    private static List<DateTimeRangeDraft> MapSchedule(string? sectionScheduleJson)
+    {
+        if (string.IsNullOrWhiteSpace(sectionScheduleJson))
+            return new List<DateTimeRangeDraft>();
+
+        try
+        {
+            var items = JsonSerializer.Deserialize<List<ExternalScheduleItem>>(sectionScheduleJson);
+            if (items == null)
+                return new List<DateTimeRangeDraft>();
+
+            var result = new List<DateTimeRangeDraft>();
+
+            foreach (var item in items)
+            {
+                if (!TimeOnly.TryParse(item.SectionScheduleTimeFrom, out var startTime) ||
+                    !TimeOnly.TryParse(item.SectionScheduleTimeTo, out var endTime))
+                {
+                    Debug.WriteLine($"Invalid time format in schedule item: From '{item.SectionScheduleTimeFrom}' To '{item.SectionScheduleTimeTo}'");
+                    continue; // skip invalid time formats
+                }
+
+                var dayMask = ToDaysBitMask(item.SectionScheduleWeekday);
+                if (dayMask == DaysBitMask.None)
+                    continue;
+
+                result.Add(new DateTimeRangeDraft
+                {
+                    StartTime = startTime,
+                    EndTime = endTime,
+                    Workdays = new HashSet<DaysBitMask> { dayMask }
+                });
+            }
+
+            return result;
+        }
+        catch
+        {
+            return new List<DateTimeRangeDraft>();
+        }
+    }
+
+    //private static List<DateTimeRangeDraft> MapSchedule(string? sectionScheduleJson)
+    //{
+    //    if (string.IsNullOrWhiteSpace(sectionScheduleJson))
+    //        return new List<DateTimeRangeDraft>();
+
+    //    try
+    //    {
+    //        var items = JsonSerializer.Deserialize<List<ExternalScheduleItem>>(sectionScheduleJson);
+    //        return items?.Select(i => new DateTimeRangeDraft
+    //        {
+    //            StartTime = TimeOnly.Parse(i.SectionScheduleTimeFrom),
+    //            EndTime = TimeOnly.Parse(i.SectionScheduleTimeTo),
+    //            Workdays = new HashSet<DaysBitMask> { ToDaysBitMask(i.SectionScheduleWeekday) }
+    //        }).ToList() ?? new List<DateTimeRangeDraft>();
+    //    }
+    //    catch
+    //    {
+    //        return new List<DateTimeRangeDraft>();
+    //    }
+    //}
+
+    private static DaysBitMask ToDaysBitMask(string weekday) => weekday.ToUpperInvariant() switch
+    {
+        "MONDAY" => DaysBitMask.Monday,
+        "TUESDAY" => DaysBitMask.Tuesday,
+        "WEDNESDAY" => DaysBitMask.Wednesday,
+        "THURSDAY" => DaysBitMask.Thursday,
+        "FRIDAY" => DaysBitMask.Friday,
+        "SATURDAY" => DaysBitMask.Saturday,
+        "SUNDAY" => DaysBitMask.Sunday,
+        _ => DaysBitMask.None
+    };
+
 }
 

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mappers/ExternalSportsSectionToWorkshopDraftMapper.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/Mappers/ExternalSportsSectionToWorkshopDraftMapper.cs
@@ -60,6 +60,7 @@ public static class ExternalSportsSectionToWorkshopDraftMapper
         {
             new WorkshopDescriptionItemDraft
             {
+                SectionName = "Опис",
                 Description = section.SectionDescription ?? string.Empty
             }
         };

--- a/OutOfSchool/OutOfSchool.Common/QuartzConstants/GroupConstants.cs
+++ b/OutOfSchool/OutOfSchool.Common/QuartzConstants/GroupConstants.cs
@@ -10,4 +10,5 @@ public static class GroupConstants
     public const string AverageRating = "averagerating";
     public const string Emails = "emails";
     public const string SportKinds = "sportkinds"; 
+    public const string SportsSections = "sportsections"; 
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/WorkshopDrafts/WorkshopDraftConfiguration.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/Configurations/WorkshopDrafts/WorkshopDraftConfiguration.cs
@@ -38,5 +38,9 @@ public class WorkshopDraftConfiguration : TrackableBaseEntityConfiguration<Works
                .WithOne()
                .HasForeignKey<WorkshopDraft>(x => x.WorkshopId)
                .IsRequired(false);
+
+        builder.Property(x => x.MinsportSectionId)
+               .HasColumnType("UUID")
+               .IsRequired(false);
     }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDrafts/WorkshopDraft.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDrafts/WorkshopDraft.cs
@@ -42,6 +42,11 @@ public class WorkshopDraft :
     /// </summary>
     public long CATOTTGId { get; set; }
 
+    /// <summary>
+    /// ID of the section in the Ministry of Sport Registry (UUID).
+    /// </summary>
+    public Guid? MinsportSectionId { get; set; }
+
     public virtual Provider Provider { get; set; }
 
     public virtual Workshop Workshop { get; set; }

--- a/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDrafts/WorkshopDraftContent.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Models/WorkshopDrafts/WorkshopDraftContent.cs
@@ -95,5 +95,5 @@ public class WorkshopDraftContent :
     
     public bool IsChampionPath { get;set; }
     
-    public Guid? MinsportSectionId { get; set; }
+   // public Guid? MinsportSectionId { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/Api/ICodeficatorRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/Api/ICodeficatorRepository.cs
@@ -43,5 +43,15 @@ public interface ICodeficatorRepository : IEntityRepositorySoftDeleted<long, CAT
     /// The task result contains the Code as a <see cref="string"/> if the entity exists; otherwise, <c>null</c>.
     /// </returns>
     public Task<string?> GetCodeByIdAsync(long id);
-    
+
+    /// <summary>
+    /// Gets the Id of a CATOTTG entity by its Code.
+    /// </summary>
+    /// <param name="code">The Code of the CATOTTG entity.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> representing the asynchronous operation.
+    /// The task result contains the Id as a <see cref="long"/> if an entity with the specified code exists; otherwise, <c>null</c>.
+    /// </returns>
+    Task<long?> GetIdByCodeAsync(string code);
+
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/Api/IProviderRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/Api/IProviderRepository.cs
@@ -11,4 +11,6 @@ public interface IProviderRepository : ISensitiveEntityRepositorySoftDeleted<Pro
     Task<Provider> GetWithNavigations(Guid id);
 
     Task<List<int>> CheckExistsByEdrpous(Dictionary<int, string> edrpous);
+
+    public Task<Guid?> GetIdByEdrpouAsync(string edrpou);
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/CodeficatorRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/CodeficatorRepository.cs
@@ -96,4 +96,14 @@ public class CodeficatorRepository : EntityRepositorySoftDeleted<long, CATOTTG>,
             .FirstOrDefaultAsync()
             .ConfigureAwait(false);
     }
+
+    //// <inheritdoc/>
+    public async Task<long?> GetIdByCodeAsync(string code)
+    {
+        return await db.CATOTTGs
+          .Where(x => !x.IsDeleted && x.Code == code)
+          .Select(x => (long?)x.Id)                  
+          .FirstOrDefaultAsync()
+          .ConfigureAwait(false);
+    }
 }

--- a/OutOfSchool/OutOfSchool.DataAccess/Repository/ProviderRepository.cs
+++ b/OutOfSchool/OutOfSchool.DataAccess/Repository/ProviderRepository.cs
@@ -82,4 +82,15 @@ public class ProviderRepository : SensitiveEntityRepositorySoftDeleted<Provider>
 
         return edrpous.Where(x => existingEdrpouIpn.Contains(x.Value)).Select(x => x.Key).ToList();
     }
+
+    public async Task<Guid?> GetIdByEdrpouAsync(string edrpou)
+    {
+        var providerId = await dbSet
+            .Where(p => !p.IsDeleted && p.Edrpou == edrpou)
+            .Select(p => p.Id)
+            .SingleOrDefaultAsync();
+
+        return providerId == Guid.Empty ? null : providerId;
+    }
+
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Extensions/SportsRegistryClientExtensions.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Extensions/SportsRegistryClientExtensions.cs
@@ -32,6 +32,7 @@ public static class SportsRegistryClientExtensions
             services.TryAddTransient<ISportsRegistryApiService, SportsRegistryApiService>();
             services.TryAddTransient<ISportsRegistrySectionProvider, SportsRegistrySectionProvider>();
             services.TryAddTransient<ISportsRegistryDictionaryProvider, SportsRegistryDictionaryProvider>();
+            services.TryAddTransient<ISportsRegistryWorkshopProvider, SportsRegistryWorkshopProviderService>();
         }
         else
         {

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Extensions/SportsRegistryClientExtensions.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Extensions/SportsRegistryClientExtensions.cs
@@ -1,3 +1,4 @@
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -5,6 +6,7 @@ using OutOfSchool.Common.Communication;
 using OutOfSchool.Common.Communication.ICommunication;
 using OutOfSchool.SportsRegistryApiClient.Config;
 using OutOfSchool.SportsRegistryApiClient.Interfaces;
+
 using OutOfSchool.SportsRegistryApiClient.Services;
 
 namespace OutOfSchool.SportsRegistryApiClient.Extensions;

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Interfaces/ISportsRegistryApiService.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Interfaces/ISportsRegistryApiService.cs
@@ -1,4 +1,5 @@
 using OutOfSchool.Common.Models;
+using OutOfSchool.SportsRegistryApiClient.Models.External;
 using OutOfSchool.SportsRegistryApiClient.Models.Requests;
 using OutOfSchool.SportsRegistryApiClient.Models.Responses;
 
@@ -32,5 +33,5 @@ public interface ISportsRegistryApiService
     /// A paged response containing the sports sections 
     /// or an <see cref="ErrorResponse"/> if the request fails.
     /// </returns>
-    Task<Either<ErrorResponse, SportsSectionListResponse>> GetSectionsAsync(int page = 0, int pageSize = 100);
+    Task<Either<ErrorResponse, SportsSectionListResponse>> GetSectionsAsync(int page = 0, int pageSize = 100, ExternalSportsSectionFilter? filter = null);
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Interfaces/ISportsRegistryApiService.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Interfaces/ISportsRegistryApiService.cs
@@ -25,4 +25,12 @@ public interface ISportsRegistryApiService
     /// <returns>A collection of sport kinds with their codes, names, and metadata.</returns>
     Task<Either<ErrorResponse, SportKindListResponse>> GetSportKindsAsync(int page = 0, int pageSize = 100);
 
+    /// <summary>
+    /// Retrieves a paged list of sports sections (workshops) from the Sports Registry.
+    /// </summary>
+    /// <returns>
+    /// A paged response containing the sports sections 
+    /// or an <see cref="ErrorResponse"/> if the request fails.
+    /// </returns>
+    Task<Either<ErrorResponse, SportsSectionListResponse>> GetSectionsAsync(int page = 0, int pageSize = 100);
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Interfaces/ISportsRegistryWorkshopProvider.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Interfaces/ISportsRegistryWorkshopProvider.cs
@@ -1,0 +1,20 @@
+﻿using OutOfSchool.Common.Models;
+using OutOfSchool.SportsRegistryApiClient.Models.Requests;
+
+namespace OutOfSchool.SportsRegistryApiClient.Interfaces;
+
+public interface ISportsRegistryWorkshopProvider
+{ /// <summary>
+  /// Retrieves all workshops (sports sections).
+  /// </summary>
+  /// <param name="pageSize">
+  /// The number of records to fetch per page (default is 50).
+  /// </param>
+  /// <returns>
+  /// An <see cref="Either{TLeft, TRight}"/> containing either an <see cref="ErrorResponse"/> 
+  /// if the request failed, or a list of <see cref="SportsSectionUpdateRequest"/> 
+  /// representing the updated workshops.
+  /// </returns>
+    Task<Either<ErrorResponse, List<SportsSectionUpdateRequest>>>
+        GetAllSportsSectionsAsync(int pageSize = 50);
+}

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Interfaces/ISportsRegistryWorkshopProvider.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Interfaces/ISportsRegistryWorkshopProvider.cs
@@ -1,20 +1,21 @@
 ﻿using OutOfSchool.Common.Models;
+using OutOfSchool.SportsRegistryApiClient.Models.External;
 using OutOfSchool.SportsRegistryApiClient.Models.Requests;
 
 namespace OutOfSchool.SportsRegistryApiClient.Interfaces;
 
 public interface ISportsRegistryWorkshopProvider
-{ /// <summary>
-  /// Retrieves all workshops (sports sections).
-  /// </summary>
-  /// <param name="pageSize">
-  /// The number of records to fetch per page (default is 50).
-  /// </param>
-  /// <returns>
-  /// An <see cref="Either{TLeft, TRight}"/> containing either an <see cref="ErrorResponse"/> 
-  /// if the request failed, or a list of <see cref="SportsSectionUpdateRequest"/> 
-  /// representing the updated workshops.
-  /// </returns>
-    Task<Either<ErrorResponse, List<SportsSectionUpdateRequest>>>
-        GetAllSportsSectionsAsync(int pageSize = 50);
+{
+    /// <summary>
+    /// Retrieves all workshops (sports sections).
+    /// </summary>
+    /// <param name="pageSize">
+    ///     The number of records to fetch per page (default is 50).
+    /// </param>
+    /// <returns>
+    /// An <see cref="Either{TLeft, TRight}"/> containing either an <see cref="ErrorResponse"/> 
+    /// if the request failed, or a list of <see cref="SportsSectionUpdateRequest"/> 
+    /// representing the updated workshops.
+    /// </returns>
+    Task<Either<ErrorResponse, List<ExternalSportsSectionDto>>> GetAllSportsSectionsAsync(int pageSize = 50);
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Interfaces/ISportsRegistryWorkshopProvider.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Interfaces/ISportsRegistryWorkshopProvider.cs
@@ -7,15 +7,19 @@ namespace OutOfSchool.SportsRegistryApiClient.Interfaces;
 public interface ISportsRegistryWorkshopProvider
 {
     /// <summary>
-    /// Retrieves all workshops (sports sections).
+    /// Retrieves sports sections from the Sports Registry.
+    /// Optionally filters by updated date range.
     /// </summary>
-    /// <param name="pageSize">
-    ///     The number of records to fetch per page (default is 50).
-    /// </param>
+    /// <param name="updatedAtFrom">Lower bound of update date filter (inclusive).</param>
+    /// <param name="updatedAtTo">Upper bound of update date filter (inclusive).</param>
+    /// <param name="pageSize">Page size (default 50).</param>
     /// <returns>
     /// An <see cref="Either{TLeft, TRight}"/> containing either an <see cref="ErrorResponse"/> 
-    /// if the request failed, or a list of <see cref="SportsSectionUpdateRequest"/> 
-    /// representing the updated workshops.
+    /// if the request failed, or a list of <see cref="ExternalSportsSectionDto"/> 
+    /// representing the updated sections.
     /// </returns>
-    Task<Either<ErrorResponse, List<ExternalSportsSectionDto>>> GetAllSportsSectionsAsync(int pageSize = 50);
+    Task<Either<ErrorResponse, List<ExternalSportsSectionDto>>> GetAllSportsSectionsAsync(
+        DateTimeOffset? updatedAtFrom = null,
+        DateTimeOffset? updatedAtTo = null,
+        int pageSize = 50);
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Models/External/ExternalSportSectionFilter.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Models/External/ExternalSportSectionFilter.cs
@@ -1,0 +1,19 @@
+﻿namespace OutOfSchool.SportsRegistryApiClient.Models.External;
+
+/// <summary>
+/// Represents filter criteria for retrieving sports sections from the Sports Registry.
+/// </summary>
+public class ExternalSportsSectionFilter
+{
+    /// <summary>
+    /// The lower bound of the update date filter (inclusive).
+    /// If null, filtering from this side is not applied.
+    /// </summary>
+    public DateTimeOffset? UpdatedAtFrom { get; set; }
+
+    /// <summary>
+    /// The upper bound of the update date filter (inclusive).
+    /// If null, filtering from this side is not applied.
+    /// </summary>
+    public DateTimeOffset? UpdatedAtTo { get; set; }
+}

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Models/External/ExternalSportsSectionDto.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Models/External/ExternalSportsSectionDto.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace OutOfSchool.SportsRegistryApiClient.Models.External;
 
@@ -72,4 +73,19 @@ public class ExternalPhotoDto
 {
     public Guid Id { get; set; }
     public string Checksum { get; set; }
+}
+
+public class ExternalScheduleItem
+{
+    [JsonPropertyName("sectionScheduleTimeFrom")]
+    public string SectionScheduleTimeFrom { get; set; }
+
+    [JsonPropertyName("sectionScheduleTimeTo")]
+    public string SectionScheduleTimeTo { get; set; }
+
+    [JsonPropertyName("section_schedule_weekday")]
+    public string SectionScheduleWeekday { get; set; }
+
+    [JsonPropertyName("sectionScheduleWeekdayDictName")]
+    public string SectionScheduleWeekdayDictName { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Models/External/ExternalSportsSectionDto.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Models/External/ExternalSportsSectionDto.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+
+namespace OutOfSchool.SportsRegistryApiClient.Models.External;
+
+public class ExternalSportsSectionDto
+{
+    public Guid SectionId { get; set; }
+    
+    public string SectionName { get; set; }
+    public string SectionDescription { get; set; }
+
+    public long SectionSportKindDictIdCode { get; set; }
+    public string SectionSportKindDictName { get; set; }
+
+    public int SectionAgeFrom { get; set; }
+    public int SectionAgeTo { get; set; }
+
+    public bool SectionIsInShlyahProject { get; set; }
+    
+    public string SectionAddressRegionDictIdCode { get; set; }
+    public string SectionAddressRegionDictName { get; set; }
+    public string SectionAddressDistrictDictIdCode { get; set; }
+    public string SectionAddressDistrictDictName { get; set; }
+    public string SectionAddressHromadaDictIdCode { get; set; }
+    public string SectionAddressHromadaDictName { get; set; }
+    public string SectionAddressLocalityDictIdCode { get; set; }
+    public string SectionAddressLocalityDictName { get; set; }
+    public string SectionAddressStreet { get; set; }
+    public string SectionAddressHouse { get; set; }
+    
+    public string SectionEmail { get; set; }
+    
+    public string SectionPhones { get; set; }
+
+    // URLs
+    public string? SectionRegistrationFormUrl { get; set; }
+    public string? SectionUrl { get; set; }
+    public string? SectionFacebookUrl { get; set; }
+    public string? SectionInstagramUrl { get; set; }
+    
+    public string SectionPracticeFormat { get; set; }
+    public string SectionPracticeFormatDictName { get; set; }
+
+    public decimal SectionPracticeCost { get; set; }
+    public int SectionMaxStudentsAmount { get; set; }
+
+    public DateTime SectionPracticePeriodDateFrom { get; set; }
+    public DateTime SectionPracticePeriodDateTo { get; set; }
+    
+    public string SectionSchedule { get; set; }
+
+    public string? SectionSelectionCriteria { get; set; }
+    public string SectionRegistrationFlow { get; set; }
+    
+    public List<ExternalPhotoDto>? SectionPhotos { get; set; }
+    public List<ExternalPhotoDto>? SectionTitlePhoto { get; set; }
+    
+    public string SectionTrainers { get; set; }
+    
+    public string SectionPozashkillyaModerationStatus { get; set; }
+    public int SectionStatusDictIdCode { get; set; }
+    public string SectionStatusDictName { get; set; }
+
+    public string OrganizationCode { get; set; }
+    
+    public DateTime AddedToRegistryAt { get; set; }
+    public DateTime UpdatedInRegistryAt { get; set; }
+}
+
+public class ExternalPhotoDto
+{
+    public Guid Id { get; set; }
+    public string Checksum { get; set; }
+}

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Models/Responses/SportsSectionListResponse.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Models/Responses/SportsSectionListResponse.cs
@@ -1,10 +1,11 @@
 ﻿using OutOfSchool.Common.Models;
+using OutOfSchool.SportsRegistryApiClient.Models.External;
 using OutOfSchool.SportsRegistryApiClient.Models.Requests;
 
 namespace OutOfSchool.SportsRegistryApiClient.Models.Responses;
 public class SportsSectionListResponse : IResponse
 {
-    public List<SportsSectionUpdateRequest> Content { get; set; }
+    public List<ExternalSportsSectionDto> Content { get; set; }
     public int TotalPages { get; set; }
     public int PageNo { get; set; }
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Models/Responses/SportsSectionListResponse.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Models/Responses/SportsSectionListResponse.cs
@@ -1,0 +1,10 @@
+﻿using OutOfSchool.Common.Models;
+using OutOfSchool.SportsRegistryApiClient.Models.Requests;
+
+namespace OutOfSchool.SportsRegistryApiClient.Models.Responses;
+public class SportsSectionListResponse : IResponse
+{
+    public List<SportsSectionUpdateRequest> Content { get; set; }
+    public int TotalPages { get; set; }
+    public int PageNo { get; set; }
+}

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/DisabledSportsRegistryProviderService.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/DisabledSportsRegistryProviderService.cs
@@ -22,4 +22,6 @@ sealed class DisabledSportsRegistryStub : ISportsRegistrySectionProvider, ISport
     public Task<Either<ErrorResponse, List<SportKindDto>>> GetAllSportKindsAsync(int pageSize = 50)
         => Task.FromResult<Either<ErrorResponse,List<SportKindDto>>> (Disabled("GetSportKinds"));
 
+    public Task<Either<ErrorResponse, List<SportsSectionUpdateRequest>>> GetUpdatedWorkshopsAsync(int pageSize = 50)
+        => Task.FromResult<Either<ErrorResponse, List<SportsSectionUpdateRequest>>>(Disabled("GetUpdatedWorkshops"));
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/SportsRegistryApiService.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/SportsRegistryApiService.cs
@@ -58,6 +58,21 @@ public class SportsRegistryApiService : ISportsRegistryApiService
             .ConfigureAwait(false);
         return httpResult;
     }
+    public async Task<Either<ErrorResponse, SportsSectionListResponse>> GetSectionsAsync(int page = 0, int pageSize = 100)
+    {
+        var tokenResult = await GetAccessTokenAsync();
+
+        var httpResult = await tokenResult
+            .Map(accessToken => new Request
+            {
+                Url = new Uri($"{config.PlatformApiUrl}/api/public/data-factory/sections?pageNo={page}&pageSize={pageSize}"),
+                HttpMethodType = HttpMethodType.Get,
+                Token = accessToken
+            })
+            .FlatMapAsync(request => communicationService.SendRequest<SportsSectionListResponse, ErrorResponse>(request))
+            .ConfigureAwait(false);
+        return httpResult;
+    }
 
     private async Task<Either<ErrorResponse, TResponse>> StartProcessAsync<TRequest, TResponse>(
         TRequest request,
@@ -183,5 +198,6 @@ public class SportsRegistryApiService : ISportsRegistryApiService
             return errorsRaw;
         }
     }
+
     #endregion
 }

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/SportsRegistryApiService.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/SportsRegistryApiService.cs
@@ -9,6 +9,7 @@ using OutOfSchool.Common.Models;
 using OutOfSchool.SportsRegistryApiClient.Config;
 using OutOfSchool.SportsRegistryApiClient.Interfaces;
 using OutOfSchool.SportsRegistryApiClient.Models;
+using OutOfSchool.SportsRegistryApiClient.Models.External;
 using OutOfSchool.SportsRegistryApiClient.Models.Requests;
 using OutOfSchool.SportsRegistryApiClient.Models.Responses;
 
@@ -58,21 +59,67 @@ public class SportsRegistryApiService : ISportsRegistryApiService
             .ConfigureAwait(false);
         return httpResult;
     }
-    public async Task<Either<ErrorResponse, SportsSectionListResponse>> GetSectionsAsync(int page = 0, int pageSize = 100)
+
+    public async Task<Either<ErrorResponse, SportsSectionListResponse>> GetSectionsAsync(
+    int page = 0,
+    int pageSize = 100,
+    ExternalSportsSectionFilter? filter = null)
     {
         var tokenResult = await GetAccessTokenAsync();
+
+        var queryParams = new List<string>()
+        {
+            $"pageNo={page}",
+            $"pageSize={pageSize}"
+        };
+
+        if (filter != null)
+        {
+            if (filter.UpdatedAtFrom.HasValue)
+            {
+                queryParams.Add($"updatedAtFrom={FormatForRegistry(filter.UpdatedAtFrom.Value)}");
+            }
+
+            if (filter.UpdatedAtTo.HasValue)
+            {
+                queryParams.Add($"updatedAtTo={FormatForRegistry(filter.UpdatedAtTo.Value)}");
+            }
+        }
+
+        var queryString = string.Join("&", queryParams);
+        var url = new Uri($"{config.PlatformApiUrl}/api/public/data-factory/sections?{queryString}");
 
         var httpResult = await tokenResult
             .Map(accessToken => new Request
             {
-                Url = new Uri($"{config.PlatformApiUrl}/api/public/data-factory/sections?pageNo={page}&pageSize={pageSize}"),
+                Url = url,
                 HttpMethodType = HttpMethodType.Get,
                 Token = accessToken
             })
-            .FlatMapAsync(request => communicationService.SendRequest<SportsSectionListResponse, ErrorResponse>(request))
+            .FlatMapAsync(request =>
+                communicationService.SendRequest<SportsSectionListResponse, ErrorResponse>(request))
             .ConfigureAwait(false);
+
         return httpResult;
     }
+    private static string FormatForRegistry(DateTimeOffset dt) =>
+    dt.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'");
+
+    //public async Task<Either<ErrorResponse, SportsSectionListResponse>> GetSectionsAsync(int page = 0, int pageSize = 100)
+    //{
+    //    var tokenResult = await GetAccessTokenAsync();
+
+    //    var httpResult = await tokenResult
+    //        .Map(accessToken => new Request
+    //        {
+    //            Url = new Uri($"{config.PlatformApiUrl}/api/public/data-factory/sections?pageNo={page}&pageSize={pageSize}"),
+    //            HttpMethodType = HttpMethodType.Get,
+    //            Token = accessToken
+    //        })
+    //        .FlatMapAsync(request => communicationService.SendRequest<SportsSectionListResponse, ErrorResponse>(request))
+    //        .ConfigureAwait(false);
+    //    return httpResult;
+    //}
 
     private async Task<Either<ErrorResponse, TResponse>> StartProcessAsync<TRequest, TResponse>(
         TRequest request,

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/SportsRegistryWorkshopProviderService.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/SportsRegistryWorkshopProviderService.cs
@@ -3,6 +3,7 @@ using OutOfSchool.Common.Models;
 using OutOfSchool.SportsRegistryApiClient.Interfaces;
 using OutOfSchool.SportsRegistryApiClient.Models.Requests;
 using System.Net;
+using OutOfSchool.SportsRegistryApiClient.Models.External;
 
 namespace OutOfSchool.SportsRegistryApiClient.Services;
 public class SportsRegistryWorkshopProviderService : ISportsRegistryWorkshopProvider
@@ -17,9 +18,9 @@ public class SportsRegistryWorkshopProviderService : ISportsRegistryWorkshopProv
         this.apiService = apiService;
         this.logger = logger;
     }
-   public async Task<Either<ErrorResponse, List<SportsSectionUpdateRequest>>> GetAllSportsSectionsAsync(int pageSize = 50)
+   public async Task<Either<ErrorResponse, List<ExternalSportsSectionDto>>> GetAllSportsSectionsAsync(int pageSize = 50)
     {
-        var all = new List<SportsSectionUpdateRequest>();
+        var all = new List<ExternalSportsSectionDto>();
         int currentPage = 0;
         int totalPages = 1;
 
@@ -36,7 +37,7 @@ public class SportsRegistryWorkshopProviderService : ISportsRegistryWorkshopProv
                 },
                 success =>
                 {
-                    var items = success.Content ?? new List<SportsSectionUpdateRequest>();
+                    var items = success.Content ?? new List<ExternalSportsSectionDto>();
                     all.AddRange(items);
                     totalPages = success.TotalPages;
                     return false;

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/SportsRegistryWorkshopProviderService.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/SportsRegistryWorkshopProviderService.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.Extensions.Logging;
+using OutOfSchool.Common.Models;
+using OutOfSchool.SportsRegistryApiClient.Interfaces;
+using OutOfSchool.SportsRegistryApiClient.Models.Requests;
+using System.Net;
+
+namespace OutOfSchool.SportsRegistryApiClient.Services;
+public class SportsRegistryWorkshopProviderService : ISportsRegistryWorkshopProvider
+{
+    private readonly ISportsRegistryApiService apiService;
+    private readonly ILogger<SportsRegistryWorkshopProviderService> logger;
+
+    public SportsRegistryWorkshopProviderService(
+        ISportsRegistryApiService apiService,
+        ILogger<SportsRegistryWorkshopProviderService> logger)
+    {
+        this.apiService = apiService;
+        this.logger = logger;
+    }
+   public async Task<Either<ErrorResponse, List<SportsSectionUpdateRequest>>> GetAllSportsSectionsAsync(int pageSize = 50)
+    {
+        var all = new List<SportsSectionUpdateRequest>();
+        int currentPage = 0;
+        int totalPages = 1;
+
+        while (currentPage < totalPages)
+        {
+            var pageResult = await apiService.GetSectionsAsync(currentPage, pageSize);
+
+            var failed = pageResult.Match(
+                error =>
+                {
+                    logger.LogError("Failed to fetch sections page {Page}: {Message}",
+                        currentPage, error.Message);
+                    return true;
+                },
+                success =>
+                {
+                    var items = success.Content ?? new List<SportsSectionUpdateRequest>();
+                    all.AddRange(items);
+                    totalPages = success.TotalPages;
+                    return false;
+                });
+
+            if (failed)
+            {
+                return new ErrorResponse
+                {
+                    HttpStatusCode = HttpStatusCode.BadRequest,
+                    Message = $"Failed to fetch sections on page {currentPage}"
+                };
+            }
+
+            currentPage++;
+        }
+
+        return all;
+    }
+}

--- a/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/SportsRegistryWorkshopProviderService.cs
+++ b/OutOfSchool/OutOfSchool.SportsRegistryApiClient/Services/SportsRegistryWorkshopProviderService.cs
@@ -18,7 +18,11 @@ public class SportsRegistryWorkshopProviderService : ISportsRegistryWorkshopProv
         this.apiService = apiService;
         this.logger = logger;
     }
-   public async Task<Either<ErrorResponse, List<ExternalSportsSectionDto>>> GetAllSportsSectionsAsync(int pageSize = 50)
+
+    public async Task<Either<ErrorResponse, List<ExternalSportsSectionDto>>> GetAllSportsSectionsAsync(
+        DateTimeOffset? updatedAtFrom = null,
+        DateTimeOffset? updatedAtTo = null,
+        int pageSize = 50)
     {
         var all = new List<ExternalSportsSectionDto>();
         int currentPage = 0;
@@ -26,7 +30,14 @@ public class SportsRegistryWorkshopProviderService : ISportsRegistryWorkshopProv
 
         while (currentPage < totalPages)
         {
-            var pageResult = await apiService.GetSectionsAsync(currentPage, pageSize);
+            var filter = new ExternalSportsSectionFilter
+            {
+                UpdatedAtFrom = updatedAtFrom,
+                UpdatedAtTo = updatedAtTo
+            };
+
+            var pageResult = await apiService.GetSectionsAsync(currentPage, pageSize, filter)
+                .ConfigureAwait(false);
 
             var failed = pageResult.Match(
                 error =>
@@ -58,3 +69,57 @@ public class SportsRegistryWorkshopProviderService : ISportsRegistryWorkshopProv
         return all;
     }
 }
+
+
+//public class SportsRegistryWorkshopProviderService : ISportsRegistryWorkshopProvider
+//{
+//    private readonly ISportsRegistryApiService apiService;
+//    private readonly ILogger<SportsRegistryWorkshopProviderService> logger;
+
+//    public SportsRegistryWorkshopProviderService(
+//        ISportsRegistryApiService apiService,
+//        ILogger<SportsRegistryWorkshopProviderService> logger)
+//    {
+//        this.apiService = apiService;
+//        this.logger = logger;
+//    }
+//   public async Task<Either<ErrorResponse, List<ExternalSportsSectionDto>>> GetAllSportsSectionsAsync(int pageSize = 50)
+//    {
+//        var all = new List<ExternalSportsSectionDto>();
+//        int currentPage = 0;
+//        int totalPages = 1;
+
+//        while (currentPage < totalPages)
+//        {
+//            var pageResult = await apiService.GetSectionsAsync(currentPage, pageSize);
+
+//            var failed = pageResult.Match(
+//                error =>
+//                {
+//                    logger.LogError("Failed to fetch sections page {Page}: {Message}",
+//                        currentPage, error.Message);
+//                    return true;
+//                },
+//                success =>
+//                {
+//                    var items = success.Content ?? new List<ExternalSportsSectionDto>();
+//                    all.AddRange(items);
+//                    totalPages = success.TotalPages;
+//                    return false;
+//                });
+
+//            if (failed)
+//            {
+//                return new ErrorResponse
+//                {
+//                    HttpStatusCode = HttpStatusCode.BadRequest,
+//                    Message = $"Failed to fetch sections on page {currentPage}"
+//                };
+//            }
+
+//            currentPage++;
+//        }
+
+//        return all;
+//    }
+//}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SportSectionSyncServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/SportSectionSyncServiceTests.cs
@@ -1,0 +1,527 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using OutOfSchool.BusinessLogic.Services.SportsRegistry;
+using OutOfSchool.Common.Models;
+using OutOfSchool.Services.Enums.WorkshopStatus;
+using OutOfSchool.Services.Models;
+using OutOfSchool.Services.Models.SubordinationStructure;
+using OutOfSchool.Services.Models.WorkshopDrafts;
+using OutOfSchool.Services.Repository.Api;
+using OutOfSchool.SportsRegistryApiClient.Interfaces;
+using OutOfSchool.SportsRegistryApiClient.Models.External;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+
+namespace OutOfSchool.WebApi.Tests.Services;
+[TestFixture]
+public class SportSectionSyncServiceTests
+{
+    private Mock<ISportsRegistryWorkshopProvider> sectionsProviderMock;
+    private Mock<IInstitutionHierarchyRepository> hierarchyRepositoryMock;
+    private Mock<IWorkshopDraftRepository> workshopDraftRepositoryMock;
+    private Mock<IWorkshopRepository> workshopRepositoryMock;
+    private Mock<ICodeficatorRepository> codeficatorRepositoryMock;
+    private Mock<IProviderRepository> providerRepositoryMock;
+    private Mock<ILogger<SportsSectionSyncService>> loggerMock;
+
+    private Guid ministryId;
+    long sportKindIdCode;
+    string organizationCode;
+    Guid sectionId;
+
+    [SetUp]
+    public void SetUp()
+    {
+        sectionsProviderMock = new Mock<ISportsRegistryWorkshopProvider>();
+        workshopDraftRepositoryMock = new Mock<IWorkshopDraftRepository>();
+        workshopRepositoryMock = new Mock<IWorkshopRepository>();
+        codeficatorRepositoryMock = new Mock<ICodeficatorRepository>();
+        providerRepositoryMock = new Mock<IProviderRepository>();
+        hierarchyRepositoryMock = new Mock<IInstitutionHierarchyRepository>();
+
+        loggerMock = new Mock<ILogger<SportsSectionSyncService>>();
+        ministryId = Guid.NewGuid();
+        sportKindIdCode = 55;
+        organizationCode = "45080641";
+        sectionId = Guid.NewGuid();
+    }
+
+    [Test]
+    public async Task SyncSportsSectionsAsync_WhenEmptyList_ShouldReturnZero()
+    {
+        SetupEmptySectionsProvider();
+
+        var service = CreateService();
+
+        var result = await service.SyncSportsSectionsAsync();
+
+        result.Should().Be(0);
+        workshopDraftRepositoryMock.Verify(r => r.RunInTransaction(It.IsAny<Func<Task>>()), Times.Never);
+    }
+
+    [Test]
+    public async Task SyncSportsSectionsAsync_WhenApiReturnsError_ShouldFallbackToFullFetch_AndReturnZero()
+    {
+        // Arrange
+        var error = new ErrorResponse { Message = "API failure" };
+        var failedResponse = (Either<ErrorResponse, List<ExternalSportsSectionDto>>)(error);
+        var successResponse = (Either<ErrorResponse, List<ExternalSportsSectionDto>>)(new List<ExternalSportsSectionDto>());
+
+        sectionsProviderMock
+            .SetupSequence(p => p.GetAllSportsSectionsAsync(
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<int>()))
+            .ReturnsAsync(failedResponse)  // first call with error
+            .ReturnsAsync(successResponse); // second call (fallback)
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SyncSportsSectionsAsync();
+
+        // Assert
+        result.Should().Be(0);
+
+        sectionsProviderMock.Verify(p =>
+            p.GetAllSportsSectionsAsync(
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<int>()),
+            Times.Exactly(2));
+
+        workshopDraftRepositoryMock.Verify(r => r.RunInTransaction(It.IsAny<Func<Task>>()), Times.Never);
+
+        loggerMock.Verify(
+           x => x.Log(
+           It.Is<LogLevel>(l => l == LogLevel.Warning),
+           It.IsAny<EventId>(),
+           It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("fallback to full fetch")),
+           It.IsAny<Exception>(),
+           It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+       Times.Once);
+    }
+
+    [Test]
+    public async Task SyncSportsSectionsAsync_WhenNewSection_ShouldCreateDraft()
+    {
+        // Arrange
+        var section = BuildSection(sectionId, sportKindIdCode, organizationCode);
+
+        SetupSectionsProviderWithSections(new List<ExternalSportsSectionDto> { section });
+        providerRepositoryMock.Setup(p => p.GetIdByEdrpouAsync(organizationCode))
+            .ReturnsAsync(Guid.NewGuid());
+
+        SetUpEmptyWorkshops();
+        SetUpEmptyDrafts();
+       
+        var sportHierarchy = BuildHierarchy();
+        hierarchyRepositoryMock
+            .Setup(r => r.GetByFilter(
+                It.IsAny<Expression<Func<InstitutionHierarchy, bool>>>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<IQueryable<InstitutionHierarchy>, IQueryable<InstitutionHierarchy>>>()))
+            .ReturnsAsync(new List<InstitutionHierarchy>() { sportHierarchy });
+
+        codeficatorRepositoryMock
+            .Setup(r => r.GetIdByCodeAsync(
+                It.IsAny<string>()))
+            .ReturnsAsync(sportKindIdCode);
+
+        IEnumerable<WorkshopDraft> createdDrafts = null!;
+
+        workshopDraftRepositoryMock
+            .Setup(r => r.Create(It.IsAny<IEnumerable<WorkshopDraft>>()))
+            .Callback<IEnumerable<WorkshopDraft>>(drafts => createdDrafts = drafts.ToList())
+            .Returns<IEnumerable<WorkshopDraft>>(drafts => Task.FromResult(drafts));
+
+        workshopDraftRepositoryMock
+            .Setup(r => r.RunInTransaction(It.IsAny<Func<Task>>()))
+            .Returns<Func<Task>>(func => func());
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SyncSportsSectionsAsync();
+
+        // Assert
+        result.Should().Be(1);
+        createdDrafts.Should().NotBeNull();
+        createdDrafts.Should().ContainSingle();
+        createdDrafts.First().WorkshopDraftContent.Title.Should().Be("New Sports Section");
+
+        workshopDraftRepositoryMock.Verify(r => r.Create(It.IsAny<IEnumerable<WorkshopDraft>>()), Times.Once);
+        workshopDraftRepositoryMock.Verify(r => r.RunInTransaction(It.IsAny<Func<Task>>()), Times.Once);
+    }
+
+    [Test]
+    public async Task SyncSportsSectionsAsync_WhenExistingDraft_ShouldUpdateDraft()
+    {
+        // Arrange
+        var section = new ExternalSportsSectionDto
+        {
+            SectionId = sectionId,
+            SectionName = "Updated Sports Section",
+            SectionSportKindDictIdCode = sportKindIdCode,
+            OrganizationCode = organizationCode,
+            UpdatedInRegistryAt = DateTime.UtcNow
+        };
+
+        SetupSectionsProviderWithSections(new List<ExternalSportsSectionDto> { section });
+        providerRepositoryMock
+            .Setup(p => p.GetIdByEdrpouAsync(organizationCode))
+            .ReturnsAsync(Guid.NewGuid());
+
+        var existingDraft = new WorkshopDraft
+        {
+            Id = Guid.NewGuid(),
+            MinsportSectionId = sectionId,
+            DraftStatus = WorkshopDraftStatus.Draft,
+            WorkshopDraftContent = new WorkshopDraftContent()
+        };
+
+        SetUpDraftsWithData(new List<WorkshopDraft> { existingDraft });
+        SetUpEmptyWorkshops();
+
+        var sportHierarchy = BuildHierarchy(sportKindIdCode);
+        hierarchyRepositoryMock
+            .Setup(r => r.GetByFilter(
+                It.IsAny<Expression<Func<InstitutionHierarchy, bool>>>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<IQueryable<InstitutionHierarchy>, IQueryable<InstitutionHierarchy>>>()))
+            .ReturnsAsync(new List<InstitutionHierarchy> { sportHierarchy });
+
+        codeficatorRepositoryMock
+            .Setup(r => r.GetIdByCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync(12345);
+
+        WorkshopDraft? updatedDraft = null;
+
+        workshopDraftRepositoryMock
+            .Setup(r => r.Update(It.IsAny<WorkshopDraft>()))
+            .Callback<WorkshopDraft>(d => updatedDraft = d)
+            .Returns<WorkshopDraft>(d => Task.FromResult(d));
+
+        workshopDraftRepositoryMock
+            .Setup(r => r.RunInTransaction(It.IsAny<Func<Task>>()))
+            .Returns<Func<Task>>(f => f());
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SyncSportsSectionsAsync();
+
+        // Assert
+        result.Should().Be(1);
+        updatedDraft.Should().NotBeNull();
+        updatedDraft!.DraftStatus.Should().Be(WorkshopDraftStatus.PendingModeration);
+        updatedDraft.WorkshopDraftContent.InstitutionHierarchyId.Should().Be(sportHierarchy.Id);
+
+        workshopDraftRepositoryMock.Verify(r => r.Update(It.IsAny<WorkshopDraft>()), Times.Once);
+        workshopDraftRepositoryMock.Verify(r => r.Create(It.IsAny<IEnumerable<WorkshopDraft>>()), Times.Never);
+    }
+
+    [Test]
+    public async Task SyncSportsSectionsAsync_WhenWorkshopExists_ShouldCreateDraftFromWorkshop()
+    {
+        // Arrange
+        var section = new ExternalSportsSectionDto
+        {
+            SectionId = sectionId,
+            SectionName = "Section With Workshop",
+            SectionSportKindDictIdCode = sportKindIdCode,
+            OrganizationCode = organizationCode,
+            UpdatedInRegistryAt = DateTime.UtcNow
+        };
+
+        SetupSectionsProviderWithSections(new List<ExternalSportsSectionDto> { section });
+
+        var existingWorkshop = new Workshop
+        {
+            Id = Guid.NewGuid(),
+            MinsportSectionId = sectionId,
+            ProviderId = Guid.NewGuid()
+        };
+
+        SetUpWorkshopsWithData(new List<Workshop> { existingWorkshop });
+        SetUpEmptyDrafts();
+
+        var sportHierarchy = BuildHierarchy(sportKindIdCode);
+        hierarchyRepositoryMock
+            .Setup(r => r.GetByFilter(
+                It.IsAny<Expression<Func<InstitutionHierarchy, bool>>>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<IQueryable<InstitutionHierarchy>, IQueryable<InstitutionHierarchy>>>()))
+            .ReturnsAsync(new List<InstitutionHierarchy> { sportHierarchy });
+
+        codeficatorRepositoryMock
+            .Setup(r => r.GetIdByCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync(12345);
+
+        IEnumerable<WorkshopDraft>? createdDrafts = null;
+
+        workshopDraftRepositoryMock
+            .Setup(r => r.Create(It.IsAny<IEnumerable<WorkshopDraft>>()))
+            .Callback<IEnumerable<WorkshopDraft>>(drafts => createdDrafts = drafts.ToList())
+            .Returns<IEnumerable<WorkshopDraft>>(drafts => Task.FromResult(drafts));
+
+        workshopDraftRepositoryMock
+            .Setup(r => r.RunInTransaction(It.IsAny<Func<Task>>()))
+            .Returns<Func<Task>>(f => f());
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SyncSportsSectionsAsync();
+
+        // Assert
+        result.Should().Be(1);
+        createdDrafts.Should().NotBeNull();
+        createdDrafts.First().WorkshopId.Should().Be(existingWorkshop.Id);
+        createdDrafts.First().MinsportSectionId.Should().Be(existingWorkshop.MinsportSectionId);
+        createdDrafts.First().DraftStatus.Should().Be(WorkshopDraftStatus.PendingModeration);
+
+        workshopDraftRepositoryMock.Verify(r => r.Create(It.IsAny<IEnumerable<WorkshopDraft>>()), Times.Once);
+        workshopDraftRepositoryMock.Verify(r => r.Update(It.IsAny<WorkshopDraft>()), Times.Never);
+    }
+
+    [Test]
+    public async Task SyncSportsSectionsAsync_WhenProviderNotFound_ShouldSkipSection()
+    {
+        // Arrange
+        var section = BuildSection(sectionId, sportKindIdCode);
+        
+        SetupSectionsProviderWithSections(new List<ExternalSportsSectionDto> { section });
+
+        var sportHierarchy = BuildHierarchy(sportKindIdCode);
+        hierarchyRepositoryMock
+            .Setup(r => r.GetByFilter(
+                It.IsAny<Expression<Func<InstitutionHierarchy, bool>>>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<IQueryable<InstitutionHierarchy>, IQueryable<InstitutionHierarchy>>>()))
+            .ReturnsAsync(new List<InstitutionHierarchy> { sportHierarchy });
+
+        providerRepositoryMock
+            .Setup(p => p.GetIdByEdrpouAsync(It.IsAny<string>()))
+            .ReturnsAsync((Guid?)null);
+
+        codeficatorRepositoryMock
+            .Setup(c => c.GetIdByCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync(1234L);
+
+        var createdDrafts = new List<WorkshopDraft>();
+        workshopDraftRepositoryMock
+            .Setup(r => r.Create(It.IsAny<IEnumerable<WorkshopDraft>>()))
+            .Callback<IEnumerable<WorkshopDraft>>(d => createdDrafts.AddRange(d))
+            .ReturnsAsync((IEnumerable<WorkshopDraft> d) => d);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SyncSportsSectionsAsync();
+
+        // Assert
+        result.Should().Be(0);
+        createdDrafts.Should().BeEmpty();
+        
+        VerifyLog(LogLevel.Warning, "provider was not found", Times.Once());
+    }
+
+    [Test]
+    public async Task SyncSportsSectionsAsync_WhenHierarchyNotFound_ShouldSkipSection()
+    {
+        // Arrange
+        var section = new ExternalSportsSectionDto
+        {
+            SectionId = sectionId,
+            SectionName = "Section Without Hierarchy",
+            SectionSportKindDictIdCode = sportKindIdCode,
+            OrganizationCode = "12345678",
+        };
+
+        SetupSectionsProviderWithSections(new List<ExternalSportsSectionDto> { section });
+
+        providerRepositoryMock
+            .Setup(p => p.GetIdByEdrpouAsync(It.IsAny<string>()))
+            .ReturnsAsync(Guid.NewGuid());
+
+        codeficatorRepositoryMock
+            .Setup(c => c.GetIdByCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync(1234L);
+
+        // hierarchy not found
+        hierarchyRepositoryMock
+            .Setup(r => r.GetByFilter(
+                It.IsAny<Expression<Func<InstitutionHierarchy, bool>>>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<IQueryable<InstitutionHierarchy>, IQueryable<InstitutionHierarchy>>>()))
+            .ReturnsAsync(new List<InstitutionHierarchy>());
+
+        SetUpEmptyWorkshops();
+        SetUpEmptyDrafts();
+
+        var createdDrafts = new List<WorkshopDraft>();
+        workshopDraftRepositoryMock
+            .Setup(r => r.Create(It.IsAny<IEnumerable<WorkshopDraft>>()))
+            .Callback<IEnumerable<WorkshopDraft>>(d => createdDrafts.AddRange(d))
+            .ReturnsAsync((IEnumerable<WorkshopDraft> d) => d);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SyncSportsSectionsAsync();
+
+        // Assert
+        result.Should().Be(0);
+        createdDrafts.Should().BeEmpty();
+
+        VerifyLog(LogLevel.Warning, "no InstitutionHierarchy found", Times.Once());
+    }
+    [Test]
+    public async Task SyncSportsSectionsAsync_WhenRunInTransactionThrows_ShouldLogErrorAndReturnZero()
+    {
+        // Arrange
+        var section = new ExternalSportsSectionDto
+        {
+            SectionId = sectionId,
+            SectionName = "Section With Transaction Error",
+            SectionSportKindDictIdCode = sportKindIdCode,
+            OrganizationCode = organizationCode,
+        };
+
+        SetupSectionsProviderWithSections(new List<ExternalSportsSectionDto> { section });
+
+        providerRepositoryMock
+            .Setup(p => p.GetIdByEdrpouAsync(It.IsAny<string>()))
+            .ReturnsAsync(Guid.NewGuid());
+
+        hierarchyRepositoryMock
+            .Setup(r => r.GetByFilter(
+                It.IsAny<Expression<Func<InstitutionHierarchy, bool>>>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<IQueryable<InstitutionHierarchy>, IQueryable<InstitutionHierarchy>>>()))
+            .ReturnsAsync(new List<InstitutionHierarchy> { BuildHierarchy(sportKindIdCode) });
+
+        codeficatorRepositoryMock
+            .Setup(c => c.GetIdByCodeAsync(It.IsAny<string>()))
+            .ReturnsAsync(1234L);
+
+        SetUpEmptyWorkshops();
+        SetUpEmptyDrafts();
+       
+        workshopDraftRepositoryMock
+            .Setup(r => r.RunInTransaction(It.IsAny<Func<Task>>()))
+            .ThrowsAsync(new Exception("DB transaction failed"));
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SyncSportsSectionsAsync();
+
+        // Assert
+        result.Should().Be(0);
+
+        VerifyLog(LogLevel.Error, "Error during sports sections sync", Times.Once()); 
+    }
+
+    private SportsSectionSyncService CreateService()
+    {
+        return new SportsSectionSyncService(
+            sectionsProviderMock.Object,
+            workshopDraftRepositoryMock.Object,
+            workshopRepositoryMock.Object,
+            codeficatorRepositoryMock.Object,
+            providerRepositoryMock.Object,
+            hierarchyRepositoryMock.Object,
+            loggerMock.Object);
+    }
+    private ExternalSportsSectionDto BuildSection(Guid id, long sportKindIdCode = 55, string organizationCode = "45080641")
+    {
+        var section = new ExternalSportsSectionDto
+        {
+            SectionId = id,
+            SectionName = "New Sports Section",
+            SectionSportKindDictIdCode = sportKindIdCode,
+            OrganizationCode = organizationCode,
+        };
+        return section;
+    }
+    private InstitutionHierarchy BuildHierarchy(long sportKindId = 55)
+    {
+        return new InstitutionHierarchy
+        {
+            Id = Guid.NewGuid(),
+            Title = "Hierarchy Title",
+            InstitutionId = ministryId,
+            SportRegistryIdCode = sportKindId,
+            HierarchyLevel = 2,
+            SportsSectionNumeral = "football",
+            RegistrySyncDate = DateTime.UtcNow
+        };
+    }
+
+    private void SetUpEmptyDrafts() =>
+    workshopDraftRepositoryMock
+        .Setup(r => r.GetByFilter(
+            It.IsAny<Expression<Func<WorkshopDraft, bool>>>(),
+            It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<WorkshopDraft>, IQueryable<WorkshopDraft>>>()))
+        .ReturnsAsync(new List<WorkshopDraft>());
+
+    private void SetUpDraftsWithData(IEnumerable<WorkshopDraft> drafts) =>
+        workshopDraftRepositoryMock
+            .Setup(r => r.GetByFilter(
+                It.IsAny<Expression<Func<WorkshopDraft, bool>>>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<IQueryable<WorkshopDraft>, IQueryable<WorkshopDraft>>>()))
+            .ReturnsAsync(drafts);
+    private void SetUpEmptyWorkshops() =>
+    workshopRepositoryMock
+        .Setup(r => r.GetByFilter(
+            It.IsAny<Expression<Func<Workshop, bool>>>(),
+            It.IsAny<string>(),
+            It.IsAny<Func<IQueryable<Workshop>, IQueryable<Workshop>>>()))
+        .ReturnsAsync(new List<Workshop>());
+
+    private void SetUpWorkshopsWithData(IEnumerable<Workshop> workshops) =>
+        workshopRepositoryMock
+            .Setup(r => r.GetByFilter(
+                It.IsAny<Expression<Func<Workshop, bool>>>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<IQueryable<Workshop>, IQueryable<Workshop>>>()))
+            .ReturnsAsync(workshops);
+
+    private void SetupSectionsProviderWithSections(IEnumerable<ExternalSportsSectionDto> sections)
+    {
+        var apiResponse = (Either<ErrorResponse, List<ExternalSportsSectionDto>>)sections.ToList();
+        sectionsProviderMock
+            .Setup(p => p.GetAllSportsSectionsAsync(
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<int>()))
+            .ReturnsAsync(apiResponse);
+    }
+
+    private void SetupEmptySectionsProvider()
+    {
+        SetupSectionsProviderWithSections(new List<ExternalSportsSectionDto>());
+    }
+
+    private void VerifyLog(LogLevel level, string containsText, Times times)
+    {
+        loggerMock.Verify(
+            x => x.Log(
+                It.Is<LogLevel>(l => l == level),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains(containsText)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                times);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/WorkshopDraftServiceTests.cs
@@ -805,7 +805,7 @@ public class WorkshopDraftServiceTests
             .Setup(x => x.SyncDraftAsync(It.Is<WorkshopDraft>(d => d.Id == workshopDraft.Id)))
             .Callback<WorkshopDraft>(d =>
             {
-                d.WorkshopDraftContent.MinsportSectionId = Guid.NewGuid();
+                d.MinsportSectionId = Guid.NewGuid();
             })
             .Returns(Task.CompletedTask)
             .Verifiable();
@@ -842,7 +842,7 @@ public class WorkshopDraftServiceTests
             Times.Once);
 
         Assert.AreEqual(createdWorkshopId, resultId);
-        Assert.NotNull(workshopDraft.WorkshopDraftContent.MinsportSectionId);
+        Assert.NotNull(workshopDraft.MinsportSectionId);
     }
 
     [Test]

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/SportsRegistryTestController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/SportsRegistryTestController.cs
@@ -20,19 +20,25 @@ public class SportsRegistryTestController : ControllerBase
         this.logger = logger;
     }
 
+
     /// <summary>
-    /// Calls the external Sports Registry API and returns the list of sports sections.
+    /// Calls the external Sports Registry API and returns the list of sports sections fot the last numberDays days.
     /// Use only for testing connectivity and data format.
     /// </summary>
     /// <param name="pageSize">Optional page size (default 10)</param>
+    /// <param name="numberDays"></param>
     /// <returns>List of sections from the external registry or error message</returns>
     [AllowAnonymous]
     [HttpGet("sections")]
-    public async Task<IActionResult> GetSections([FromQuery] int pageSize = 10)
+    public async Task<IActionResult> GetSections(
+        [FromQuery] int pageSize = 10,
+        [FromQuery] int numberDays = 1)
     {
         logger.LogInformation("Testing fetch of sports sections from Sports Registry...");
 
-        var result = await workshopProvider.GetAllSportsSectionsAsync(pageSize);
+        var updatedAtFrom = DateTimeOffset.UtcNow.AddDays(-numberDays);
+        var updatedAtTo = DateTimeOffset.UtcNow;
+        var result = await workshopProvider.GetAllSportsSectionsAsync(updatedAtFrom, updatedAtTo,pageSize);
 
         return result.Match<IActionResult>(
             error =>

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/SportsRegistryTestController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/SportsRegistryTestController.cs
@@ -1,0 +1,49 @@
+﻿using global::OutOfSchool.SportsRegistryApiClient.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+namespace OutOfSchool.WebApi.Controllers.V2;
+/// <summary>
+/// Temporary controller for testing connection with the Ministry of Sports registry.
+/// </summary>
+[ApiController]
+[AspApiVersion(2)]
+[Route("api/v{version:apiVersion}/[controller]/[action]")]
+public class SportsRegistryTestController : ControllerBase
+{
+    private readonly ISportsRegistryWorkshopProvider workshopProvider;
+    private readonly ILogger<SportsRegistryTestController> logger;
+
+    public SportsRegistryTestController(
+        ISportsRegistryWorkshopProvider workshopProvider,
+        ILogger<SportsRegistryTestController> logger)
+    {
+        this.workshopProvider = workshopProvider;
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// Calls the external Sports Registry API and returns the list of sports sections.
+    /// Use only for testing connectivity and data format.
+    /// </summary>
+    /// <param name="pageSize">Optional page size (default 10)</param>
+    /// <returns>List of sections from the external registry or error message</returns>
+    [AllowAnonymous]
+    [HttpGet("sections")]
+    public async Task<IActionResult> GetSections([FromQuery] int pageSize = 10)
+    {
+        logger.LogInformation("Testing fetch of sports sections from Sports Registry...");
+
+        var result = await workshopProvider.GetAllSportsSectionsAsync(pageSize);
+
+        return result.Match<IActionResult>(
+            error =>
+            {
+                logger.LogError("Failed to fetch sports sections: {Message}", error.Message);
+                return StatusCode((int)error.HttpStatusCode, error);
+            },
+            success =>
+            {
+                logger.LogInformation("Fetched {Count} sports sections successfully", success.Count);
+                return Ok(success);
+            });
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/SportsSectionSyncController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/SportsSectionSyncController.cs
@@ -1,0 +1,106 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+using OutOfSchool.BusinessLogic.Services.SportsRegistry;
+using OutOfSchool.Services.Repository.Api;
+using OutOfSchool.SportsRegistryApiClient.Interfaces;
+namespace OutOfSchool.WebApi.Controllers.V2
+{
+    [ApiController]
+    [ApiVersion("2.0")]
+    [Route("api/v{version:apiVersion}/sports-sections/sync")]
+    public class SportsSectionSyncController : ControllerBase
+    {
+        private readonly ISportsSectionSyncService syncService;
+        private readonly ISportsRegistryWorkshopProvider workshopProvider;
+        private readonly IWorkshopDraftRepository workshopDraftRepository;
+        private readonly ILogger<SportsSectionSyncController> logger;
+        public SportsSectionSyncController(
+            ISportsSectionSyncService syncService,
+            ISportsRegistryWorkshopProvider workshopProvider,
+            IWorkshopDraftRepository workshopDraftRepository,
+            ILogger<SportsSectionSyncController> logger)
+        {
+            this.syncService = syncService;
+            this.workshopProvider = workshopProvider;
+            this.workshopDraftRepository = workshopDraftRepository;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Виконує синхронізацію спортивних секцій із Мінспорту до Позашкілля.
+        /// </summary>
+        /// <returns>Кількість створених або оновлених секцій.</returns>
+        [HttpPost("run")]
+        [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+        public async Task<IActionResult> RunSyncAsync()
+        {
+            try
+            {
+                logger.LogInformation("Manual sync of sports sections started...");
+
+                var result = await syncService.SyncSportsSectionsAsync().ConfigureAwait(false);
+
+                logger.LogInformation("Manual sync completed. {Count} sections processed.", result);
+
+                return Ok(new
+                {
+                    message = "Sync completed successfully.",
+                    totalProcessed = result
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error while syncing sports sections.");
+                return StatusCode(500, new
+                {
+                    message = "An error occurred during synchronization.",
+                    details = ex.Message
+                });
+            }
+        }
+
+        /// <summary>
+        /// Показує поточний стан секцій у Мінспорту та Позашкіллі (для перевірки перед синхронізацією).
+        /// </summary>
+        [HttpGet("status")]
+        [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetStatusAsync()
+        {
+            try
+            {
+                logger.LogInformation("Fetching sports sections status...");
+
+                var externalResponse = await workshopProvider.GetAllSportsSectionsAsync().ConfigureAwait(false);
+
+                var externalSections = externalResponse.Match(
+                    error => throw new InvalidOperationException($"Failed to fetch sports sections: {error.Message}"),
+                    success => success);
+
+                var localDrafts = await workshopDraftRepository.GetAll().ConfigureAwait(false);
+
+                var totalExternal = externalSections.Count;
+                var totalLocal = localDrafts.Count();
+                var linked = localDrafts.Count(w => w.MinsportSectionId.HasValue);
+                var notLinked = totalLocal - linked;
+
+                return Ok(new
+                {
+                    external = totalExternal,
+                    local = totalLocal,
+                    linked,
+                    notLinked,
+                    message = "Sports sections status retrieved successfully."
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error while fetching sports sections status.");
+                return StatusCode(500, new
+                {
+                    message = "An error occurred while fetching status.",
+                    details = ex.Message
+                });
+            }
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/SportsSectionSyncController.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Controllers/V2/SportsSectionSyncController.cs
@@ -3,104 +3,103 @@ using Microsoft.AspNetCore.Mvc;
 using OutOfSchool.BusinessLogic.Services.SportsRegistry;
 using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.SportsRegistryApiClient.Interfaces;
-namespace OutOfSchool.WebApi.Controllers.V2
+namespace OutOfSchool.WebApi.Controllers.V2;
+
+[ApiController]
+[ApiVersion("2.0")]
+[Route("api/v{version:apiVersion}/sports-sections/sync")]
+public class SportsSectionSyncController : ControllerBase
 {
-    [ApiController]
-    [ApiVersion("2.0")]
-    [Route("api/v{version:apiVersion}/sports-sections/sync")]
-    public class SportsSectionSyncController : ControllerBase
+    private readonly ISportsSectionSyncService syncService;
+    private readonly ISportsRegistryWorkshopProvider workshopProvider;
+    private readonly IWorkshopDraftRepository workshopDraftRepository;
+    private readonly ILogger<SportsSectionSyncController> logger;
+    public SportsSectionSyncController(
+        ISportsSectionSyncService syncService,
+        ISportsRegistryWorkshopProvider workshopProvider,
+        IWorkshopDraftRepository workshopDraftRepository,
+        ILogger<SportsSectionSyncController> logger)
     {
-        private readonly ISportsSectionSyncService syncService;
-        private readonly ISportsRegistryWorkshopProvider workshopProvider;
-        private readonly IWorkshopDraftRepository workshopDraftRepository;
-        private readonly ILogger<SportsSectionSyncController> logger;
-        public SportsSectionSyncController(
-            ISportsSectionSyncService syncService,
-            ISportsRegistryWorkshopProvider workshopProvider,
-            IWorkshopDraftRepository workshopDraftRepository,
-            ILogger<SportsSectionSyncController> logger)
+        this.syncService = syncService;
+        this.workshopProvider = workshopProvider;
+        this.workshopDraftRepository = workshopDraftRepository;
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// Initiates manual synchronization of sports sections from the Ministry of Sports to the OutOfSchool system.
+    /// </summary>
+    /// <returns>Quantity of created or updated sections.</returns>
+    [HttpPost("run")]
+    [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+    public async Task<IActionResult> RunSyncAsync()
+    {
+        try
         {
-            this.syncService = syncService;
-            this.workshopProvider = workshopProvider;
-            this.workshopDraftRepository = workshopDraftRepository;
-            this.logger = logger;
+            logger.LogInformation("Manual sync of sports sections started...");
+
+            var result = await syncService.SyncSportsSectionsAsync().ConfigureAwait(false);
+
+            logger.LogInformation("Manual sync completed. {Count} sections processed.", result);
+
+            return Ok(new
+            {
+                message = "Sync completed successfully.",
+                totalProcessed = result
+            });
         }
-
-        /// <summary>
-        /// Виконує синхронізацію спортивних секцій із Мінспорту до Позашкілля.
-        /// </summary>
-        /// <returns>Кількість створених або оновлених секцій.</returns>
-        [HttpPost("run")]
-        [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
-        public async Task<IActionResult> RunSyncAsync()
+        catch (Exception ex)
         {
-            try
+            logger.LogError(ex, "Error while syncing sports sections.");
+            return StatusCode(500, new
             {
-                logger.LogInformation("Manual sync of sports sections started...");
-
-                var result = await syncService.SyncSportsSectionsAsync().ConfigureAwait(false);
-
-                logger.LogInformation("Manual sync completed. {Count} sections processed.", result);
-
-                return Ok(new
-                {
-                    message = "Sync completed successfully.",
-                    totalProcessed = result
-                });
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error while syncing sports sections.");
-                return StatusCode(500, new
-                {
-                    message = "An error occurred during synchronization.",
-                    details = ex.Message
-                });
-            }
+                message = "An error occurred during synchronization.",
+                details = ex.Message
+            });
         }
+    }
 
-        /// <summary>
-        /// Показує поточний стан секцій у Мінспорту та Позашкіллі (для перевірки перед синхронізацією).
-        /// </summary>
-        [HttpGet("status")]
-        [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetStatusAsync()
+    /// <summary>
+    /// Display current state of sports sections in the Ministry of Sports and OutOfSchool (for pre-sync check).
+    /// </summary>
+    [HttpGet("status")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetStatusAsync()
+    {
+        try
         {
-            try
+            logger.LogInformation("Fetching sports sections status...");
+
+            var externalResponse = await workshopProvider.GetAllSportsSectionsAsync().ConfigureAwait(false);
+
+            var externalSections = externalResponse.Match(
+                error => throw new InvalidOperationException($"Failed to fetch sports sections: {error.Message}"),
+                success => success);
+
+            var localDrafts = await workshopDraftRepository.GetAll().ConfigureAwait(false);
+
+            var totalExternal = externalSections.Count;
+            var totalLocal = localDrafts.Count();
+            var linked = localDrafts.Count(w => w.MinsportSectionId.HasValue);
+            var notLinked = totalLocal - linked;
+
+            return Ok(new
             {
-                logger.LogInformation("Fetching sports sections status...");
-
-                var externalResponse = await workshopProvider.GetAllSportsSectionsAsync().ConfigureAwait(false);
-
-                var externalSections = externalResponse.Match(
-                    error => throw new InvalidOperationException($"Failed to fetch sports sections: {error.Message}"),
-                    success => success);
-
-                var localDrafts = await workshopDraftRepository.GetAll().ConfigureAwait(false);
-
-                var totalExternal = externalSections.Count;
-                var totalLocal = localDrafts.Count();
-                var linked = localDrafts.Count(w => w.MinsportSectionId.HasValue);
-                var notLinked = totalLocal - linked;
-
-                return Ok(new
-                {
-                    external = totalExternal,
-                    local = totalLocal,
-                    linked,
-                    notLinked,
-                    message = "Sports sections status retrieved successfully."
-                });
-            }
-            catch (Exception ex)
+                external = totalExternal,
+                local = totalLocal,
+                linked,
+                notLinked,
+                message = "Sports sections status retrieved successfully."
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error while fetching sports sections status.");
+            return StatusCode(500, new
             {
-                logger.LogError(ex, "Error while fetching sports sections status.");
-                return StatusCode(500, new
-                {
-                    message = "An error occurred while fetching status.",
-                    details = ex.Message
-                });
-            }
+                message = "An error occurred while fetching status.",
+                details = ex.Message
+            });
         }
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -612,7 +612,7 @@ public static class Startup
             q.AddLicenseApprovalNotificationGenerating(services, quartzConfig);
             q.AddEmailSender(quartzConfig);
             q.AddSportKindSync(quartzConfig);
-            //q.AddSportsSectionSync(quartzConfig); // temporary disabled
+            q.AddSportsSectionSync(quartzConfig);
 
         });
 

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -400,6 +400,8 @@ public static class Startup
         services.AddTransient<ISubDirectionService, SubDirectionService>();
         services.AddTransient<IRegistrySyncService, RegistrySyncService>();
         services.AddTransient<ISportKindSyncService, SportKindSyncService>();
+        services.AddTransient<ISportsSectionSyncService, SportsSectionSyncService>();
+
         services.AddSingleton<ISendGridAccessibilityService, SendGridAccessibilityService>();
         services.AddScoped<IRazorViewToStringRenderer, RazorViewToStringRenderer>();
 
@@ -610,6 +612,8 @@ public static class Startup
             q.AddLicenseApprovalNotificationGenerating(services, quartzConfig);
             q.AddEmailSender(quartzConfig);
             q.AddSportKindSync(quartzConfig);
+            q.AddSportsSectionSync(quartzConfig);
+
         });
 
         var isRedisEnabled = configuration.GetValue<bool>("Redis:Enabled");

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -400,7 +400,7 @@ public static class Startup
         services.AddTransient<ISubDirectionService, SubDirectionService>();
         services.AddTransient<IRegistrySyncService, RegistrySyncService>();
         services.AddTransient<ISportKindSyncService, SportKindSyncService>();
-        //services.AddTransient<ISportsSectionSyncService, SportsSectionSyncService>();
+        services.AddTransient<ISportsSectionSyncService, SportsSectionSyncService>();
 
         services.AddSingleton<ISendGridAccessibilityService, SendGridAccessibilityService>();
         services.AddScoped<IRazorViewToStringRenderer, RazorViewToStringRenderer>();

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -612,7 +612,7 @@ public static class Startup
             q.AddLicenseApprovalNotificationGenerating(services, quartzConfig);
             q.AddEmailSender(quartzConfig);
             q.AddSportKindSync(quartzConfig);
-            q.AddSportsSectionSync(quartzConfig);
+            //q.AddSportsSectionSync(quartzConfig); // temporary disabled
 
         });
 

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -400,7 +400,7 @@ public static class Startup
         services.AddTransient<ISubDirectionService, SubDirectionService>();
         services.AddTransient<IRegistrySyncService, RegistrySyncService>();
         services.AddTransient<ISportKindSyncService, SportKindSyncService>();
-        services.AddTransient<ISportsSectionSyncService, SportsSectionSyncService>();
+        //services.AddTransient<ISportsSectionSyncService, SportsSectionSyncService>();
 
         services.AddSingleton<ISendGridAccessibilityService, SendGridAccessibilityService>();
         services.AddScoped<IRazorViewToStringRenderer, RazorViewToStringRenderer>();

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Development.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Development.json
@@ -82,9 +82,9 @@
   },
   "SportsRegistryApiClient": {
     "Enable": true,
-    "ApiUrl": "https://external-service-api-mms-main.apps.krrt-stage.ncr.gov.ua",
-    "PlatformApiUrl": "https://platform-gateway-mms-main.apps.krrt-stage.ncr.gov.ua",
-    "TokenEndpoint": "https://mms-keycloak.apps.krrt-stage.ncr.gov.ua/auth/realms/mms-external-system/protocol/openid-connect/token",
+    "ApiUrl": "https://external-service-api-erso-main.apps.krrt3.ncr.gov.ua",
+    "PlatformApiUrl": "https://platform-gateway-erso-main.apps.krrt3.ncr.gov.ua",
+    "TokenEndpoint": "https://erso-auth.apps.krrt3.ncr.gov.ua/auth/realms/erso-external-system/protocol/openid-connect/token",
     "ClientId": "pozashkillya",
     "ClientSecret": "replace_me"
   }

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.Development.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.Development.json
@@ -78,7 +78,8 @@
     "TokenEndpoint": "http://localhost:8083/oauth2/token"
   },
   "ImageStorage": {
-    "BaseImageUrl": "https://minio.pozashkillia-test.iea.gov.ua/outofschool/"
+    "BaseImageUrl": "https://storage.pozashkillia.iea.gov.ua/public/"
+    // "BaseImageUrl": "https://minio.pozashkillia-test.iea.gov.ua/outofschool/"
   },
   "SportsRegistryApiClient": {
     "Enable": true,

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -269,8 +269,8 @@
       "LicenseApprovalNotificationCronScheduleString": "0 0 6 10 JAN ? *",
       "EmailSenderCronScheduleString": "0/30 * * * * ?",
       "SportKindSyncCronScheduleString": "0 0 1 * * ?",
-      //"SportsSectionSyncCronScheduleString": "0 0 1 * * ?"
-      "SportsSectionSyncCronScheduleString": "0 0/2 * * * ?"
+      "SportsSectionSyncCronScheduleString": "0 0 2 * * ?"
+      //"SportsSectionSyncCronScheduleString": "0 0/2 * * * ?"
     }
   },
   "ThumbnailGeneration": {

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -269,8 +269,7 @@
       "LicenseApprovalNotificationCronScheduleString": "0 0 6 10 JAN ? *",
       "EmailSenderCronScheduleString": "0/30 * * * * ?",
       "SportKindSyncCronScheduleString": "0 0 1 * * ?",
-      "SportsSectionSyncCronScheduleString": "0 0 2 * * ?"
-      //"SportsSectionSyncCronScheduleString": "0 0/2 * * * ?"
+      "SportsSectionSyncCronScheduleString": "0 0/30 * * * ?"
     }
   },
   "ThumbnailGeneration": {

--- a/OutOfSchool/OutOfSchool.WebApi/appsettings.json
+++ b/OutOfSchool/OutOfSchool.WebApi/appsettings.json
@@ -268,7 +268,9 @@
       "AverageRatingCalculatingCronScheduleString": "0 0 4 * * ?",
       "LicenseApprovalNotificationCronScheduleString": "0 0 6 10 JAN ? *",
       "EmailSenderCronScheduleString": "0/30 * * * * ?",
-      "SportKindSyncCronScheduleString": "0 0 1 * * ?"
+      "SportKindSyncCronScheduleString": "0 0 1 * * ?",
+      //"SportsSectionSyncCronScheduleString": "0 0 1 * * ?"
+      "SportsSectionSyncCronScheduleString": "0 0/2 * * * ?"
     }
   },
   "ThumbnailGeneration": {


### PR DESCRIPTION
This PR introduces the SportsSectionSyncService to synchronize sports sections from MinSport, along with a scheduled Quartz job to run the synchronization automatically.
Changes included:

Implemented SportsSectionSyncService for fetching and processing sports sections from MinSport.
Added a Quartz job to schedule automatic synchronization.
Created mapping logic for ExternalSportsSectionDto to WorkshopDraft.
Added test controllers to verify synchronization manually in development.
Unit tests added for various scenarios
