### PR TITLE
Extended the validation logic for CompetitiveEventAccountingTypeId field

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Enums/CompetitiveEventAccountingTypes.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Enums/CompetitiveEventAccountingTypes.cs
@@ -1,0 +1,8 @@
+﻿namespace OutOfSchool.BusinessLogic.Enums;
+public enum CompetitiveEventAccountingTypes
+{
+    EducationalProject = 1,
+    Competition = 2,
+    MainCompetition = 3,
+    ContestStage = 4
+}

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventBaseDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventBaseDto.cs
@@ -1,5 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
 using OutOfSchool.BusinessLogic.Util.CustomValidation;
@@ -7,6 +7,8 @@ using OutOfSchool.BusinessLogic.Util.JsonTools;
 using OutOfSchool.BusinessLogic.Validators;
 using OutOfSchool.Common.Enums;
 using OutOfSchool.Common.Enums.CompetitiveEvent;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 
@@ -60,7 +62,17 @@ public class CompetitiveEventBaseDto : IValidatableObject, IHasContactsDto<OutOf
     public uint NumberOfSeats { get; set; } = uint.MaxValue;
 
     [Required]
-    public int CompetitiveEventAccountingTypeId { get; set; }
+    [JsonIgnore]
+    [EnumDataType(typeof(CompetitiveEventAccountingTypes), ErrorMessage = Constants.EnumErrorMessage)]
+    public CompetitiveEventAccountingTypes CompetitiveEventAccountingTypeId { get; set; }
+
+    [JsonPropertyName("competitiveEventAccountingTypeId")]
+    [BindNever]
+    public int CompetitiveEventAccountingTypeIdAsInt
+    {
+        get => (int)CompetitiveEventAccountingTypeId;
+        set => CompetitiveEventAccountingTypeId = (CompetitiveEventAccountingTypes)value;
+    }
 
     [Required]
     [MinLength(Constants.MinLengthOfDescriptionOfTheEnrollmentProcedureForCompetitiveEvent)]
@@ -192,7 +204,7 @@ public static class CompetitiveEventBaseDtoExtensions
         ScheduledStartTime = dto.ScheduledStartTime,
         ScheduledEndTime = dto.ScheduledEndTime,
         NumberOfSeats = dto.NumberOfSeats,
-        CompetitiveEventAccountingTypeId = dto.CompetitiveEventAccountingTypeId,
+        CompetitiveEventAccountingTypeId = (int)dto.CompetitiveEventAccountingTypeId,
         DescriptionOfTheEnrollmentProcedure = dto.DescriptionOfTheEnrollmentProcedure,
         OrganizerOfTheEventId = dto.OrganizerOfTheEventId,
         PlannedFormatOfClasses = dto.PlannedFormatOfClasses ?? default,
@@ -231,7 +243,7 @@ public static class CompetitiveEventBaseDtoExtensions
         model.ScheduledStartTime = dto.ScheduledStartTime;
         model.ScheduledEndTime = dto.ScheduledEndTime;
         model.NumberOfSeats = dto.NumberOfSeats;
-        model.CompetitiveEventAccountingTypeId = dto.CompetitiveEventAccountingTypeId;
+        model.CompetitiveEventAccountingTypeId = (int)dto.CompetitiveEventAccountingTypeId;
         model.DescriptionOfTheEnrollmentProcedure = dto.DescriptionOfTheEnrollmentProcedure;
         model.OrganizerOfTheEventId = dto.OrganizerOfTheEventId;
         model.PlannedFormatOfClasses = dto.PlannedFormatOfClasses ?? model.PlannedFormatOfClasses;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/CompetitiveEventDto.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
+using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
 using OutOfSchool.BusinessLogic.Util.JsonTools;
 
@@ -52,7 +53,7 @@ public static class CompetitiveEventDtoExtensions
             ScheduledStartTime = model.ScheduledStartTime,
             ScheduledEndTime = model.ScheduledEndTime,
             NumberOfSeats = model.NumberOfSeats,
