### PR TITLE
Added custom ModelBinder and JsonConverter for trimming string fields in dtos at the system level

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/JsonTools/JsonModelBinder.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/JsonTools/JsonModelBinder.cs
@@ -7,6 +7,13 @@ namespace OutOfSchool.BusinessLogic.Util.JsonTools;
 
 public class JsonModelBinder : IModelBinder
 {
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public JsonModelBinder(IOptions<JsonOptions> jsonOptions)
+    {
+        _jsonOptions = jsonOptions.Value.JsonSerializerOptions;
+    }
+
     public Task BindModelAsync(ModelBindingContext bindingContext)
     {
         if (bindingContext == null)
@@ -23,10 +30,7 @@ public class JsonModelBinder : IModelBinder
 
             try
             {
-                var serviceProvider = bindingContext.HttpContext.RequestServices;
-                var jsonOptions = serviceProvider.GetRequiredService<IOptions<JsonOptions>>().Value.JsonSerializerOptions;
-
-                var result = JsonSerializerHelper.Deserialize(valueAsString, bindingContext.ModelType, jsonOptions);
+                var result = JsonSerializerHelper.Deserialize(valueAsString, bindingContext.ModelType, _jsonOptions);
                 
                 if (result != null)
                 {

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Util/JsonTools/JsonModelBinder.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Util/JsonTools/JsonModelBinder.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
 
 namespace OutOfSchool.BusinessLogic.Util.JsonTools;
 
@@ -21,7 +23,10 @@ public class JsonModelBinder : IModelBinder
 
             try
             {
-                var result = JsonSerializerHelper.Deserialize(valueAsString, bindingContext.ModelType);
+                var serviceProvider = bindingContext.HttpContext.RequestServices;
+                var jsonOptions = serviceProvider.GetRequiredService<IOptions<JsonOptions>>().Value.JsonSerializerOptions;
+
+                var result = JsonSerializerHelper.Deserialize(valueAsString, bindingContext.ModelType, jsonOptions);
                 
                 if (result != null)
                 {

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/EnumCollectionModelBinderProviderTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/EnumCollectionModelBinderProviderTests.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using OutOfSchool.WebApi.Util.ModelBinding;
 using System;
 using System.Collections.Generic;
+using static OutOfSchool.Tests.Common.TestModelBinderHelpers;
 
 namespace OutOfSchool.WebApi.Tests.Util;
 
@@ -225,44 +225,5 @@ public class EnumCollectionModelBinderProviderTests
         Assert.That(result1, Is.Not.SameAs(result2));
         Assert.That(result1, Is.InstanceOf<EnumCollectionModelBinder<TestEnum>>());
         Assert.That(result2, Is.InstanceOf<EnumCollectionModelBinder<TestEnum>>());
-    }
-
-    // Helper methods
-    private static ModelMetadata CreateModelMetadata(Type modelType)
-    {
-        if (modelType == null)
-            return null;
-
-        var metadataProvider = new EmptyModelMetadataProvider();
-        return metadataProvider.GetMetadataForType(modelType);
-    }
-
-    private static ModelBinderProviderContext CreateContext(ModelMetadata metadata)
-    {
-        var context = new TestModelBinderProviderContext();
-        context.SetMetadata(metadata);
-        return context;
-    }
-
-    // Custom implementation of ModelBinderProviderContext for testing
-    private class TestModelBinderProviderContext : ModelBinderProviderContext
-    {
-        private ModelMetadata _metadata;
-
-        public override ModelMetadata Metadata => _metadata;
-
-        public void SetMetadata(ModelMetadata metadata)
-        {
-            _metadata = metadata;
-        }
-
-        public override BindingInfo BindingInfo => null;
-
-        public override IModelBinder CreateBinder(ModelMetadata metadata)
-        {
-            throw new NotImplementedException("Not needed for these tests");
-        }
-
-        public override IModelMetadataProvider MetadataProvider => null;
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingJsonConverterTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingJsonConverterTests.cs
@@ -1,0 +1,61 @@
+﻿using NUnit.Framework;
+using OutOfSchool.WebApi.Util.JsonTools;
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+namespace OutOfSchool.WebApi.Tests.Util;
+
+[TestFixture]
+public class StringTrimmingJsonConverterTests
+{
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions();
+    private static readonly StringTrimmingJsonConverter _converter = new();
+
+    [TestCase("\"  Hello World  \"", "Hello World")]
+    [TestCase("\"NoSpaces\"", "NoSpaces")]
+    [TestCase("null", null)]
+    public void Read_WhenReaderIsNotNull_ShouldReturnTrimmedString(string jsonInput, string expectedOutput)
+    {
+        // Arrange
+        byte[] bytes = Encoding.UTF8.GetBytes(jsonInput);
+        var reader = new Utf8JsonReader(bytes.AsSpan());
+        reader.Read();
+
+        // Act
+        var result = _converter.Read(ref reader, typeof(string), _jsonSerializerOptions);
+
+        // Assert
+        Assert.AreEqual(expectedOutput, result);
+    }
+
+    [Test]
+    public void Write_WhenWriterIsNull_ThrowArgumentNullException()
+    {
+        // Arrange
+        var jsonTextWriter = null as Utf8JsonWriter;
+        string value = "Test String";
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => _converter.Write(jsonTextWriter, value, _jsonSerializerOptions));
+    }
+
+    [Test]
+    public void Write_WhenWriterIsNotNull_ShouldWriteValidJsonString()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        using var jsonTextWriter = new Utf8JsonWriter(stream);
+        string value = "  Test String  ";
+        var expectedValue = "\"  Test String  \"";
+
+        // Act
+        _converter.Write(jsonTextWriter, value, _jsonSerializerOptions);
+        jsonTextWriter.Flush();
+        var result = Encoding.UTF8.GetString(stream.ToArray());
+
+        // Assert
+        Assert.AreEqual(expectedValue, result);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderProviderTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderProviderTests.cs
@@ -43,6 +43,21 @@ public class StringTrimmingModelBinderProviderTests
     }
 
     [Test]
+    public void GetBinder_WithStringModelTypeAndBodyBindingSource_ReturnsNull()
+    {
+        // Arrange
+        var metadata = CreateModelMetadata(typeof(string));
+        var context = CreateContext(metadata);
+        context.BindingInfo.BindingSource = BindingSource.Body;
+
+        // Act
+        var result = _provider.GetBinder(context);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
     public void GetBinder_WithOtherModelType_ReturnsNull()
     {
         // Arrange

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderProviderTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderProviderTests.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using NUnit.Framework;
+using OutOfSchool.WebApi.Util.ModelBinding;
+using static OutOfSchool.Tests.Common.TestModelBinderHelpers;
+
+namespace OutOfSchool.WebApi.Tests.Util;
+
+[TestFixture]
+public class StringTrimmingModelBinderProviderTests
+{
+    private StringTrimmingModelBinderProvider _provider;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _provider = new StringTrimmingModelBinderProvider();
+    }
+
+    [Test]
+    public void GetBinder_WithNullContext_ReturnsNull()
+    {
+        // Act
+        var result = _provider.GetBinder(null);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void GetBinder_WithStringModelType_ReturnsProvider()
+    {
+        // Arrange
+        var metadata = CreateModelMetadata(typeof(string));
+        var context = CreateContext(metadata);
+        context.BindingInfo.BindingSource = BindingSource.Form;
+
+        // Act
+        var result = _provider.GetBinder(context);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.InstanceOf<StringTrimmingModelBinder>());
+    }
+
+    [Test]
+    public void GetBinder_WithOtherModelType_ReturnsNull()
+    {
+        // Arrange
+        var metadata = CreateModelMetadata(typeof(int));
+        var context = CreateContext(metadata);
+
+        // Act
+        var result = _provider.GetBinder(context);
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderTests.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using NUnit.Framework;
+using OutOfSchool.WebApi.Util.ModelBinding;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace OutOfSchool.WebApi.Tests.Util;
+
+[TestFixture]
+public class StringTrimmingModelBinderTests
+{
+    private StringTrimmingModelBinder _binder;
+    private DefaultModelBindingContext _bindingContext;
+    private SimpleValueProvider _valueProvider;
+    private ModelStateDictionary _modelState;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _binder = new StringTrimmingModelBinder();
+        _valueProvider = new SimpleValueProvider();
+        _modelState = new ModelStateDictionary();
+
+        _bindingContext = new DefaultModelBindingContext
+        {
+            ModelName = "testModel",
+            ValueProvider = _valueProvider,
+            ModelState = _modelState,
+            ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(string))
+        };
+    }
+
+    [Test]
+    public void BindModelAsync_WithNullBindingContext_ThrowsNullArgumentException()
+    {
+        // Act & Assert
+        var exception = Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await _binder.BindModelAsync(null));
+
+        Assert.That(exception.ParamName, Is.EqualTo("bindingContext"));
+    }
+
+    [Test]
+    public async Task BindModelAsync_WithNullValue_ReturnsNullModel()
+    {
+        // Arrange
+        _valueProvider.SetValue("testModel", null);
+
+        // Act
+        await _binder.BindModelAsync(_bindingContext);
+
+        // Assert
+        Assert.That(_bindingContext.Result.IsModelSet, Is.True);
+        var result = _bindingContext.Result.Model as string;
+        Assert.That(result, Is.Null);
+        Assert.That(_modelState.IsValid, Is.True);
+    }
+
+    [Test]
+    public async Task BindModelAsync_WithWhitespaceString_TrimsAndReturnsValue()
+    {
+        // Arrange
+        var value = "   example string   ";
+        var expectedValue = value.Trim();
+        _valueProvider.SetValue("testModel", value);
+
+        // Act
+        await _binder.BindModelAsync(_bindingContext);
+
+        // Assert
+        Assert.That(_bindingContext.Result.IsModelSet, Is.True);
+        var result = _bindingContext.Result.Model as string;
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.EqualTo(expectedValue));
+        Assert.That(_modelState.IsValid, Is.True);
+    }
+
+    private class SimpleValueProvider : IValueProvider
+    {
+        private readonly Dictionary<string, string> _values = new();
+
+        public void SetValue(string key, string value)
+        {
+            _values[key] = value;
+        }
+
+        public bool ContainsPrefix(string prefix)
+        {
+            return _values.ContainsKey(prefix);
+        }
+
+        public ValueProviderResult GetValue(string key)
+        {
+            if (_values.TryGetValue(key, out var value))
+            {
+                return new ValueProviderResult(value);
+            }
+
+            return ValueProviderResult.None;
+        }
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderTests.cs
@@ -58,6 +58,22 @@ public class StringTrimmingModelBinderTests
     }
 
     [Test]
+    public async Task BindModelAsync_WithEmptyStringValue_ReturnsNullModel()
+    {
+        // Arrange
+        _valueProvider.SetValue("testModel", "");
+
+        // Act
+        await _binder.BindModelAsync(_bindingContext);
+
+        // Assert
+        Assert.That(_bindingContext.Result.IsModelSet, Is.True);
+        var result = _bindingContext.Result.Model as string;
+        Assert.That(result, Is.Null);
+        Assert.That (_modelState.IsValid, Is.True);
+    }
+
+    [Test]
     public async Task BindModelAsync_WithWhitespaceString_TrimsAndReturnsValue()
     {
         // Arrange

--- a/OutOfSchool/OutOfSchool.WebApi/Startup.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Startup.cs
@@ -50,6 +50,7 @@ using OutOfSchool.Services.Repository.Files;
 using OutOfSchool.Services.Repository.WorkshopDraftRepository;
 using OutOfSchool.SportsRegistryApiClient.Extensions;
 using OutOfSchool.WebApi.Enums;
+using OutOfSchool.WebApi.Util.JsonTools;
 using OutOfSchool.WebApi.Util.ModelBinding;
 using StackExchange.Redis;
 
@@ -243,9 +244,13 @@ public static class Startup
                         Duration = cacheProfilesConfig.PublicDurationInSeconds,
                     });
                 options.ModelBinderProviders.Insert(0, new EnumCollectionModelBinderProvider());
+                options.ModelBinderProviders.Insert(1, new StringTrimmingModelBinderProvider());
             })
             .AddJsonOptions(options =>
-                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+            {
+                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                options.JsonSerializerOptions.Converters.Add(new StringTrimmingJsonConverter());
+            });
 
         services.AddHttpClient(configuration["Communication:ClientName"])
             .ConfigurePrimaryHttpMessageHandler(handler =>

--- a/OutOfSchool/OutOfSchool.WebApi/Util/JsonTools/StringTrimmingJsonConverter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/JsonTools/StringTrimmingJsonConverter.cs
@@ -3,6 +3,9 @@ using System.Text.Json.Serialization;
 
 namespace OutOfSchool.WebApi.Util.JsonTools;
 
+/// <summary>
+/// Custom JSON converter that trims leading and trailing whitespace from string values during deserialization.
+/// </summary>
 public class StringTrimmingJsonConverter : JsonConverter<string>
 {
     public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/OutOfSchool/OutOfSchool.WebApi/Util/JsonTools/StringTrimmingJsonConverter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/JsonTools/StringTrimmingJsonConverter.cs
@@ -12,6 +12,7 @@ public class StringTrimmingJsonConverter : JsonConverter<string>
 
     public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
     {
+        ArgumentNullException.ThrowIfNull(writer);
         writer.WriteStringValue(value);
     }
 }

--- a/OutOfSchool/OutOfSchool.WebApi/Util/JsonTools/StringTrimmingJsonConverter.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/JsonTools/StringTrimmingJsonConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OutOfSchool.WebApi.Util.JsonTools;
+
+public class StringTrimmingJsonConverter : JsonConverter<string>
+{
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.GetString()?.Trim();
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value);
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinder.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinder.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace OutOfSchool.WebApi.Util.ModelBinding;
+
+public class StringTrimmingModelBinder : IModelBinder
+{
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        ArgumentNullException.ThrowIfNull(bindingContext);
+
+        var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+        
+        if (valueProviderResult == ValueProviderResult.None)
+            return Task.CompletedTask;
+
+        var value = valueProviderResult.FirstValue;
+        if (string.IsNullOrEmpty(value))
+            return Task.CompletedTask;
+
+        bindingContext.Result = ModelBindingResult.Success(value.Trim());
+        return Task.CompletedTask;
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinder.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinder.cs
@@ -11,11 +11,17 @@ public class StringTrimmingModelBinder : IModelBinder
         var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
         
         if (valueProviderResult == ValueProviderResult.None)
+        {
+            bindingContext.Result = ModelBindingResult.Success(null);
             return Task.CompletedTask;
+        }
 
         var value = valueProviderResult.FirstValue;
         if (string.IsNullOrEmpty(value))
+        {
+            bindingContext.Result = ModelBindingResult.Success(null);
             return Task.CompletedTask;
+        }
 
         bindingContext.Result = ModelBindingResult.Success(value.Trim());
         return Task.CompletedTask;

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinder.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinder.cs
@@ -2,6 +2,10 @@
 
 namespace OutOfSchool.WebApi.Util.ModelBinding;
 
+
+/// <summary>
+/// Model binder that trims leading and trailing whitespace from string inputs.
+/// </summary>
 public class StringTrimmingModelBinder : IModelBinder
 {
     public Task BindModelAsync(ModelBindingContext bindingContext)

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinderProvider.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinderProvider.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace OutOfSchool.WebApi.Util.ModelBinding;
+
+public class StringTrimmingModelBinderProvider : IModelBinderProvider
+{
+    public IModelBinder GetBinder(ModelBinderProviderContext context)
+    {
+        if (context?.Metadata?.ModelType == null)
+            return null;
+
+        var modelType = context.Metadata.ModelType;
+
+        if (modelType == typeof(string) && context.BindingInfo.BindingSource != BindingSource.Body)
+        {
+            return new StringTrimmingModelBinder();
+        }
+
+        return null;
+    }
+}

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinderProvider.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinderProvider.cs
@@ -2,6 +2,9 @@
 
 namespace OutOfSchool.WebApi.Util.ModelBinding;
 
+/// <summary>
+/// Provider for registration of <see cref="StringTrimmingModelBinder"/>.
+/// </summary>
 public class StringTrimmingModelBinderProvider : IModelBinderProvider
 {
     public IModelBinder GetBinder(ModelBinderProviderContext context)

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinderProvider.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinderProvider.cs
@@ -11,7 +11,7 @@ public class StringTrimmingModelBinderProvider : IModelBinderProvider
 
         var modelType = context.Metadata.ModelType;
 
-        if (modelType == typeof(string) && context.BindingInfo.BindingSource != BindingSource.Body)
+        if (modelType == typeof(string) && context.BindingInfo?.BindingSource != BindingSource.Body)
         {
             return new StringTrimmingModelBinder();
         }

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestModelBinderHelpers.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestModelBinderHelpers.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
+
+namespace OutOfSchool.Tests.Common;
+public static class TestModelBinderHelpers
+{
+    // Helper methods
+    public static ModelMetadata CreateModelMetadata(Type modelType)
+    {
+        if (modelType == null)
+            return null;
+
+        var metadataProvider = new EmptyModelMetadataProvider();
+        return metadataProvider.GetMetadataForType(modelType);
+    }
+
+    public static ModelBinderProviderContext CreateContext(ModelMetadata metadata)
+    {
+        var context = new TestModelBinderProviderContext();
+        context.SetMetadata(metadata);
+        return context;
+    }
+
+    // Custom implementation of ModelBinderProviderContext for testing
+    public class TestModelBinderProviderContext : ModelBinderProviderContext
+    {
+        private ModelMetadata _metadata;
+
+        public override ModelMetadata Metadata => _metadata;
+
+        public void SetMetadata(ModelMetadata metadata)
+        {
+            _metadata = metadata;
+        }
+
+        public override BindingInfo BindingInfo => new BindingInfo();
+
+        public override IModelBinder CreateBinder(ModelMetadata metadata)
+        {
+            throw new NotImplementedException("Not needed for these tests");
+        }
+
+        public override IModelMetadataProvider MetadataProvider => null;
+    }
+}

--- a/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestModelBinderHelpers.cs
+++ b/OutOfSchool/Tests/OutOfSchool.Tests.Common/TestModelBinderHelpers.cs
@@ -25,6 +25,7 @@ public static class TestModelBinderHelpers
     public class TestModelBinderProviderContext : ModelBinderProviderContext
     {
         private ModelMetadata _metadata;
+        private BindingInfo _bindingInfo = new();
 
         public override ModelMetadata Metadata => _metadata;
 
@@ -33,7 +34,7 @@ public static class TestModelBinderHelpers
             _metadata = metadata;
         }
 
-        public override BindingInfo BindingInfo => new BindingInfo();
+        public override BindingInfo BindingInfo => _bindingInfo;
 
         public override IModelBinder CreateBinder(ModelMetadata metadata)
         {


### PR DESCRIPTION
- Created custom ModelBinder and JsonConverter for trimming string fields in dtos at the system level
- Wrote unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic trimming of leading/trailing whitespace from string inputs in JSON deserialization and model binding.

* **Improvements**
  * JSON processing now respects configured serialization options.
  * Trimming binder is applied except for raw request-body bindings and is integrated into MVC pipeline order.

* **Tests**
  * Added and reorganized unit tests and shared test helpers covering trimming and binding behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->