### PR TITLE
Fix DateTimeRange Update For Workshops

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/DateTimeRangeDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/DateTimeRangeDto.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text;
 using System.Text.Json.Serialization;
 using OutOfSchool.BusinessLogic.Util.JsonTools;
 using OutOfSchool.Services.Enums;
@@ -72,23 +73,21 @@ public static class DateTimeRangeDtoExtensions
     {
         var activeModels = modelList.Where(dtr => dtr.IsDeleted == false).ToList();
         var result = new List<DateTimeRange>();
+        var dtoListDict = dtoList.ToDictionary(DateTimeRangeDtoToString);
 
-        var existingDtos = dtoList.Where(dto => dto.Id > 0).ToList();
-        var newDtos = dtoList.Where(dto => dto.Id <= 0).ToList();
-
-        var existingDtoDict = existingDtos.ToDictionary(dto => dto.Id);
-
-        // Update existing models that have matching DTOs
+        // Add active models that have matching DTOs to the result
         foreach (var model in activeModels)
         {
-            if (existingDtoDict.TryGetValue(model.Id, out var dto))
+            var key = DateTimeRangeToString(model);
+            if (dtoListDict.TryGetValue(key, out var dto))
             {
-                result.Add(dto.SetToModel(model));
+                result.Add(model);
+                dtoListDict.Remove(key);
             }
         }
 
-        // Add new models for all new DTOs (those with ID = 0)
-        result.AddRange(newDtos.Select(newDto => newDto.ToModel()));
+        // Add new models for all new DTOs to the result
+        result.AddRange(dtoListDict.Values.Select(dto => dto.ToModel()));
 
         return result;
     }
@@ -118,4 +117,22 @@ public static class DateTimeRangeDtoExtensions
 
     public static List<DateTimeRangeDto> ToNotDeletedDto(this IEnumerable<DateTimeRange> list)
         => list.MapNonDeletedToList(ToDto);
