### PR TITLE
update binder to allow the default values

### DIFF
--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Codeficator/CodeficatorFilter.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Codeficator/CodeficatorFilter.cs
@@ -11,7 +11,7 @@ public class CodeficatorFilter
     public long ParentId { get; set; } = 0;
 
     /// <summary>
-    /// Gets or sets сategories. By default - 'MTCXKB'".
+    /// Gets or sets categories. By default - 'MTCXKB'.
     /// </summary>
     public string Categories { get; set; } = CodeficatorCategory.SearchableCategories.Name;
 }

--- a/OutOfSchool/OutOfSchool.BusinessLogic/Models/Codeficator/CodeficatorFilter.cs
+++ b/OutOfSchool/OutOfSchool.BusinessLogic/Models/Codeficator/CodeficatorFilter.cs
@@ -11,7 +11,7 @@ public class CodeficatorFilter
     public long ParentId { get; set; } = 0;
 
     /// <summary>
-    /// Gets or sets сategories. By default - 'MTCXK'".
+    /// Gets or sets сategories. By default - 'MTCXKB'".
     /// </summary>
     public string Categories { get; set; } = CodeficatorCategory.SearchableCategories.Name;
 }

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderTests.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
-using NUnit.Framework;
-using OutOfSchool.WebApi.Util.ModelBinding;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Primitives;
+using NUnit.Framework;
+using OutOfSchool.WebApi.Util.ModelBinding;
 
 namespace OutOfSchool.WebApi.Tests.Util;
 
@@ -42,7 +43,7 @@ public class StringTrimmingModelBinderTests
     }
 
     [Test]
-    public async Task BindModelAsync_WithNullValue_ReturnsNullModel()
+    public async Task BindModelAsync_WithNullValue_PreservesDefaultValue()
     {
         // Arrange
         _valueProvider.SetValue("testModel", null);
@@ -51,14 +52,12 @@ public class StringTrimmingModelBinderTests
         await _binder.BindModelAsync(_bindingContext);
 
         // Assert
-        Assert.That(_bindingContext.Result.IsModelSet, Is.True);
-        var result = _bindingContext.Result.Model as string;
-        Assert.That(result, Is.Null);
+        Assert.That(_bindingContext.Result.IsModelSet, Is.False);
         Assert.That(_modelState.IsValid, Is.True);
     }
 
     [Test]
-    public async Task BindModelAsync_WithEmptyStringValue_ReturnsNullModel()
+    public async Task BindModelAsync_WithEmptyStringValue_BindsEmptyString()
     {
         // Arrange
         _valueProvider.SetValue("testModel", "");
@@ -68,9 +67,36 @@ public class StringTrimmingModelBinderTests
 
         // Assert
         Assert.That(_bindingContext.Result.IsModelSet, Is.True);
-        var result = _bindingContext.Result.Model as string;
-        Assert.That(result, Is.Null);
-        Assert.That (_modelState.IsValid, Is.True);
+        Assert.That(_bindingContext.Result.Model, Is.EqualTo(""));
+        Assert.That(_modelState.IsValid, Is.True);
+    }
+
+    [Test]
+    public async Task BindModelAsync_WithNoValue_PreservesDefaultValue()
+    {
+        // Arrange - no value set in provider
+
+        // Act
+        await _binder.BindModelAsync(_bindingContext);
+
+        // Assert
+        Assert.That(_bindingContext.Result.IsModelSet, Is.False);
+        Assert.That(_modelState.IsValid, Is.True);
+    }
+
+    [Test]
+    public async Task BindModelAsync_WithWhitespaceOnlyString_BindsEmptyString()
+    {
+        // Arrange
+        _valueProvider.SetValue("testModel", "   ");
+
+        // Act
+        await _binder.BindModelAsync(_bindingContext);
+
+        // Assert
+        Assert.That(_bindingContext.Result.IsModelSet, Is.True);
+        Assert.That(_bindingContext.Result.Model, Is.EqualTo(""));
+        Assert.That(_modelState.IsValid, Is.True);
     }
 
     [Test]