-            CompetitiveEventAccountingTypeId = model.CompetitiveEventAccountingTypeId,
+            CompetitiveEventAccountingTypeId = (CompetitiveEventAccountingTypes)model.CompetitiveEventAccountingTypeId,
             DescriptionOfTheEnrollmentProcedure = model.DescriptionOfTheEnrollmentProcedure,
             OrganizerOfTheEventId = model.OrganizerOfTheEventId,
             PlannedFormatOfClasses = model.PlannedFormatOfClasses,

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventAboutDto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/TempSave/CompetitiveEventAboutDto.cs
@@ -1,7 +1,8 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Validators;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using static OutOfSchool.BusinessLogic.Validators.ConditionalValidationAttributes;
 
 namespace OutOfSchool.BusinessLogic.Models.CompetitiveEvent.TempSave;
@@ -51,7 +52,17 @@ public class CompetitiveEventAboutDto : IValidatableObject
     public DateTimeOffset? RegistrationEndTime { get; set; }
 
     [Required]
-    public int CompetitiveEventAccountingTypeId { get; set; }
+    [JsonIgnore]
+    [EnumDataType(typeof(CompetitiveEventAccountingTypes), ErrorMessage = Constants.EnumErrorMessage)]
+    public CompetitiveEventAccountingTypes CompetitiveEventAccountingTypeId { get; set; }
+
+    [JsonPropertyName("competitiveEventAccountingTypeId")]
+    [BindNever]
+    public int CompetitiveEventAccountingTypeIdAsInt
+    {
+        get => (int)CompetitiveEventAccountingTypeId;
+        set => CompetitiveEventAccountingTypeId = (CompetitiveEventAccountingTypes)value;
+    }
 
     [Required]
     public uint NumberOfSeats { get; set; } = uint.MaxValue;

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/CompetitiveEvent/V2/CompetitiveEventV2Dto.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
 using OutOfSchool.Services.Models.CompetitiveEventDrafts;
 using OutOfSchool.Services.Models.ContactInfo;
@@ -79,7 +80,7 @@ public static class CompetitiveEventV2DtoExtensions
         ScheduledStartTime = model.ScheduledStartTime,
         ScheduledEndTime = model.ScheduledEndTime,
         NumberOfSeats = model.NumberOfSeats,
-        CompetitiveEventAccountingTypeId = model.CompetitiveEventAccountingTypeId,
+        CompetitiveEventAccountingTypeId = (CompetitiveEventAccountingTypes)model.CompetitiveEventAccountingTypeId,
         DescriptionOfTheEnrollmentProcedure = model.DescriptionOfTheEnrollmentProcedure,
         OrganizerOfTheEventId = model.OrganizerOfTheEventId,
         PlannedFormatOfClasses = model.PlannedFormatOfClasses,
@@ -155,7 +156,7 @@ public static class CompetitiveEventV2DtoExtensions
             CoverImageId = draft.CoverImageId,
             ImageIds = draft.Images?.Select(x => x.ExternalStorageId).ToList() ?? [],
             CoverageId = draft.CoverageId,
-            CompetitiveEventAccountingTypeId = draft.CompetitiveEventAccountingTypeId,
+            CompetitiveEventAccountingTypeId = (CompetitiveEventAccountingTypes)draft.CompetitiveEventAccountingTypeId,
             SubDirectionIds = draft.CompetitiveEventDraftContent?.SubDirectionIds ??
                               draft.CompetitiveEvent?.SubDirections?.Select(s => s.Id).ToList() ?? [],
             CompetitiveEventDescriptionItems = draft.CompetitiveEventDraftContent?.CompetitiveEventDescriptionItems?.ToDto(),
@@ -180,7 +181,7 @@ public static class CompetitiveEventV2DtoExtensions
             CompetitiveEventId = competitiveEventV2Dto.Id == Guid.Empty ? null : competitiveEventV2Dto.Id,
             CoverImageId = competitiveEventV2Dto.CoverImageId,
             CoverageId = competitiveEventV2Dto.CoverageId,
-            CompetitiveEventAccountingTypeId = competitiveEventV2Dto.CompetitiveEventAccountingTypeId,
+            CompetitiveEventAccountingTypeId = (int)competitiveEventV2Dto.CompetitiveEventAccountingTypeId,
             CompetitiveEventDraftContent = competitiveEventV2Dto.ToDraftContent(),
             // This is needed for search
             CATOTTGId = competitiveEventV2Dto.Contacts.SingleOrDefault(c => c.IsDefault)?.Address?.CATOTTGId ?? 0,