+
+    private static string DateTimeRangeDtoToString(DateTimeRangeDto dto)
+    {
+        var builder = new StringBuilder(dto.StartTime.ToString());
+        builder.Append(dto.EndTime.ToString());
+        builder.Append(dto.Workdays?.ToDaysBitMask().GetHashCode());
+
+        return builder.ToString();
+    }
+
+    private static string DateTimeRangeToString(DateTimeRange model)
+    {
+        var builder = new StringBuilder(model.StartTime.ToString());
+        builder.Append(model.EndTime.ToString());
+        builder.Append(model.Workdays.GetHashCode());
+
+        return builder.ToString();
+    }
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/DateTimeRangeDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/DateTimeRangeDto.cs
@@ -79,7 +79,7 @@ public static class DateTimeRangeDtoExtensions
         foreach (var model in activeModels)
         {
             var key = DateTimeRangeToString(model);
-            if (dtoListDict.TryGetValue(key, out var dto))
+            if (dtoListDict.ContainsKey(key))
             {
                 result.Add(model);
                 dtoListDict.Remove(key);

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateUpdateDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Workshops/WorkshopCreateUpdateDto.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
-using OutOfSchool.BusinessLogic.Util.CustomComparers;
 using OutOfSchool.BusinessLogic.Util.JsonTools;
 using OutOfSchool.Common.Enums.Workshop;
 using static OutOfSchool.BusinessLogic.Validators.ConditionalValidationAttributes;
@@ -31,10 +30,7 @@ public static class WorkshopCreateUpdateDtoExtensions
         model.ShortTitle = dto.ShortTitle?.Trim(TrimChars);
         model.MinAge = dto.MinAge ?? default;
         model.MaxAge = dto.MaxAge ?? default;
-        model.DateTimeRanges = dto.DateTimeRanges?.ToModel()
-            .Concat(model.DateTimeRanges ?? [])
-            .Distinct(new DateTimeRangeComparerWithoutFK())
-            .ToList() ?? [];
+        model.DateTimeRanges = dto.DateTimeRanges?.SetToModel(model.DateTimeRanges);
         model.IsPaid = dto.IsPaid;
         model.Price = dto.Price ?? default;
         model.PayRate = dto.PayRate ?? default;

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -1041,6 +1041,47 @@ public class WorkshopServiceTests
     }
 
     [Test]
+    public async Task Update_WhenEntityIsValidAndDateTimeRangesAreFilled_ShouldReturnUpdatedEntityWithProperDateTimeRanges()
+    {
+        var dto = WorkshopCreateUpdateDtoGenerator.Generate();
+        dto.InstitutionHierarchyId = Guid.NewGuid();
+        dto.WorkshopType = WorkshopType.CreativeUnion;
+        dto.Teachers = TeachersGenerator.Generate(2).ToDto();
+        dto.DateTimeRanges = [
+            new() { StartTime = TimeSpan.Parse("18:00"), EndTime = TimeSpan.Parse("19:45"), Workdays = [DaysBitMask.Monday, DaysBitMask.Tuesday] },
+            new() { StartTime = TimeSpan.Parse("18:30"), EndTime = TimeSpan.Parse("20:15"), Workdays = [DaysBitMask.Wednesday, DaysBitMask.Thursday] },
+            new() { StartTime = TimeSpan.Parse("19:00"), EndTime = TimeSpan.Parse("20:45"), Workdays = [DaysBitMask.Friday] },
+            new() { StartTime = TimeSpan.Parse("14:15"), EndTime = TimeSpan.Parse("16:45"), Workdays = [DaysBitMask.Saturday, DaysBitMask.Sunday] },
+            ];
+        var workshop = dto.SetToModel(WorkshopGenerator.Generate());
+        workshop.Teachers = TeachersGenerator.Generate(2);
+        workshop.Applications = [];
+        workshop.DateTimeRanges = [
+            new() { Id = 1, StartTime = TimeSpan.Parse("18:00"), EndTime = TimeSpan.Parse("19:45"), Workdays = new List<DaysBitMask>{DaysBitMask.Monday, DaysBitMask.Tuesday }.ToDaysBitMask() },
+            new() { Id = 2, StartTime = TimeSpan.Parse("18:30"), EndTime = TimeSpan.Parse("20:30"), Workdays = new List<DaysBitMask>{DaysBitMask.Wednesday, DaysBitMask.Friday}.ToDaysBitMask() },
+            new() { Id = 3, StartTime = TimeSpan.Parse("14:15"), EndTime = TimeSpan.Parse("16:45"), Workdays = new List<DaysBitMask>{DaysBitMask.Saturday}.ToDaysBitMask() }
+            ];
+
+        applicationRepository.Setup(x => x.CountTakenSeatsForWorkshops(It.IsAny<List<Guid>>())).ReturnsAsync(new List<WorkshopTakenSeats>());
+        workshopRepository.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<Workshop>>>()))
+            .Returns((Func<Task<Workshop>> f) => f.Invoke());
+
+        workshopRepository.Setup(r => r.GetWithNavigations(It.IsAny<Guid>(), false))
+            .ReturnsAsync(workshop);
+
+        // Act
+        var result = await workshopService.Update(dto).ConfigureAwait(false);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.DateTimeRanges.Count.Should().Be(4);
+        result.DateTimeRanges[0].Id.Should().Be(1);
+        result.DateTimeRanges[1].Id.Should().Be(0);
+        result.DateTimeRanges[2].Id.Should().Be(0);
+        result.DateTimeRanges[3].Id.Should().Be(0);
+    }
+
+    [Test]
     [TestCase(5U, uint.MaxValue, 5, WorkshopStatus.Closed, WorkshopStatus.Open)]
     [TestCase(5U, 5U, 5, WorkshopStatus.Open, WorkshopStatus.Closed)]
     [TestCase(5U, 3U, 5, WorkshopStatus.Open, WorkshopStatus.Closed)]