@@ -110,7 +136,7 @@ public class StringTrimmingModelBinderTests
         {
             if (_values.TryGetValue(key, out var value))
             {
-                return new ValueProviderResult(value);
+                return new ValueProviderResult(value != null ? new StringValues([value]) : StringValues.Empty);
             }
 
             return ValueProviderResult.None;

--- a/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderTests.cs
+++ b/OutOfSchool/OutOfSchool.WebApi.Tests/Util/StringTrimmingModelBinderTests.cs
@@ -68,7 +68,7 @@ public class StringTrimmingModelBinderTests
         // Assert
         Assert.That(_bindingContext.Result.IsModelSet, Is.True);
         Assert.That(_bindingContext.Result.Model, Is.EqualTo(""));
-        Assert.That(_modelState.IsValid, Is.True);
+        Assert.That(_modelState.ValidationState, Is.EqualTo(ModelValidationState.Unvalidated));
     }
 
     [Test]
@@ -96,7 +96,7 @@ public class StringTrimmingModelBinderTests
         // Assert
         Assert.That(_bindingContext.Result.IsModelSet, Is.True);
         Assert.That(_bindingContext.Result.Model, Is.EqualTo(""));
-        Assert.That(_modelState.IsValid, Is.True);
+        Assert.That(_modelState.ValidationState, Is.EqualTo(ModelValidationState.Unvalidated));
     }
 
     [Test]
@@ -115,7 +115,7 @@ public class StringTrimmingModelBinderTests
         var result = _bindingContext.Result.Model as string;
         Assert.That(result, Is.Not.Null);
         Assert.That(result, Is.EqualTo(expectedValue));
-        Assert.That(_modelState.IsValid, Is.True);
+        Assert.That(_modelState.ValidationState, Is.EqualTo(ModelValidationState.Unvalidated));
     }
 
     private class SimpleValueProvider : IValueProvider

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinder.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinder.cs
@@ -29,7 +29,6 @@ public class StringTrimmingModelBinder : IModelBinder
         }
         
         bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
-        bindingContext.ModelState.MarkFieldValid(bindingContext.ModelName);
         bindingContext.Result = ModelBindingResult.Success(value.Trim());
         return Task.CompletedTask;
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinder.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinder.cs
@@ -16,17 +16,20 @@ public class StringTrimmingModelBinder : IModelBinder
         
         if (valueProviderResult == ValueProviderResult.None)
         {
-            bindingContext.Result = ModelBindingResult.Success(null);
+            // No value was provided -> keep existing/default property values.
             return Task.CompletedTask;
         }
 
         var value = valueProviderResult.FirstValue;
-        if (string.IsNullOrEmpty(value))
+
+        if (value is null)
         {
-            bindingContext.Result = ModelBindingResult.Success(null);
+            // Value is null -> keep existing/default property values.
             return Task.CompletedTask;
         }
-
+        
+        bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
+        bindingContext.ModelState.MarkFieldValid(bindingContext.ModelName);
         bindingContext.Result = ModelBindingResult.Success(value.Trim());
         return Task.CompletedTask;
     }

--- a/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinderProvider.cs
+++ b/OutOfSchool/OutOfSchool.WebApi/Util/ModelBinding/StringTrimmingModelBinderProvider.cs
@@ -7,6 +7,8 @@ namespace OutOfSchool.WebApi.Util.ModelBinding;
 /// </summary>
 public class StringTrimmingModelBinderProvider : IModelBinderProvider
 {
+    private static readonly StringTrimmingModelBinder Binder = new();
+
     public IModelBinder GetBinder(ModelBinderProviderContext context)
     {
         if (context?.Metadata?.ModelType == null)
@@ -16,7 +18,7 @@ public class StringTrimmingModelBinderProvider : IModelBinderProvider
 
         if (modelType == typeof(string) && context.BindingInfo?.BindingSource != BindingSource.Body)
         {
-            return new StringTrimmingModelBinder();
+            return Binder;
         }
 
         return null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Form input handling: null inputs now preserve existing/default field values; empty strings bind as empty values; whitespace-only input is trimmed to empty. Validation states updated to reflect these outcomes.

* **Performance**
  * Model binding now reuses a single binder instance to reduce per-request overhead.

* **Documentation**
  * Corrected an XML summary label in internal docs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->