@@ -244,7 +245,7 @@ public static class CompetitiveEventV2DtoExtensions
         model.ScheduledStartTime = dto.ScheduledStartTime;
         model.ScheduledEndTime = dto.ScheduledEndTime;
         model.NumberOfSeats = dto.NumberOfSeats;
-        model.CompetitiveEventAccountingTypeId = dto.CompetitiveEventAccountingTypeId;
+        model.CompetitiveEventAccountingTypeId = (int)dto.CompetitiveEventAccountingTypeId;
         model.DescriptionOfTheEnrollmentProcedure = dto.DescriptionOfTheEnrollmentProcedure;
         model.OrganizerOfTheEventId = dto.OrganizerOfTheEventId;
         model.PlannedFormatOfClasses = dto.PlannedFormatOfClasses ?? model.PlannedFormatOfClasses;
@@ -282,7 +283,7 @@ public static class CompetitiveEventV2DtoExtensions
         ScheduledStartTime = dto.ScheduledStartTime,
         ScheduledEndTime = dto.ScheduledEndTime,
         NumberOfSeats = dto.NumberOfSeats,
-        CompetitiveEventAccountingTypeId = dto.CompetitiveEventAccountingTypeId,
+        CompetitiveEventAccountingTypeId = (int)dto.CompetitiveEventAccountingTypeId,
         DescriptionOfTheEnrollmentProcedure = dto.DescriptionOfTheEnrollmentProcedure,
         OrganizerOfTheEventId = dto.OrganizerOfTheEventId,
         PlannedFormatOfClasses = dto.PlannedFormatOfClasses ?? default,

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventServiceTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventServiceTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using OutOfSchool.BusinessLogic;
+using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Services;
@@ -132,7 +133,7 @@ public class CompetitiveEventServiceTests
             ScheduledEndTime = DateTime.UtcNow,
             NumberOfSeats = 10,
             OrganizerOfTheEventId = Guid.NewGuid(),
-            CompetitiveEventAccountingTypeId = 1,
+            CompetitiveEventAccountingTypeId = CompetitiveEventAccountingTypes.EducationalProject,
         };
         // Act
         var countBeforeCreating = await repo.Count().ConfigureAwait(false);
@@ -175,7 +176,7 @@ public class CompetitiveEventServiceTests
             ScheduledEndTime = DateTime.UtcNow,
             NumberOfSeats = 10,
             OrganizerOfTheEventId = Guid.NewGuid(),
-            CompetitiveEventAccountingTypeId = 1,
+            CompetitiveEventAccountingTypeId = CompetitiveEventAccountingTypes.EducationalProject,
         };
 
         // Act and Assert
@@ -198,7 +199,7 @@ public class CompetitiveEventServiceTests
             ScheduledEndTime = DateTime.UtcNow,
             NumberOfSeats = 10,
             OrganizerOfTheEventId = Guid.NewGuid(),
-            CompetitiveEventAccountingTypeId = 1,
+            CompetitiveEventAccountingTypeId = CompetitiveEventAccountingTypes.EducationalProject,
         };
 
         // Act

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventServiceUpdateAndCreateTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Services/CompetitiveEventServiceUpdateAndCreateTests.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using OutOfSchool.BusinessLogic;
+using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Models;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Services;
@@ -17,6 +13,11 @@ using OutOfSchool.Services.Models;
 using OutOfSchool.Services.Models.CompetitiveEvents;
 using OutOfSchool.Services.Repository.Api;
 using OutOfSchool.Services.Repository.Base.Api;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace OutOfSchool.WebApi.Tests.Services;
 
@@ -67,7 +68,7 @@ class CompetitiveEventServiceUpdateAndCreateTests
         var input = new CompetitiveEventBaseDto
         {
             Title = "Test",
-            CompetitiveEventAccountingTypeId = 1,
+            CompetitiveEventAccountingTypeId = CompetitiveEventAccountingTypes.EducationalProject,
             SubDirectionIds = [1]
         };
 
@@ -113,7 +114,7 @@ class CompetitiveEventServiceUpdateAndCreateTests
         var input = new CompetitiveEventBaseDto
         {
             Title = "Test Event",
-            CompetitiveEventAccountingTypeId = 1,
+            CompetitiveEventAccountingTypeId = CompetitiveEventAccountingTypes.EducationalProject,
             SubDirectionIds = [1],
             CompetitiveEventDescriptionItems = new List<CompetitiveEventDescriptionItemDto>()
         };