@@ -1279,7 +1320,7 @@ public class WorkshopServiceTests
     }
 
     [Test]
-    public async Task UpdateV2_WhenInstitutionTitleIsMinSportAndDateTimeRangesAreFilled_ShouldSetSectionAndChampionPath()
+    public async Task UpdateV2_WhenDtoIsValidAndDateTimeRangesAreFilled_ShouldReturnUpdatedEntityWithProperDateTimeRanges()
     {
         // Arrange
         var dto = WorkshopV2DtoGenerator.Generate();

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -25,6 +25,7 @@ using OutOfSchool.BusinessLogic.Services.Images;
 using OutOfSchool.BusinessLogic.Services.SearchString;
 using OutOfSchool.BusinessLogic.Services.SubordinationStructure;
 using OutOfSchool.BusinessLogic.Services.Workshops;
+using OutOfSchool.BusinessLogic.Util;
 using OutOfSchool.Common.Config;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Enums.Workshop;
@@ -44,7 +45,7 @@ public class WorkshopServiceTests
 {
     private IWorkshopService workshopService;
     private Mock<IWorkshopRepository> workshopRepository;
-    private Mock<IInstitutionHierarchyService>  institutionHierarchyServiceMock;
+    private Mock<IInstitutionHierarchyService> institutionHierarchyServiceMock;
     private Mock<IEntityRepositorySoftDeleted<long, DateTimeRange>> dateTimeRangeRepository;
     private Mock<IEntityRepositorySoftDeleted<Guid, ChatRoomWorkshop>> roomRepository;
     private Mock<ITeacherService> teacherService;
@@ -97,31 +98,31 @@ public class WorkshopServiceTests
         providerId = Guid.NewGuid();
         studySubjectId = Guid.NewGuid();
 
-    workshopService =
-                new WorkshopService(
-                    workshopRepository.Object,
-                    languageServiceMock.Object,
-                    institutionHierarchyServiceMock.Object,
-                    tagRepository.Object,
-                    dateTimeRangeRepository.Object,
-                    roomRepository.Object,
-                    teacherService.Object,
-                    logger.Object,
-                    workshopImagesMediator.Object,
-                    averageRatingServiceMock.Object,
-                    providerRepositoryMock.Object,
-                    currentUserServiceMock.Object,
-                    ministryAdminServiceMock.Object,
-                    regionAdminServiceMock.Object,
-                    codeficatorServiceMock.Object,
-                    tagServiceMock.Object,
-                    searchStringServiceMock.Object,
-                    contactsServiceMock.Object,
-                    applicationRepository.Object,
-                    featureManagerMock.Object,
-                    changesLogService.Object,
-                    institutionOptionsMock.Object
-                    );
+        workshopService =
+                    new WorkshopService(
+                        workshopRepository.Object,
+                        languageServiceMock.Object,
+                        institutionHierarchyServiceMock.Object,
+                        tagRepository.Object,
+                        dateTimeRangeRepository.Object,
+                        roomRepository.Object,
+                        teacherService.Object,
+                        logger.Object,
+                        workshopImagesMediator.Object,
+                        averageRatingServiceMock.Object,
+                        providerRepositoryMock.Object,
+                        currentUserServiceMock.Object,
+                        ministryAdminServiceMock.Object,
+                        regionAdminServiceMock.Object,
+                        codeficatorServiceMock.Object,
+                        tagServiceMock.Object,
+                        searchStringServiceMock.Object,
+                        contactsServiceMock.Object,
+                        applicationRepository.Object,
+                        featureManagerMock.Object,
+                        changesLogService.Object,
+                        institutionOptionsMock.Object
+                        );
         languageServiceMock.Setup(s => s.GetById(It.IsAny<long>()))
             .ReturnsAsync((long id) => new LanguageDto { Id = id, Name = "English" });
 
@@ -278,7 +279,7 @@ public class WorkshopServiceTests
         await workshopService.Invoking(w => w.Create(WorkshopCreateRequestDtoGenerator.FromModel(createdEntity)))
             .Should().ThrowAsync<InvalidOperationException>();
     }
-    
+
     [Test]
     public async Task Create_WhenInstitutionIdMatchesMinSport_ShouldSetWorkshopTypeToSectionAndIsChampionPathTrue()
     {
@@ -294,8 +295,8 @@ public class WorkshopServiceTests
         featureManagerMock.Setup(f => f.IsEnabledAsync("EnableWorkshopGroupTypeField")).ReturnsAsync(true);
         var dto = WorkshopCreateRequestDtoGenerator.FromModel(createdEntity);
         workshopRepository.Setup(w => w.Create(It.IsAny<Workshop>()))
-            .ReturnsAsync((Workshop w) => w); 
-        
+            .ReturnsAsync((Workshop w) => w);
+
         // Act
         var result = await workshopService.Create(dto).ConfigureAwait(false);
 
@@ -303,7 +304,7 @@ public class WorkshopServiceTests
         result.WorkshopType.Should().Be(WorkshopType.Section);
         result.IsChampionPath.Should().BeTrue();
     }
-    
+
     [Test]
     public async Task Create_WhenInstitutionTitleIsNotMinSport_ShouldNotChangeWorkshopTypeAndIsChampionPathFalse()
     {
@@ -319,11 +320,11 @@ public class WorkshopServiceTests
             {
                 Institution = new InstitutionDto { Title = "Інший заклад" }
             });
-    
+
         featureManagerMock.Setup(f => f.IsEnabledAsync("EnableWorkshopGroupTypeField")).ReturnsAsync(true);
 
         var dto = WorkshopCreateRequestDtoGenerator.FromModel(createdEntity);
-        
+
         workshopRepository.Setup(w => w.Create(It.IsAny<Workshop>()))
             .ReturnsAsync((Workshop w) => w);
 
@@ -556,7 +557,7 @@ public class WorkshopServiceTests
         result.Should().NotBeNull();
         result.UploadingCoverImageResult.Should().BeNull();
     }
-    
+
     [Test]
     public async Task CreateV2_WhenInstitutionIdMatchesMinSport_ShouldSetWorkshopTypeToSectionAndIsChampionPathTrue()
     {
@@ -572,7 +573,7 @@ public class WorkshopServiceTests
         featureManagerMock.Setup(f => f.IsEnabledAsync("EnableWorkshopGroupTypeField")).ReturnsAsync(true);
 
         var dto = WorkshopV2CreateRequestDtoGenerator.FromModel(createdEntity);
-        
+
         workshopRepository.Setup(w => w.Create(It.IsAny<Workshop>()))
             .ReturnsAsync((Workshop w) => w);
 
@@ -993,7 +994,7 @@ public class WorkshopServiceTests
         var changeFirstEntityDto = WorkshopCreateUpdateDtoGenerator.Generate();
         changeFirstEntityDto.DateTimeRanges = [];
         changeFirstEntityDto.AvailableSeats = 0;
-        var changedFirstEntity = changeFirstEntityDto.SetToModel(WorkshopGenerator.Generate().WithApplications().WithAddress()); 
+        var changedFirstEntity = changeFirstEntityDto.SetToModel(WorkshopGenerator.Generate().WithApplications().WithAddress());
         var teachers = TeachersGenerator.Generate(teachersInWorkshop).WithWorkshop(changedFirstEntity);
         var provider = ProvidersGenerator.Generate();
         changedFirstEntity.Teachers = teachers;
@@ -1141,7 +1142,7 @@ public class WorkshopServiceTests
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"*Language with ID = {dto.LanguageOfEducationId}*");
     }