@@ -122,7 +123,7 @@ class CompetitiveEventServiceUpdateAndCreateTests
         {
             Id = Guid.NewGuid(),
             Title = input.Title,
-            CompetitiveEventAccountingTypeId = input.CompetitiveEventAccountingTypeId
+            CompetitiveEventAccountingTypeId = (int)input.CompetitiveEventAccountingTypeId
         };
 
         mockSubDirectionRepository
@@ -161,7 +162,7 @@ class CompetitiveEventServiceUpdateAndCreateTests
         var input = new CompetitiveEventBaseDto
         {
             Title = "Test Event",
-            CompetitiveEventAccountingTypeId = 1,
+            CompetitiveEventAccountingTypeId = CompetitiveEventAccountingTypes.EducationalProject,
             SubDirectionIds = [1],
             CompetitiveEventDescriptionItems =
             [
@@ -174,7 +175,7 @@ class CompetitiveEventServiceUpdateAndCreateTests
         {
             Id = Guid.NewGuid(),
             Title = input.Title,
-            CompetitiveEventAccountingTypeId = input.CompetitiveEventAccountingTypeId,
+            CompetitiveEventAccountingTypeId = (int)input.CompetitiveEventAccountingTypeId,
             CompetitiveEventDescriptionItems =
             [
                 new CompetitiveEventDescriptionItem { Description = "Desc 1", SectionName = "Section 1" },

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventContactsDtoGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Bogus;
+using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.TempSave;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
@@ -27,7 +28,7 @@ public static class CompetitiveEventContactsDtoGenerator
         .RuleFor(x => x.ScheduledStartTime, f => f.Date.FutureOffset(1))
         .RuleFor(x => x.ScheduledEndTime, f => f.Date.FutureOffset(2))
         .RuleFor(x => x.NumberOfSeats, f => f.Random.UInt(1, 100))
-        .RuleFor(x => x.CompetitiveEventAccountingTypeId, f => f.Random.Int(1, 10))
+        .RuleFor(x => x.CompetitiveEventAccountingTypeId, f => (CompetitiveEventAccountingTypes)f.Random.Int(1, 4))
         .RuleFor(x => x.MinimumAge, f => f.Random.Int(5, 8))
         .RuleFor(x => x.MaximumAge, f => f.Random.Int(9, 15))
         .RuleFor(x => x.Base64CoverImage, f => f.Image.LoremFlickrUrl())

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventV2DtoGenerator.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestDataGenerators/CompetitiveEventV2DtoGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Bogus;
+using OutOfSchool.BusinessLogic.Enums;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent;
 using OutOfSchool.BusinessLogic.Models.CompetitiveEvent.V2;
 using OutOfSchool.BusinessLogic.Models.ContactInfo;
@@ -29,7 +30,7 @@ public static class CompetitiveEventV2DtoGenerator
         .RuleFor(x => x.ScheduledStartTime, f => f.Date.FutureOffset(1))
         .RuleFor(x => x.ScheduledEndTime, f => f.Date.FutureOffset(2))
         .RuleFor(x => x.NumberOfSeats, f => f.Random.UInt(1, 100))
-        .RuleFor(x => x.CompetitiveEventAccountingTypeId, f => f.Random.Int(1, 10))
+        .RuleFor(x => x.CompetitiveEventAccountingTypeId, f => (CompetitiveEventAccountingTypes)f.Random.Int(1, 4))
         .RuleFor(x => x.OrganizerOfTheEventId, f => f.Random.Guid())
         .RuleFor(x => x.MinimumAge, f => f.Random.Int(5, 18))
         .RuleFor(x => x.CoverImageId, f => f.Image.LoremFlickrUrl())


### PR DESCRIPTION
- Added CompetitiveEventAccountingTypes enum to help with validation of CompetitiveEventAccountingTypeId field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CompetitiveEventAccountingTypes enum with four categories: EducationalProject, Competition, MainCompetition, and ContestStage.

* **Refactor**
  * Updated competitive event accounting type handling to use enum-based system for improved type safety and validation across API models and data layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->