-    
+
     [Test]
     public async Task Update_WhenInstitutionTitleIsExactlyMinSport_ShouldSetSectionAndChampionPath()
     {
@@ -1158,11 +1159,11 @@ public class WorkshopServiceTests
         workshop.Applications = [];
 
         SetupUpdate(workshop);
-        
+
         applicationRepository
             .Setup(x => x.CountTakenSeatsForWorkshops(It.IsAny<List<Guid>>()))
             .ReturnsAsync(new List<WorkshopTakenSeats>());
-        
+
         SetupInstitutionHierarchyAsMinSport(dto.InstitutionHierarchyId.Value);
         // Act
         var result = await workshopService.Update(dto).ConfigureAwait(false);
@@ -1171,7 +1172,7 @@ public class WorkshopServiceTests
         result.WorkshopType.Should().Be(WorkshopType.Section);
         result.IsChampionPath.Should().BeTrue();
     }
-    
+
     [Test]
     public async Task Update_WhenInstitutionTitleIsDifferent_ShouldKeepWorkshopTypeAndSetChampionPathFalse()
     {
@@ -1191,7 +1192,7 @@ public class WorkshopServiceTests
         applicationRepository
             .Setup(x => x.CountTakenSeatsForWorkshops(It.IsAny<List<Guid>>()))
             .ReturnsAsync(new List<WorkshopTakenSeats>());
-        
+
         institutionHierarchyServiceMock.Setup(s => s.GetById(dto.InstitutionHierarchyId.Value))
             .ReturnsAsync(new InstitutionHierarchyDto
             {
@@ -1205,7 +1206,7 @@ public class WorkshopServiceTests
         result.WorkshopType.Should().Be(WorkshopType.CreativeUnion);
         result.IsChampionPath.Should().BeFalse();
     }
-    
+
     [Test]
     public async Task Update_WhenInstitutionHierarchyIdIsNull_ShouldThrowInvalidOperationException()
     {
@@ -1237,7 +1238,7 @@ public class WorkshopServiceTests
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"*Language with ID = {dto.LanguageOfEducationId}*");
     }
-    
+
     [Test]
     public async Task UpdateV2_WhenInstitutionTitleIsExactlyMinSport_ShouldSetSectionAndChampionPath()
     {
@@ -1248,7 +1249,7 @@ public class WorkshopServiceTests
         dto.Teachers = TeachersGenerator.Generate(2).ToDto();
         dto.DateTimeRanges = [];
         dto.AvailableSeats = 0;
-    
+
         var workshop = dto.SetToModel(WorkshopGenerator.Generate());
         workshop.Teachers = TeachersGenerator.Generate(2);
         workshop.Applications = [];
@@ -1276,7 +1277,61 @@ public class WorkshopServiceTests
         result.Workshop.WorkshopType.Should().Be(WorkshopType.Section);
         result.Workshop.IsChampionPath.Should().BeTrue();
     }
-    
+
+    [Test]
+    public async Task UpdateV2_WhenInstitutionTitleIsMinSportAndDateTimeRangesAreFilled_ShouldSetSectionAndChampionPath()
+    {
+        // Arrange
+        var dto = WorkshopV2DtoGenerator.Generate();
+        dto.InstitutionHierarchyId = Guid.NewGuid();
+        dto.WorkshopType = WorkshopType.CreativeUnion;
+        dto.Teachers = TeachersGenerator.Generate(2).ToDto();
+        dto.DateTimeRanges = [
+            new() { StartTime = TimeSpan.Parse("18:00"), EndTime = TimeSpan.Parse("19:45"), Workdays = [DaysBitMask.Monday, DaysBitMask.Tuesday] },
+            new() { StartTime = TimeSpan.Parse("18:30"), EndTime = TimeSpan.Parse("20:15"), Workdays = [DaysBitMask.Wednesday, DaysBitMask.Thursday] },
+            new() { StartTime = TimeSpan.Parse("19:00"), EndTime = TimeSpan.Parse("20:45"), Workdays = [DaysBitMask.Friday] },
+            new() { StartTime = TimeSpan.Parse("14:15"), EndTime = TimeSpan.Parse("16:45"), Workdays = [DaysBitMask.Saturday, DaysBitMask.Sunday] },
+            ];
+
+
+        var workshop = dto.SetToModel(WorkshopGenerator.Generate());
+        workshop.Teachers = TeachersGenerator.Generate(2);
+        workshop.Applications = [];
+        workshop.DateTimeRanges = [
+            new() { Id = 1, StartTime = TimeSpan.Parse("18:00"), EndTime = TimeSpan.Parse("19:45"), Workdays = new List<DaysBitMask>{DaysBitMask.Monday, DaysBitMask.Tuesday }.ToDaysBitMask() },
+            new() { Id = 2,StartTime = TimeSpan.Parse("18:30"), EndTime = TimeSpan.Parse("20:30"), Workdays = new List<DaysBitMask>{DaysBitMask.Wednesday, DaysBitMask.Friday}.ToDaysBitMask() },
+            new() { Id = 3,StartTime = TimeSpan.Parse("14:15"), EndTime = TimeSpan.Parse("16:45"), Workdays = new List<DaysBitMask>{DaysBitMask.Saturday}.ToDaysBitMask() }
+            ];
+
+        SetupUpdate(workshop);
+
+        SetupInstitutionHierarchyAsMinSport(dto.InstitutionHierarchyId.Value);
+
+        applicationRepository.Setup(x => x.CountTakenSeatsForWorkshops(It.IsAny<List<Guid>>()))
+            .ReturnsAsync(new List<WorkshopTakenSeats>());
+
+        workshopImagesMediator.Setup(i => i.ChangeImagesAsync(It.IsAny<Workshop>(), It.IsAny<IList<string>>(), It.IsAny<IList<IFormFile>>()))
+            .ReturnsAsync(new MultipleImageChangingResult());
+
+        workshopImagesMediator.Setup(i => i.ChangeCoverImageAsync(It.IsAny<Workshop>(), It.IsAny<string>(), It.IsAny<IFormFile>()))
+            .ReturnsAsync(new ImageChangingResult());
+
+        workshopRepository.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<(Workshop, MultipleImageChangingResult, ImageChangingResult)>>>()))
+            .Returns((Func<Task<(Workshop, MultipleImageChangingResult, ImageChangingResult)>> f) => f.Invoke());
+
+        // Act
+        var result = await workshopService.UpdateV2(dto).ConfigureAwait(false);
+
+        // Assert
+        result.Workshop.WorkshopType.Should().Be(WorkshopType.Section);
+        result.Workshop.IsChampionPath.Should().BeTrue();
+        result.Workshop.DateTimeRanges.Count.Should().Be(4);
+        result.Workshop.DateTimeRanges[0].Id.Should().Be(1);
+        result.Workshop.DateTimeRanges[1].Id.Should().Be(0);
+        result.Workshop.DateTimeRanges[2].Id.Should().Be(0);
+        result.Workshop.DateTimeRanges[3].Id.Should().Be(0);
+    }
+
     [Test]
     public async Task UpdateV2_WhenInstitutionTitleIsNotMinSport_ShouldKeepWorkshopTypeAndSetChampionPathFalse()
     {
@@ -1319,7 +1374,7 @@ public class WorkshopServiceTests
         result.Workshop.WorkshopType.Should().Be(WorkshopType.Studio);
         result.Workshop.IsChampionPath.Should().BeFalse();
     }
-    
+
     [Test]
     public async Task UpdateV2_WhenInstitutionHierarchyIdIsNull_ShouldThrowInvalidOperationException()
     {
@@ -1511,9 +1566,10 @@ public class WorkshopServiceTests
         var result = await workshopService.GetByFilter(filter).ConfigureAwait(false);
 
         // Assert
-        result.Should().BeEquivalentTo(new SearchResult<WorkshopCard>() { 
-            Entities = workshops.ToCard().AsReadOnly(), 
-            TotalAmount = workshops.Count() 
+        result.Should().BeEquivalentTo(new SearchResult<WorkshopCard>()
+        {
+            Entities = workshops.ToCard().AsReadOnly(),
+            TotalAmount = workshops.Count()
         });
     }
 
@@ -1679,13 +1735,13 @@ public class WorkshopServiceTests
     #endregion
 
     #region Setup
-    
+
     private void SetupInstitutionHierarchy()
     {
         institutionHierarchyServiceMock.Setup(s => s.GetById(It.IsAny<Guid>()))
             .ReturnsAsync(new InstitutionHierarchyDto
             {
-                Institution = new InstitutionDto { Title = "Мінспорт"}
+                Institution = new InstitutionDto { Title = "Мінспорт" }
             });
     }
     private void SetupInstitutionHierarchyAsMinSport(Guid institutionHierarchyId)
@@ -1844,8 +1900,8 @@ public class WorkshopServiceTests
         workshopRepository.Setup(w => w.SaveChangesAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(It.IsAny<int>());
 
         workshopRepository.Setup(r => r.RunInTransaction(It.IsAny<Func<Task<Workshop>>>()))
-            .Returns((Func<Task<Workshop>> f) => f.Invoke()); 
-        
+            .Returns((Func<Task<Workshop>> f) => f.Invoke());
+
         SetupInstitutionHierarchy();
     }
 

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/Database/WorkshopServiceTests.cs
@@ -1293,14 +1293,13 @@ public class WorkshopServiceTests
             new() { StartTime = TimeSpan.Parse("14:15"), EndTime = TimeSpan.Parse("16:45"), Workdays = [DaysBitMask.Saturday, DaysBitMask.Sunday] },
             ];
 
-
         var workshop = dto.SetToModel(WorkshopGenerator.Generate());
         workshop.Teachers = TeachersGenerator.Generate(2);
         workshop.Applications = [];
         workshop.DateTimeRanges = [
             new() { Id = 1, StartTime = TimeSpan.Parse("18:00"), EndTime = TimeSpan.Parse("19:45"), Workdays = new List<DaysBitMask>{DaysBitMask.Monday, DaysBitMask.Tuesday }.ToDaysBitMask() },
-            new() { Id = 2,StartTime = TimeSpan.Parse("18:30"), EndTime = TimeSpan.Parse("20:30"), Workdays = new List<DaysBitMask>{DaysBitMask.Wednesday, DaysBitMask.Friday}.ToDaysBitMask() },
-            new() { Id = 3,StartTime = TimeSpan.Parse("14:15"), EndTime = TimeSpan.Parse("16:45"), Workdays = new List<DaysBitMask>{DaysBitMask.Saturday}.ToDaysBitMask() }
+            new() { Id = 2, StartTime = TimeSpan.Parse("18:30"), EndTime = TimeSpan.Parse("20:30"), Workdays = new List<DaysBitMask>{DaysBitMask.Wednesday, DaysBitMask.Friday}.ToDaysBitMask() },
+            new() { Id = 3, StartTime = TimeSpan.Parse("14:15"), EndTime = TimeSpan.Parse("16:45"), Workdays = new List<DaysBitMask>{DaysBitMask.Saturday}.ToDaysBitMask() }
             ];
 
         SetupUpdate(workshop);


### PR DESCRIPTION
1) Fixed the SetToModel method of the DateTimeRangeDto class.
2) Added private methods (DateTimeRangeToString and DateTimeRangeDtoToString) to the DateTimeRangeDto class.
3) Added a test to verify updating the DateTimeRange property of the Workshop class.
4) Fixed the SetToModel method of the WorkshopCreateUpdateDto class which is used in V1 (without images).
5) Added a test to verify updating the DateTimeRange property of the Workshop class for V1 (without images).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved workshop date/time range handling: matching now uses a stable composite key (start/end/workdays) to reliably retain, update, or create ranges; behavior for add/update flows changed without altering public APIs.
* **Tests**
  * Added/expanded tests covering multiple date/time range scenarios and update/create flows.
* **Chores**
  * Minor formatting and import cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->